### PR TITLE
Access email attachment content from webhook

### DIFF
--- a/app/actions/primary.ts
+++ b/app/actions/primary.ts
@@ -2575,6 +2575,342 @@ export async function downloadAttachment(
   }
 }
 
+// ============================================================================
+// ENHANCED ATTACHMENT EXTRACTION
+// ============================================================================
+
+/**
+ * Extract attachment content from an email by filename
+ * Uses the new attachment extractor for cleaner code
+ */
+export async function extractEmailAttachment(emailId: string, filename: string) {
+  try {
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    })
+
+    if (!session?.user?.id) {
+      return { error: "Unauthorized" }
+    }
+
+    // Get the email with raw content from structured emails
+    const email = await db
+      .select({
+        id: structuredEmails.id,
+        rawContent: structuredEmails.rawContent,
+        sesEventId: structuredEmails.sesEventId,
+      })
+      .from(structuredEmails)
+      .where(
+        and(
+          eq(structuredEmails.id, emailId),
+          eq(structuredEmails.userId, session.user.id)
+        )
+      )
+      .limit(1)
+
+    if (!email.length) {
+      return { error: "Email not found or access denied" }
+    }
+
+    const emailData = email[0]
+    let rawEmailContent = emailData.rawContent
+
+    // If no raw content in structured email, try to get it from SES events
+    if (!rawEmailContent && emailData.sesEventId) {
+      const sesEvent = await db
+        .select({
+          emailContent: sesEvents.emailContent,
+          s3BucketName: sesEvents.s3BucketName,
+          s3ObjectKey: sesEvents.s3ObjectKey,
+        })
+        .from(sesEvents)
+        .where(eq(sesEvents.id, emailData.sesEventId))
+        .limit(1)
+
+      if (sesEvent.length) {
+        if (sesEvent[0].emailContent) {
+          rawEmailContent = sesEvent[0].emailContent
+        } else if (sesEvent[0].s3BucketName && sesEvent[0].s3ObjectKey) {
+          // Try to fetch from S3
+          try {
+            const { getEmailFromS3 } = await import("@/lib/aws-ses/aws-ses")
+            const s3Email = await getEmailFromS3(sesEvent[0].s3BucketName, sesEvent[0].s3ObjectKey)
+            rawEmailContent = s3Email.toString()
+          } catch (s3Error) {
+            console.error('Failed to fetch email from S3:', s3Error)
+          }
+        }
+      }
+    }
+
+    if (!rawEmailContent) {
+      return { error: "Raw email content not available" }
+    }
+
+    // Extract attachment content using the new extractor
+    const { extractAttachmentByFilename } = await import('@/lib/email-management/attachment-extractor')
+    const attachment = await extractAttachmentByFilename(rawEmailContent, filename)
+
+    if (!attachment) {
+      return { error: "Attachment not found" }
+    }
+
+    return {
+      success: true,
+      data: {
+        filename: attachment.filename,
+        contentType: attachment.contentType,
+        size: attachment.size,
+        content: attachment.content.toString('base64'), // Return as base64
+        contentId: attachment.contentId,
+        contentDisposition: attachment.contentDisposition,
+      }
+    }
+  } catch (error) {
+    console.error('Error extracting email attachment:', error)
+    return { 
+      error: error instanceof Error ? error.message : 'Failed to extract attachment' 
+    }
+  }
+}
+
+/**
+ * Extract attachment content by contentId (useful for inline images)
+ */
+export async function extractEmailAttachmentByContentId(emailId: string, contentId: string) {
+  try {
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    })
+
+    if (!session?.user?.id) {
+      return { error: "Unauthorized" }
+    }
+
+    // Get the email with raw content from structured emails
+    const email = await db
+      .select({
+        id: structuredEmails.id,
+        rawContent: structuredEmails.rawContent,
+        sesEventId: structuredEmails.sesEventId,
+      })
+      .from(structuredEmails)
+      .where(
+        and(
+          eq(structuredEmails.id, emailId),
+          eq(structuredEmails.userId, session.user.id)
+        )
+      )
+      .limit(1)
+
+    if (!email.length) {
+      return { error: "Email not found or access denied" }
+    }
+
+    const emailData = email[0]
+    let rawEmailContent = emailData.rawContent
+
+    // If no raw content in structured email, try to get it from SES events
+    if (!rawEmailContent && emailData.sesEventId) {
+      const sesEvent = await db
+        .select({
+          emailContent: sesEvents.emailContent,
+          s3BucketName: sesEvents.s3BucketName,
+          s3ObjectKey: sesEvents.s3ObjectKey,
+        })
+        .from(sesEvents)
+        .where(eq(sesEvents.id, emailData.sesEventId))
+        .limit(1)
+
+      if (sesEvent.length) {
+        if (sesEvent[0].emailContent) {
+          rawEmailContent = sesEvent[0].emailContent
+        } else if (sesEvent[0].s3BucketName && sesEvent[0].s3ObjectKey) {
+          // Try to fetch from S3
+          try {
+            const { getEmailFromS3 } = await import("@/lib/aws-ses/aws-ses")
+            const s3Email = await getEmailFromS3(sesEvent[0].s3BucketName, sesEvent[0].s3ObjectKey)
+            rawEmailContent = s3Email.toString()
+          } catch (s3Error) {
+            console.error('Failed to fetch email from S3:', s3Error)
+          }
+        }
+      }
+    }
+
+    if (!rawEmailContent) {
+      return { error: "Raw email content not available" }
+    }
+
+    // Extract attachment content using the new extractor
+    const { extractAttachmentByContentId } = await import('@/lib/email-management/attachment-extractor')
+    const attachment = await extractAttachmentByContentId(rawEmailContent, contentId)
+
+    if (!attachment) {
+      return { error: "Attachment not found" }
+    }
+
+    return {
+      success: true,
+      data: {
+        filename: attachment.filename,
+        contentType: attachment.contentType,
+        size: attachment.size,
+        content: attachment.content.toString('base64'), // Return as base64
+        contentId: attachment.contentId,
+        contentDisposition: attachment.contentDisposition,
+      }
+    }
+  } catch (error) {
+    console.error('Error extracting email attachment by contentId:', error)
+    return { 
+      error: error instanceof Error ? error.message : 'Failed to extract attachment' 
+    }
+  }
+}
+
+/**
+ * List all attachments in an email with their metadata and availability
+ */
+export async function getEmailAttachments(emailId: string) {
+  try {
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    })
+
+    if (!session?.user?.id) {
+      return { error: "Unauthorized" }
+    }
+
+    // Get the email with attachment metadata and raw content availability
+    const email = await db
+      .select({
+        id: structuredEmails.id,
+        attachments: structuredEmails.attachments,
+        rawContent: structuredEmails.rawContent,
+        sesEventId: structuredEmails.sesEventId,
+      })
+      .from(structuredEmails)
+      .where(
+        and(
+          eq(structuredEmails.id, emailId),
+          eq(structuredEmails.userId, session.user.id)
+        )
+      )
+      .limit(1)
+
+    if (!email.length) {
+      return { error: "Email not found or access denied" }
+    }
+
+    const emailData = email[0]
+
+    // First try to get from stored attachments metadata
+    let attachmentsMetadata = []
+    if (emailData.attachments) {
+      try {
+        attachmentsMetadata = JSON.parse(emailData.attachments)
+      } catch (error) {
+        console.warn('Failed to parse stored attachments metadata:', error)
+      }
+    }
+
+    // Check if we can get content (have raw email or can fetch it)
+    let hasRawContent = !!emailData.rawContent
+    
+    if (!hasRawContent && emailData.sesEventId) {
+      // Check if we can get raw content from SES events
+      const sesEvent = await db
+        .select({
+          emailContent: sesEvents.emailContent,
+          s3BucketName: sesEvents.s3BucketName,
+          s3ObjectKey: sesEvents.s3ObjectKey,
+        })
+        .from(sesEvents)
+        .where(eq(sesEvents.id, emailData.sesEventId))
+        .limit(1)
+
+      if (sesEvent.length) {
+        hasRawContent = !!(sesEvent[0].emailContent || (sesEvent[0].s3BucketName && sesEvent[0].s3ObjectKey))
+      }
+    }
+
+    // If we have raw content available, get full attachment info
+    if (hasRawContent) {
+      let rawEmailContent = emailData.rawContent
+
+      // Fetch raw content if not already available
+      if (!rawEmailContent && emailData.sesEventId) {
+        const sesEvent = await db
+          .select({
+            emailContent: sesEvents.emailContent,
+            s3BucketName: sesEvents.s3BucketName,
+            s3ObjectKey: sesEvents.s3ObjectKey,
+          })
+          .from(sesEvents)
+          .where(eq(sesEvents.id, emailData.sesEventId))
+          .limit(1)
+
+        if (sesEvent.length) {
+          if (sesEvent[0].emailContent) {
+            rawEmailContent = sesEvent[0].emailContent
+          } else if (sesEvent[0].s3BucketName && sesEvent[0].s3ObjectKey) {
+            try {
+              const { getEmailFromS3 } = await import("@/lib/aws-ses/aws-ses")
+              const s3Email = await getEmailFromS3(sesEvent[0].s3BucketName, sesEvent[0].s3ObjectKey)
+              rawEmailContent = s3Email.toString()
+            } catch (s3Error) {
+              console.error('Failed to fetch email from S3:', s3Error)
+              hasRawContent = false
+            }
+          }
+        }
+      }
+
+      if (rawEmailContent) {
+        try {
+          const { extractAttachmentContent } = await import('@/lib/email-management/attachment-extractor')
+          const fullAttachments = await extractAttachmentContent(rawEmailContent)
+          
+          return {
+            success: true,
+            data: fullAttachments.map(att => ({
+              filename: att.filename,
+              contentType: att.contentType,
+              size: att.size,
+              contentId: att.contentId,
+              contentDisposition: att.contentDisposition,
+              hasContent: true, // Content is available for extraction
+            }))
+          }
+        } catch (extractError) {
+          console.warn('Failed to extract attachments from raw content:', extractError)
+          hasRawContent = false
+        }
+      }
+    }
+
+    // Fallback to metadata only
+    return {
+      success: true,
+      data: attachmentsMetadata.map((att: any) => ({
+        filename: att.filename,
+        contentType: att.contentType,
+        size: att.size,
+        contentId: att.contentId,
+        contentDisposition: att.contentDisposition,
+        hasContent: false, // Content not available
+      }))
+    }
+  } catch (error) {
+    console.error('Error getting email attachments:', error)
+    return { 
+      error: error instanceof Error ? error.message : 'Failed to get attachments' 
+    }
+  }
+}
+
 export async function getAllDomainsForAdmin() {
   try {
     const session = await auth.api.getSession({

--- a/examples/api-attachment-endpoint.ts
+++ b/examples/api-attachment-endpoint.ts
@@ -1,0 +1,160 @@
+// Example API endpoint for attachment extraction
+// app/api/emails/[emailId]/attachments/[filename]/route.ts
+
+import { NextRequest, NextResponse } from 'next/server'
+import { extractEmailAttachment, extractEmailAttachmentByContentId } from '@/app/actions/primary'
+
+interface RouteParams {
+  emailId: string
+  filename: string
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: RouteParams }
+) {
+  try {
+    const { emailId, filename } = params
+    const { searchParams } = new URL(request.url)
+    const contentId = searchParams.get('contentId')
+    const download = searchParams.get('download') === 'true'
+
+    console.log('Extracting attachment:', { emailId, filename, contentId, download })
+
+    // Extract by contentId if provided, otherwise by filename
+    const result = contentId 
+      ? await extractEmailAttachmentByContentId(emailId, contentId)
+      : await extractEmailAttachment(emailId, filename)
+
+    if (result.error) {
+      return NextResponse.json(
+        { error: result.error }, 
+        { status: result.error === 'Unauthorized' ? 401 : 404 }
+      )
+    }
+
+    const attachment = result.data
+    if (!attachment) {
+      return NextResponse.json(
+        { error: 'Attachment not found' }, 
+        { status: 404 }
+      )
+    }
+
+    // Convert base64 to buffer
+    const buffer = Buffer.from(attachment.content, 'base64')
+
+    // Set appropriate headers
+    const headers: HeadersInit = {
+      'Content-Type': attachment.contentType || 'application/octet-stream',
+      'Content-Length': buffer.length.toString(),
+    }
+
+    if (download) {
+      // Force download
+      headers['Content-Disposition'] = `attachment; filename="${attachment.filename}"`
+    } else {
+      // Inline display (for images, PDFs, etc.)
+      headers['Content-Disposition'] = `inline; filename="${attachment.filename}"`
+    }
+
+    return new NextResponse(buffer, { headers })
+
+  } catch (error) {
+    console.error('Error in attachment endpoint:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}
+
+// Usage examples:
+// GET /api/emails/email123/attachments/document.pdf
+// GET /api/emails/email123/attachments/image.jpg?download=true
+// GET /api/emails/email123/attachments/inline-image.png?contentId=<abc123>
+
+/* 
+Frontend usage:
+
+// Download attachment
+const downloadUrl = `/api/emails/${emailId}/attachments/${filename}?download=true`
+window.open(downloadUrl, '_blank')
+
+// Display inline image
+const imageUrl = `/api/emails/${emailId}/attachments/${filename}`
+<img src={imageUrl} alt={filename} />
+
+// Extract by contentId (for inline images in HTML emails)
+const inlineImageUrl = `/api/emails/${emailId}/attachments/image.png?contentId=${contentId}`
+
+// Direct fetch for processing
+const response = await fetch(`/api/emails/${emailId}/attachments/${filename}`)
+const blob = await response.blob()
+// Process blob...
+*/
+
+// Alternative JSON endpoint that returns metadata + base64 content
+// app/api/emails/[emailId]/attachments/[filename]/data/route.ts
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: RouteParams }
+) {
+  try {
+    const { emailId, filename } = params
+    const { searchParams } = new URL(request.url)
+    const contentId = searchParams.get('contentId')
+
+    // Extract attachment data
+    const result = contentId 
+      ? await extractEmailAttachmentByContentId(emailId, contentId)
+      : await extractEmailAttachment(emailId, filename)
+
+    if (result.error) {
+      return NextResponse.json(
+        { error: result.error }, 
+        { status: result.error === 'Unauthorized' ? 401 : 404 }
+      )
+    }
+
+    // Return full attachment data as JSON
+    return NextResponse.json({
+      success: true,
+      data: result.data
+    })
+
+  } catch (error) {
+    console.error('Error in attachment data endpoint:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}
+
+/*
+Frontend usage for JSON endpoint:
+
+const response = await fetch(`/api/emails/${emailId}/attachments/${filename}/data`)
+const result = await response.json()
+
+if (result.success) {
+  const attachment = result.data
+  console.log('Filename:', attachment.filename)
+  console.log('Content Type:', attachment.contentType)
+  console.log('Size:', attachment.size)
+  console.log('Base64 Content:', attachment.content)
+  
+  // Convert to blob
+  const byteCharacters = atob(attachment.content)
+  const byteNumbers = new Array(byteCharacters.length)
+  for (let i = 0; i < byteCharacters.length; i++) {
+    byteNumbers[i] = byteCharacters.charCodeAt(i)
+  }
+  const byteArray = new Uint8Array(byteNumbers)
+  const blob = new Blob([byteArray], { type: attachment.contentType })
+  
+  // Use blob for whatever you need
+}
+*/

--- a/examples/attachment-extraction-example.tsx
+++ b/examples/attachment-extraction-example.tsx
@@ -1,0 +1,282 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { 
+  extractEmailAttachment, 
+  extractEmailAttachmentByContentId, 
+  getEmailAttachments 
+} from '@/app/actions/primary'
+
+interface AttachmentInfo {
+  filename: string
+  contentType: string
+  size: number
+  contentId?: string
+  contentDisposition?: string
+  hasContent: boolean
+}
+
+interface ExtractedAttachment {
+  filename: string
+  contentType: string
+  size: number
+  content: string // base64 content
+  contentId?: string
+  contentDisposition?: string
+}
+
+export default function AttachmentExtractionExample({ emailId }: { emailId: string }) {
+  const [attachments, setAttachments] = useState<AttachmentInfo[]>([])
+  const [extractedAttachment, setExtractedAttachment] = useState<ExtractedAttachment | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Load all attachments for the email
+  const loadAttachments = async () => {
+    setLoading(true)
+    setError(null)
+    
+    try {
+      const result = await getEmailAttachments(emailId)
+      
+      if (result.error) {
+        setError(result.error)
+        return
+      }
+      
+      setAttachments(result.data || [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load attachments')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Extract specific attachment by filename
+  const extractByFilename = async (filename: string) => {
+    setLoading(true)
+    setError(null)
+    setExtractedAttachment(null)
+    
+    try {
+      const result = await extractEmailAttachment(emailId, filename)
+      
+      if (result.error) {
+        setError(result.error)
+        return
+      }
+      
+      setExtractedAttachment(result.data || null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to extract attachment')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Extract attachment by contentId (useful for inline images)
+  const extractByContentId = async (contentId: string) => {
+    setLoading(true)
+    setError(null)
+    setExtractedAttachment(null)
+    
+    try {
+      const result = await extractEmailAttachmentByContentId(emailId, contentId)
+      
+      if (result.error) {
+        setError(result.error)
+        return
+      }
+      
+      setExtractedAttachment(result.data || null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to extract attachment by contentId')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Download attachment content as file
+  const downloadAttachment = (attachment: ExtractedAttachment) => {
+    if (!attachment.content) return
+
+    // Convert base64 to blob
+    const byteCharacters = atob(attachment.content)
+    const byteNumbers = new Array(byteCharacters.length)
+    
+    for (let i = 0; i < byteCharacters.length; i++) {
+      byteNumbers[i] = byteCharacters.charCodeAt(i)
+    }
+    
+    const byteArray = new Uint8Array(byteNumbers)
+    const blob = new Blob([byteArray], { type: attachment.contentType })
+    
+    // Create download link
+    const url = window.URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = attachment.filename || 'attachment'
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    window.URL.revokeObjectURL(url)
+  }
+
+  // Create data URL for inline display (images, etc.)
+  const getDataUrl = (attachment: ExtractedAttachment): string => {
+    return `data:${attachment.contentType};base64,${attachment.content}`
+  }
+
+  // Check if attachment is an image
+  const isImage = (contentType: string): boolean => {
+    return contentType.startsWith('image/')
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Email Attachment Extraction Example</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Email ID: {emailId}
+          </p>
+        </CardHeader>
+        <CardContent>
+          <Button onClick={loadAttachments} disabled={loading}>
+            {loading ? 'Loading...' : 'Load Attachments'}
+          </Button>
+          
+          {error && (
+            <div className="mt-4 p-3 border border-red-200 rounded bg-red-50 text-red-700">
+              Error: {error}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {attachments.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Available Attachments</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {attachments.map((attachment, index) => (
+                <div 
+                  key={index} 
+                  className="flex items-center justify-between p-3 border rounded"
+                >
+                  <div className="flex-1">
+                    <div className="font-medium">{attachment.filename}</div>
+                    <div className="text-sm text-muted-foreground">
+                      Type: {attachment.contentType} • Size: {attachment.size} bytes
+                    </div>
+                    {attachment.contentId && (
+                      <div className="text-xs text-muted-foreground">
+                        Content ID: {attachment.contentId}
+                      </div>
+                    )}
+                  </div>
+                  
+                  <div className="flex items-center gap-2">
+                    <Badge variant={attachment.hasContent ? 'default' : 'secondary'}>
+                      {attachment.hasContent ? 'Available' : 'Metadata Only'}
+                    </Badge>
+                    
+                    {attachment.hasContent && (
+                      <>
+                        <Button
+                          size="sm"
+                          onClick={() => extractByFilename(attachment.filename)}
+                          disabled={loading}
+                        >
+                          Extract by Filename
+                        </Button>
+                        
+                        {attachment.contentId && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => extractByContentId(attachment.contentId!)}
+                            disabled={loading}
+                          >
+                            Extract by Content ID
+                          </Button>
+                        )}
+                      </>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {extractedAttachment && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Extracted Attachment</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <strong>Filename:</strong> {extractedAttachment.filename}
+              </div>
+              <div>
+                <strong>Content Type:</strong> {extractedAttachment.contentType}
+              </div>
+              <div>
+                <strong>Size:</strong> {extractedAttachment.size} bytes
+              </div>
+              {extractedAttachment.contentId && (
+                <div>
+                  <strong>Content ID:</strong> {extractedAttachment.contentId}
+                </div>
+              )}
+            </div>
+
+            <div className="flex gap-2">
+              <Button onClick={() => downloadAttachment(extractedAttachment)}>
+                Download File
+              </Button>
+              
+              {isImage(extractedAttachment.contentType) && (
+                <Button 
+                  variant="outline"
+                  onClick={() => window.open(getDataUrl(extractedAttachment), '_blank')}
+                >
+                  View Image
+                </Button>
+              )}
+            </div>
+
+            {/* Display image inline if it's an image */}
+            {isImage(extractedAttachment.contentType) && (
+              <div className="mt-4">
+                <img 
+                  src={getDataUrl(extractedAttachment)} 
+                  alt={extractedAttachment.filename}
+                  className="max-w-full max-h-96 object-contain border rounded"
+                />
+              </div>
+            )}
+
+            {/* Show content preview for text files */}
+            {extractedAttachment.contentType.startsWith('text/') && (
+              <div className="mt-4">
+                <h4 className="font-medium mb-2">Content Preview:</h4>
+                <pre className="bg-gray-50 p-3 rounded text-xs overflow-auto max-h-48">
+                  {atob(extractedAttachment.content)}
+                </pre>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/examples/webhook-attachment-processing.md
+++ b/examples/webhook-attachment-processing.md
@@ -1,0 +1,192 @@
+# Getting Attachment Content from Webhook Payload
+
+## The Problem
+
+Your webhook payload contains **attachment metadata only**:
+```json
+{
+  "filename": "email1.eml",
+  "contentType": "message/rfc822", 
+  "size": 12248,
+  "contentId": "<f_mg4gbd9y0>",
+  "contentDisposition": "attachment"
+}
+```
+
+**The metadata tells you WHAT attachments exist, but not the actual file content.**
+
+## The Solution
+
+To get the actual attachment content, you need to parse the full raw email. Here are the available methods:
+
+### Method 1: Use the New Attachment Extractor (Recommended)
+
+```typescript
+import { 
+  extractEmailAttachment, 
+  extractEmailAttachmentByContentId, 
+  getEmailAttachments 
+} from '@/app/actions/primary'
+
+// Get all attachments with availability info
+const attachmentsResult = await getEmailAttachments(emailId)
+if (attachmentsResult.success) {
+  console.log('Available attachments:', attachmentsResult.data)
+  // [{ filename: "email1.eml", contentType: "message/rfc822", size: 12248, hasContent: true }, ...]
+}
+
+// Extract specific attachment by filename
+const attachmentResult = await extractEmailAttachment(emailId, "email1.eml")
+if (attachmentResult.success) {
+  const attachment = attachmentResult.data
+  // attachment.content contains the base64-encoded file content
+  console.log('Attachment content (base64):', attachment.content)
+  
+  // Convert to blob for download
+  const blob = new Blob([atob(attachment.content)], { type: attachment.contentType })
+  // ... use blob for download or processing
+}
+
+// Extract by contentId (useful for inline images)
+const inlineResult = await extractEmailAttachmentByContentId(emailId, "<f_mg4gbd9y0>")
+if (inlineResult.success) {
+  const inlineAttachment = inlineResult.data
+  // Same structure with base64 content
+}
+```
+
+### Method 2: Use the Existing Download Function
+
+```typescript
+import { downloadAttachment } from '@/app/actions/primary'
+
+// This function already exists and works well
+const result = await downloadAttachment(emailId, "email1.eml")
+if (result.success) {
+  const attachment = result.data
+  console.log('Attachment content (base64):', attachment.content)
+}
+```
+
+### Method 3: Direct Email Parsing (Advanced)
+
+```typescript
+import { extractAttachmentContent } from '@/lib/email-management/attachment-extractor'
+
+// If you have the raw email content
+const attachments = await extractAttachmentContent(rawEmailContent)
+attachments.forEach(att => {
+  console.log(`File: ${att.filename}`)
+  console.log(`Content: ${att.content}`) // Buffer with actual file content
+})
+
+// Extract specific file
+const specificAttachment = await extractAttachmentByFilename(rawEmailContent, "email1.eml")
+if (specificAttachment) {
+  console.log('File content as Buffer:', specificAttachment.content)
+  console.log('File content as base64:', specificAttachment.content.toString('base64'))
+}
+```
+
+## Data Flow
+
+1. **Email arrives** → Stored in S3 by AWS SES
+2. **Webhook triggered** → Contains attachment metadata only
+3. **To get content** → Parse full email from S3/database
+4. **Extract attachment** → Use `mailparser` to get actual file content
+
+## Email Service Provider Patterns
+
+### AWS SES (Your Current Setup)
+- ✅ **Metadata**: Available in webhook payload
+- ✅ **Content**: Must parse full email from S3
+- ✅ **Your functions handle this automatically**
+
+### Other Email Services
+- **Mailgun**: Can include attachment content directly or provide URLs
+- **SendGrid**: Similar to AWS SES, usually requires parsing full email
+- **Postmark**: Provides attachment content in webhook payload
+
+## Usage Examples
+
+### Download Attachment as File
+```typescript
+const result = await extractEmailAttachment(emailId, filename)
+if (result.success) {
+  // Convert base64 to blob and trigger download
+  const byteCharacters = atob(result.data.content)
+  const byteNumbers = new Array(byteCharacters.length)
+  
+  for (let i = 0; i < byteCharacters.length; i++) {
+    byteNumbers[i] = byteCharacters.charCodeAt(i)
+  }
+  
+  const byteArray = new Uint8Array(byteNumbers)
+  const blob = new Blob([byteArray], { type: result.data.contentType })
+  
+  // Create download link
+  const url = window.URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = result.data.filename
+  link.click()
+  window.URL.revokeObjectURL(url)
+}
+```
+
+### Display Inline Image
+```typescript
+const result = await extractEmailAttachmentByContentId(emailId, contentId)
+if (result.success) {
+  const dataUrl = `data:${result.data.contentType};base64,${result.data.content}`
+  
+  // Use in img tag
+  const img = document.createElement('img')
+  img.src = dataUrl
+  img.alt = result.data.filename
+}
+```
+
+### Process Text Content
+```typescript
+const result = await extractEmailAttachment(emailId, "document.txt")
+if (result.success) {
+  // Decode base64 to text
+  const textContent = atob(result.data.content)
+  console.log('File content:', textContent)
+}
+```
+
+## Key Points
+
+1. **Webhook payload = metadata only** (filename, size, type, etc.)
+2. **Actual content = requires parsing full email** from S3/storage
+3. **Your system handles this** with the functions above
+4. **Content returned as base64** for easy transfer and processing
+5. **Multiple extraction methods** available (filename, contentId)
+
+## Error Handling
+
+```typescript
+const result = await extractEmailAttachment(emailId, filename)
+
+if (result.error) {
+  switch (result.error) {
+    case "Raw email content not available":
+      console.log("Email not fully stored - only metadata available")
+      break
+    case "Attachment not found":
+      console.log("File doesn't exist in this email")
+      break
+    case "Unauthorized":
+      console.log("User doesn't have access to this email")
+      break
+    default:
+      console.log("Other error:", result.error)
+  }
+} else {
+  // Success - use result.data
+}
+```
+
+The answer to your original question is **YES** - you can get attachment content, but you need to use these functions to parse the full email since the webhook payload only contains metadata.

--- a/lib/email-management/attachment-extractor.ts
+++ b/lib/email-management/attachment-extractor.ts
@@ -1,0 +1,114 @@
+import { simpleParser } from 'mailparser'
+
+export interface ExtractedAttachment {
+  filename: string | undefined
+  contentType: string | undefined
+  size: number | undefined
+  contentId: string | undefined
+  contentDisposition: string | undefined
+  content: Buffer // The actual attachment content
+}
+
+/**
+ * Extract attachment content from raw email
+ * This function parses the full email to get the actual attachment content
+ */
+export async function extractAttachmentContent(
+  rawEmailContent: string,
+  targetFilename?: string
+): Promise<ExtractedAttachment[]> {
+  try {
+    // Parse the full email to get attachment content
+    const parsed = await simpleParser(rawEmailContent)
+    
+    if (!parsed.attachments || parsed.attachments.length === 0) {
+      return []
+    }
+    
+    const extractedAttachments: ExtractedAttachment[] = []
+    
+    for (const attachment of parsed.attachments) {
+      // Filter by filename if specified
+      if (targetFilename && attachment.filename !== targetFilename) {
+        continue
+      }
+      
+      // Extract attachment with content
+      extractedAttachments.push({
+        filename: attachment.filename,
+        contentType: attachment.contentType,
+        size: attachment.size,
+        contentId: attachment.contentId,
+        contentDisposition: attachment.contentDisposition,
+        content: attachment.content || Buffer.alloc(0) // Actual file content
+      })
+    }
+    
+    return extractedAttachments
+  } catch (error) {
+    console.error('Error extracting attachment content:', error)
+    throw error
+  }
+}
+
+/**
+ * Extract specific attachment by filename
+ */
+export async function extractAttachmentByFilename(
+  rawEmailContent: string,
+  filename: string
+): Promise<ExtractedAttachment | null> {
+  const attachments = await extractAttachmentContent(rawEmailContent, filename)
+  return attachments.length > 0 ? attachments[0] : null
+}
+
+/**
+ * Extract specific attachment by contentId
+ */
+export async function extractAttachmentByContentId(
+  rawEmailContent: string,
+  contentId: string
+): Promise<ExtractedAttachment | null> {
+  try {
+    const parsed = await simpleParser(rawEmailContent)
+    
+    if (!parsed.attachments || parsed.attachments.length === 0) {
+      return null
+    }
+    
+    const attachment = parsed.attachments.find(att => 
+      att.contentId === contentId || 
+      att.contentId === `<${contentId}>` || // Handle angle brackets
+      att.contentId === contentId.replace(/^<|>$/g, '') // Remove angle brackets
+    )
+    
+    if (!attachment) {
+      return null
+    }
+    
+    return {
+      filename: attachment.filename,
+      contentType: attachment.contentType,
+      size: attachment.size,
+      contentId: attachment.contentId,
+      contentDisposition: attachment.contentDisposition,
+      content: attachment.content || Buffer.alloc(0)
+    }
+  } catch (error) {
+    console.error('Error extracting attachment by contentId:', error)
+    throw error
+  }
+}
+
+/**
+ * Save attachment to filesystem or return as base64
+ */
+export function attachmentToBase64(attachment: ExtractedAttachment): string {
+  return attachment.content.toString('base64')
+}
+
+export function attachmentToDataUrl(attachment: ExtractedAttachment): string {
+  const base64 = attachmentToBase64(attachment)
+  const mimeType = attachment.contentType || 'application/octet-stream'
+  return `data:${mimeType};base64,${base64}`
+}


### PR DESCRIPTION
Add functions to extract email attachment content by parsing the full raw email, enabling retrieval of files from webhook metadata.

The existing webhook payload only provides attachment metadata (filename, size, type). To get the actual file content, the full raw email (stored in S3 or the database) must be parsed. This PR introduces new server actions (`extractEmailAttachment`, `extractEmailAttachmentByContentId`, `getEmailAttachments`) and a utility library (`attachment-extractor.ts`) to facilitate this, returning content as base64. It also includes example API endpoints and a frontend component for demonstration.

---
[Slack Thread](https://exonenterprise.slack.com/archives/C090DRDCB4L/p1759142771271269?thread_ts=1759142771.271269&cid=C090DRDCB4L)

<a href="https://cursor.com/background-agent?bcId=bc-f58ac868-7c73-4b63-b561-cf5d39b57874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f58ac868-7c73-4b63-b561-cf5d39b57874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

