### PR TITLE
Link domain email endpoints to endpoints page

### DIFF
--- a/app/(main)/emails/[id]/page.tsx
+++ b/app/(main)/emails/[id]/page.tsx
@@ -1248,16 +1248,19 @@ export default function DomainDetailPage() {
                                                                 if (endpoint) {
                                                                     const EndpointIcon = getEndpointIcon(endpoint)
                                                                     return (
-                                                                        <div className="flex items-center gap-1.5">
+                                                                        <Link 
+                                                                            href={`/endpoints/${routing.id}`}
+                                                                            className="flex items-center gap-1.5 hover:opacity-80 transition-opacity"
+                                                                        >
                                                                             <CustomInboundIcon
                                                                                 Icon={EndpointIcon}
                                                                                 size={25}
                                                                                 backgroundColor={getEndpointIconColor(endpoint)}
                                                                             />
-                                                                            <span className={`font-medium`} style={{ color: getEndpointIconColor(endpoint) }}>
+                                                                            <span className={`font-medium hover:underline`} style={{ color: getEndpointIconColor(endpoint) }}>
                                                                                 {routing.name}
                                                                             </span>
-                                                                        </div>
+                                                                        </Link>
                                                                     )
                                                                 }
                                                             } else if (routing.type === 'webhook' && routing.id) {
@@ -1330,7 +1333,28 @@ export default function DomainDetailPage() {
                                         </div>
 
                                         <div className="flex flex-col sm:flex-row gap-3">
-                                            {!domainDetailsData.isCatchAllEnabled && (
+                                            {domainDetailsData.isCatchAllEnabled && domainDetailsData.catchAllEndpoint ? (
+                                                <div className="flex-1 flex items-center gap-3 p-3 bg-muted/50 rounded-lg border border-border">
+                                                    <div className="text-sm text-muted-foreground">Currently routing to:</div>
+                                                    <Link 
+                                                        href={`/endpoints/${domainDetailsData.catchAllEndpoint.id}`}
+                                                        className="flex items-center gap-2 hover:opacity-80 transition-opacity"
+                                                    >
+                                                        <CustomInboundIcon
+                                                            Icon={getEndpointIcon(domainDetailsData.catchAllEndpoint)}
+                                                            size={16}
+                                                            backgroundColor={getEndpointIconColor(domainDetailsData.catchAllEndpoint)}
+                                                        />
+                                                        <span className="font-medium hover:underline" style={{ color: getEndpointIconColor(domainDetailsData.catchAllEndpoint) }}>
+                                                            {domainDetailsData.catchAllEndpoint.name}
+                                                        </span>
+                                                    </Link>
+                                                </div>
+                                            ) : domainDetailsData.isCatchAllEnabled ? (
+                                                <div className="flex-1 flex items-center gap-3 p-3 bg-muted/50 rounded-lg border border-border">
+                                                    <div className="text-sm text-muted-foreground">Currently routing to: Store in Inbound</div>
+                                                </div>
+                                            ) : (
                                                 <div className="flex-1">
                                                     <Select
                                                         value={catchAllEndpointId}


### PR DESCRIPTION
Make endpoint names clickable on the domain details page to allow direct navigation to endpoint configuration and improve visibility of catch-all routing.

---
<a href="https://cursor.com/background-agent?bcId=bc-73462357-3b45-4ec9-9a5c-84285d22aa4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-73462357-3b45-4ec9-9a5c-84285d22aa4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Domain routing items now link to their endpoint pages for quick navigation.
  - Catch-all configuration displays the current routing target: linked endpoint when set, “Store in Inbound” when enabled without an endpoint, or the selection dropdown when not enabled.

- Style
  - Added hover feedback (opacity change and underline) on linked endpoint items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->