### PR TITLE
fix: update `RichTextRenderer` to support dynamic language selection for code snippets

### DIFF
--- a/features/blog/components/rich-text-renderer.tsx
+++ b/features/blog/components/rich-text-renderer.tsx
@@ -18,7 +18,7 @@ export function RichTextRenderer({ content }: RichTextRendererProps) {
             return (
               <CodeBlock
                 theme="github-dark"
-                snippets={[{ code: codeContent, language: "plaintext" }]}
+                snippets={[{ code: codeContent, language: props.language || "plaintext" }]}
                 {...props}
               />
             );

--- a/features/blog/components/rich-text-renderer.tsx
+++ b/features/blog/components/rich-text-renderer.tsx
@@ -13,12 +13,12 @@ export function RichTextRenderer({ content }: RichTextRendererProps) {
         // Custom code block component with syntax highlighting
         pre: ({ children, ...props }) => {
           // Handle code blocks
-          const codeContent = typeof children === "string" ? children : "";
+          const codeContent = typeof children === "string" ? children : props?.code || "";
           if (codeContent) {
             return (
               <CodeBlock
                 theme="github-dark"
-                snippets={[{ code: codeContent, language: props.language || "plaintext" }]}
+                snippets={[{ code: codeContent, language: props?.language || "plaintext" }]}
                 {...props}
               />
             );


### PR DESCRIPTION
Fixes: #90 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Code blocks in blog content now reliably render the intended code even when not provided as plain text, preventing empty or missing snippets.
  * Syntax highlighting respects a provided language, no longer defaulting to plaintext unnecessarily, improving readability and accuracy across code samples.
  * Overall consistency of code block rendering is improved, ensuring a more faithful display of code content and formatting in rich text posts across browsers and devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->