### PR TITLE
Rebuild durable batch email API

### DIFF
--- a/app/api/e2/[[...slugs]]/route.ts
+++ b/app/api/e2/[[...slugs]]/route.ts
@@ -23,12 +23,15 @@ import { deleteEmailAddress } from "../email-addresses/delete";
 import { getEmailAddress } from "../email-addresses/get";
 import { listEmailAddresses } from "../email-addresses/list";
 import { updateEmailAddress } from "../email-addresses/update";
+import { cancelEmailBatch } from "../emails/batch-cancel";
+import { createEmailBatch } from "../emails/batch-create";
+import { getEmailBatch } from "../emails/batch-get";
+import { retryEmailBatch } from "../emails/batch-retry";
 import { cancelEmail } from "../emails/cancel";
 import { getEmail } from "../emails/get";
 import { listEmails } from "../emails/list";
 import { replyToEmail } from "../emails/reply";
 import { retryEmail } from "../emails/retry";
-// Email routes
 import { sendEmail } from "../emails/send";
 import { updateEmail } from "../emails/update";
 import { createEndpoint } from "../endpoints/create";
@@ -482,6 +485,10 @@ https://inbound.new/api/e2
 	// Email routes (sending, listing, managing)
 	.use(sendEmail)
 	.use(listEmails)
+	.use(createEmailBatch)
+	.use(retryEmailBatch)
+	.use(getEmailBatch)
+	.use(cancelEmailBatch)
 	.use(getEmail)
 	.use(updateEmail)
 	.use(cancelEmail)

--- a/app/api/e2/emails/batch-cancel.ts
+++ b/app/api/e2/emails/batch-cancel.ts
@@ -1,0 +1,168 @@
+import { and, eq, inArray, notInArray } from "drizzle-orm";
+import { Elysia, t } from "elysia";
+import {
+	collectQstashMessageIds,
+	deleteQStashMessages,
+} from "@/app/api/e2/emails/batch-queue";
+import {
+	BatchCancelResponseSchema,
+	BatchErrorResponseSchema,
+} from "@/app/api/e2/emails/batch-schemas";
+import { refreshEmailBatchStatus } from "@/app/api/e2/emails/batch-state";
+import { validateAndRateLimit } from "@/app/api/e2/lib/auth";
+import { db } from "@/lib/db";
+import {
+	EMAIL_BATCH_STATUS,
+	emailBatches,
+	SENT_EMAIL_STATUS,
+	sentEmails,
+} from "@/lib/db/schema";
+
+const TERMINAL_BATCH_STATUSES: Set<string> = new Set([
+	EMAIL_BATCH_STATUS.COMPLETED,
+	EMAIL_BATCH_STATUS.FAILED,
+	EMAIL_BATCH_STATUS.PARTIALLY_FAILED,
+	EMAIL_BATCH_STATUS.REQUIRES_ATTENTION,
+]);
+
+export const cancelEmailBatch = new Elysia().delete(
+	"/emails/batch/:batchId",
+	async ({ request, params, set }) => {
+		const userId = await validateAndRateLimit(request, set);
+
+		const [batch] = await db
+			.select()
+			.from(emailBatches)
+			.where(
+				and(
+					eq(emailBatches.id, params.batchId),
+					eq(emailBatches.userId, userId),
+				),
+			)
+			.limit(1);
+
+		if (!batch) {
+			set.status = 404;
+			return { error: "Batch not found" };
+		}
+
+		const preRefreshed = await refreshEmailBatchStatus(params.batchId, userId);
+
+		if (TERMINAL_BATCH_STATUSES.has(preRefreshed.status)) {
+			set.status = 409;
+			return {
+				error: "Cannot cancel batch",
+				details: `Batch is in terminal status: ${preRefreshed.status}`,
+			};
+		}
+
+		const casResult = await db
+			.update(emailBatches)
+			.set({
+				status: EMAIL_BATCH_STATUS.CANCELLED,
+				completedAt: new Date(),
+				updatedAt: new Date(),
+			})
+			.where(
+				and(
+					eq(emailBatches.id, params.batchId),
+					eq(emailBatches.userId, userId),
+					notInArray(emailBatches.status, [
+						EMAIL_BATCH_STATUS.COMPLETED,
+						EMAIL_BATCH_STATUS.FAILED,
+						EMAIL_BATCH_STATUS.PARTIALLY_FAILED,
+						EMAIL_BATCH_STATUS.REQUIRES_ATTENTION,
+					]),
+				),
+			)
+			.returning({ id: emailBatches.id });
+
+		if (casResult.length === 0) {
+			const refreshed = await refreshEmailBatchStatus(params.batchId, userId);
+			if (refreshed.status === EMAIL_BATCH_STATUS.CANCELLED) {
+				return {
+					id: batch.id,
+					status: EMAIL_BATCH_STATUS.CANCELLED,
+					cancelled_count: 0,
+					counts: refreshed.counts,
+				};
+			}
+			set.status = 409;
+			return {
+				error: "Cannot cancel batch",
+				details: `Batch is in terminal status: ${refreshed.status}`,
+			};
+		}
+
+		const pendingChildren = await db
+			.select({
+				id: sentEmails.id,
+				qstashMessageId: sentEmails.qstashMessageId,
+			})
+			.from(sentEmails)
+			.where(
+				and(
+					eq(sentEmails.batchId, params.batchId),
+					eq(sentEmails.userId, userId),
+					eq(sentEmails.status, SENT_EMAIL_STATUS.PENDING),
+				),
+			);
+
+		let cancelledCount = 0;
+		if (pendingChildren.length > 0) {
+			const pendingIds = pendingChildren.map((c) => c.id);
+			const cancelResult = await db
+				.update(sentEmails)
+				.set({
+					status: SENT_EMAIL_STATUS.CANCELLED,
+					updatedAt: new Date(),
+				})
+				.where(
+					and(
+						inArray(sentEmails.id, pendingIds),
+						eq(sentEmails.userId, userId),
+						eq(sentEmails.batchId, params.batchId),
+						eq(sentEmails.status, SENT_EMAIL_STATUS.PENDING),
+					),
+				)
+				.returning({ id: sentEmails.id });
+
+			cancelledCount = cancelResult.length;
+		}
+
+		const qstashIds = collectQstashMessageIds(pendingChildren);
+		if (qstashIds.length > 0) {
+			await deleteQStashMessages(qstashIds);
+		}
+
+		const refreshed = await refreshEmailBatchStatus(params.batchId, userId);
+
+		return {
+			id: batch.id,
+			status: EMAIL_BATCH_STATUS.CANCELLED,
+			cancelled_count: cancelledCount,
+			counts: refreshed.counts,
+		};
+	},
+	{
+		params: t.Object({
+			batchId: t.String(),
+		}),
+		response: {
+			200: BatchCancelResponseSchema,
+			401: BatchErrorResponseSchema,
+			403: BatchErrorResponseSchema,
+			404: BatchErrorResponseSchema,
+			409: BatchErrorResponseSchema,
+			429: BatchErrorResponseSchema,
+			500: BatchErrorResponseSchema,
+			503: BatchErrorResponseSchema,
+		},
+		detail: {
+			tags: ["Emails"],
+			summary: "Cancel a batch",
+			description:
+				"Cancel a batch email send. Only pending items are cancelled; items already processing or sent remain unchanged. Returns 409 if batch is already in a terminal state.",
+		},
+	},
+);

--- a/app/api/e2/emails/batch-create.ts
+++ b/app/api/e2/emails/batch-create.ts
@@ -1,0 +1,560 @@
+import { Autumn as autumn } from "autumn-js";
+import { and, eq, isNull, notInArray } from "drizzle-orm";
+import { Elysia } from "elysia";
+import { nanoid } from "nanoid";
+import {
+	incrementPublishAttempt,
+	publishBatchToQStash,
+	type QueueItem,
+	recomputePublishedCount,
+} from "@/app/api/e2/emails/batch-queue";
+import {
+	BatchCreateBodySchema,
+	type BatchEmailItem,
+	BatchErrorResponseSchema,
+	BatchResponseSchema,
+	IdempotencyKeyHeadersSchema,
+} from "@/app/api/e2/emails/batch-schemas";
+import { refreshEmailBatchStatus } from "@/app/api/e2/emails/batch-state";
+import {
+	computeCanonicalHash,
+	computeChildIdempotencyHash,
+	extractDomain,
+	extractEmailAddress,
+	getAllRecipients,
+	getDistinctSenders,
+	isPostgresUniqueViolation,
+	toArray,
+	validateAggregateBatchAttachments,
+	validateEmailItem,
+} from "@/app/api/e2/emails/batch-utils";
+import {
+	type ProcessedAttachment,
+	processAttachments,
+} from "@/app/api/e2/helper/attachment-processor";
+import {
+	authenticateEmailSend,
+	senderPolicyAllowsAddress,
+} from "@/app/api/e2/lib/send-auth";
+import { db } from "@/lib/db";
+import {
+	EMAIL_BATCH_STATUS,
+	emailBatches,
+	SENT_EMAIL_STATUS,
+	sentEmails,
+} from "@/lib/db/schema";
+import { canUserSendFromEmail } from "@/lib/email-management/agent-email-helper";
+import { checkRecipientsAgainstBlocklist } from "@/lib/email-management/email-blocking";
+import { enforceOutboundSendGuard } from "@/lib/email-management/outbound-send-guard";
+
+interface ValidatedEmail {
+	item: BatchEmailItem;
+	index: number;
+	fromAddress: string;
+	fromDomain: string;
+	toAddresses: string[];
+	ccAddresses: string[];
+	bccAddresses: string[];
+	replyToAddresses: string[];
+	processedAttachments: ProcessedAttachment[];
+}
+
+const TERMINAL_BATCH_STATUSES = [
+	EMAIL_BATCH_STATUS.COMPLETED,
+	EMAIL_BATCH_STATUS.FAILED,
+	EMAIL_BATCH_STATUS.PARTIALLY_FAILED,
+	EMAIL_BATCH_STATUS.CANCELLED,
+	EMAIL_BATCH_STATUS.REQUIRES_ATTENTION,
+] as const;
+
+const TERMINAL_BATCH_STATUSES_SET: Set<string> = new Set(
+	TERMINAL_BATCH_STATUSES,
+);
+
+async function validateAllEmails(
+	emails: readonly BatchEmailItem[],
+	userId: string,
+	senderPolicy: Parameters<typeof senderPolicyAllowsAddress>[0] | null,
+): Promise<{ validated: ValidatedEmail[]; error: string | null }> {
+	const validated: ValidatedEmail[] = [];
+
+	for (let i = 0; i < emails.length; i++) {
+		const item = emails[i];
+
+		const itemValidation = validateEmailItem(item, i);
+		if (!itemValidation.valid) {
+			return {
+				validated: [],
+				error: itemValidation.error ?? "Validation failed",
+			};
+		}
+
+		const fromAddress = extractEmailAddress(item.from);
+		const fromDomain = extractDomain(item.from);
+
+		if (senderPolicy && !senderPolicyAllowsAddress(senderPolicy, fromAddress)) {
+			return {
+				validated: [],
+				error: `Email at index ${i}: This credential cannot send from that address`,
+			};
+		}
+
+		const toAddresses = toArray(item.to);
+		const ccAddresses = toArray(item.cc);
+		const bccAddresses = toArray(item.bcc);
+		const replyToAddresses = toArray(item.reply_to);
+
+		let processedAttachments: ProcessedAttachment[] = [];
+		if (item.attachments && item.attachments.length > 0) {
+			try {
+				processedAttachments = await processAttachments(
+					item.attachments.map((att) => ({
+						filename: att.filename,
+						content: att.content,
+						content_type: att.content_type,
+						content_id: att.content_id,
+					})),
+				);
+			} catch (err) {
+				const msg =
+					err instanceof Error ? err.message : "Attachment processing failed";
+				return {
+					validated: [],
+					error: `Email at index ${i}: ${msg}`,
+				};
+			}
+		}
+
+		validated.push({
+			item,
+			index: i,
+			fromAddress,
+			fromDomain,
+			toAddresses,
+			ccAddresses,
+			bccAddresses,
+			replyToAddresses,
+			processedAttachments,
+		});
+	}
+
+	const allAttachments = validated.map((v) => v.processedAttachments);
+	const aggregateCheck = validateAggregateBatchAttachments(allAttachments);
+	if (!aggregateCheck.valid) {
+		return {
+			validated: [],
+			error: aggregateCheck.error ?? "Attachment validation failed",
+		};
+	}
+
+	const allRecipients: string[] = [];
+	for (const v of validated) {
+		allRecipients.push(...getAllRecipients(v.item));
+	}
+
+	const blocklistCheck = await checkRecipientsAgainstBlocklist(allRecipients);
+	if (blocklistCheck.hasBlockedRecipients) {
+		return {
+			validated: [],
+			error: `Cannot send to blocked recipient(s): ${blocklistCheck.blockedAddresses.join(", ")}`,
+		};
+	}
+
+	const distinctSenders = getDistinctSenders(emails);
+	for (const sender of distinctSenders) {
+		const { isAgentEmail } = canUserSendFromEmail(sender.address);
+
+		const guardResult = await enforceOutboundSendGuard({
+			userId,
+			fromAddress: sender.address,
+			fromDomain: sender.domain,
+			isAgentEmail,
+		});
+
+		if (!guardResult.allowed) {
+			return {
+				validated: [],
+				error:
+					guardResult.error || `Cannot send from address: ${sender.address}`,
+			};
+		}
+	}
+
+	return { validated, error: null };
+}
+
+async function republishPendingItems(
+	batchId: string,
+	userId: string,
+): Promise<{ publishedCount: number; lastError: string | null }> {
+	const pendingRows = await db
+		.select({
+			id: sentEmails.id,
+			batchIndex: sentEmails.batchIndex,
+		})
+		.from(sentEmails)
+		.where(
+			and(
+				eq(sentEmails.batchId, batchId),
+				eq(sentEmails.userId, userId),
+				eq(sentEmails.status, SENT_EMAIL_STATUS.PENDING),
+				isNull(sentEmails.qstashMessageId),
+			),
+		);
+
+	if (pendingRows.length === 0) {
+		return { publishedCount: 0, lastError: null };
+	}
+
+	const itemsToQueue: QueueItem[] = [];
+	for (const row of pendingRows) {
+		const newAttempt = await incrementPublishAttempt(row.id, userId, batchId);
+		if (newAttempt > 0) {
+			itemsToQueue.push({
+				emailId: row.id,
+				userId,
+				batchId,
+				batchIndex: row.batchIndex ?? 0,
+				attempt: newAttempt,
+			});
+		}
+	}
+
+	if (itemsToQueue.length === 0) {
+		return { publishedCount: 0, lastError: null };
+	}
+
+	const { lastError } = await publishBatchToQStash(itemsToQueue);
+	const publishedCount = await recomputePublishedCount(batchId, userId);
+	return { publishedCount, lastError };
+}
+
+async function updateBatchStatusWithCAS(
+	batchId: string,
+	userId: string,
+	totalCount: number,
+	publishedCount: number,
+	lastError: string | null,
+): Promise<boolean> {
+	const newStatus =
+		publishedCount < totalCount
+			? EMAIL_BATCH_STATUS.PARTIALLY_QUEUED
+			: EMAIL_BATCH_STATUS.QUEUED;
+
+	const casResult = await db
+		.update(emailBatches)
+		.set({
+			status: newStatus,
+			publishedCount,
+			lastError: lastError ?? null,
+			updatedAt: new Date(),
+		})
+		.where(
+			and(
+				eq(emailBatches.id, batchId),
+				eq(emailBatches.userId, userId),
+				notInArray(emailBatches.status, [...TERMINAL_BATCH_STATUSES]),
+			),
+		)
+		.returning({ id: emailBatches.id });
+
+	return casResult.length > 0;
+}
+
+export const createEmailBatch = new Elysia().post(
+	"/emails/batch",
+	async ({ request, body, set }) => {
+		const { userId, senderPolicy } = await authenticateEmailSend(request, set);
+
+		const idempotencyKey = request.headers.get("idempotency-key");
+		const requestHash = computeCanonicalHash(body.emails);
+
+		if (idempotencyKey) {
+			const [existingBatch] = await db
+				.select()
+				.from(emailBatches)
+				.where(
+					and(
+						eq(emailBatches.userId, userId),
+						eq(emailBatches.idempotencyKey, idempotencyKey),
+					),
+				)
+				.limit(1);
+
+			if (existingBatch) {
+				if (existingBatch.requestHash !== requestHash) {
+					set.status = 409;
+					return {
+						error: "Conflict",
+						details: "Idempotency key already used with different request body",
+					};
+				}
+
+				if (TERMINAL_BATCH_STATUSES_SET.has(existingBatch.status)) {
+					const refreshed = await refreshEmailBatchStatus(
+						existingBatch.id,
+						userId,
+					);
+					set.status = 202;
+					return {
+						id: existingBatch.id,
+						status: refreshed.status,
+						counts: refreshed.counts,
+						created_at:
+							existingBatch.createdAt?.toISOString() ??
+							new Date().toISOString(),
+						updated_at: new Date().toISOString(),
+					};
+				}
+
+				const { lastError } = await republishPendingItems(
+					existingBatch.id,
+					userId,
+				);
+
+				const newPublishedCount = await recomputePublishedCount(
+					existingBatch.id,
+					userId,
+				);
+				const casSuccess = await updateBatchStatusWithCAS(
+					existingBatch.id,
+					userId,
+					existingBatch.totalCount,
+					newPublishedCount,
+					lastError,
+				);
+
+				if (!casSuccess) {
+					const refreshed = await refreshEmailBatchStatus(
+						existingBatch.id,
+						userId,
+					);
+					set.status = 202;
+					return {
+						id: existingBatch.id,
+						status: refreshed.status,
+						counts: refreshed.counts,
+						created_at:
+							existingBatch.createdAt?.toISOString() ??
+							new Date().toISOString(),
+						updated_at: new Date().toISOString(),
+					};
+				}
+
+				const refreshed = await refreshEmailBatchStatus(
+					existingBatch.id,
+					userId,
+				);
+				set.status = 202;
+				return {
+					id: existingBatch.id,
+					status: refreshed.status,
+					counts: refreshed.counts,
+					created_at:
+						existingBatch.createdAt?.toISOString() ?? new Date().toISOString(),
+					updated_at: new Date().toISOString(),
+				};
+			}
+		}
+
+		const { validated, error: validationError } = await validateAllEmails(
+			body.emails,
+			userId,
+			senderPolicy,
+		);
+
+		if (validationError) {
+			set.status = 400;
+			return { error: validationError };
+		}
+
+		const { data: emailCheck, error: emailCheckError } = await autumn.check({
+			customer_id: userId,
+			feature_id: "emails_sent",
+			required_balance: body.emails.length,
+		});
+
+		if (emailCheckError) {
+			set.status = 500;
+			return { error: "Failed to check email sending limits" };
+		}
+
+		if (!emailCheck.allowed) {
+			set.status = 429;
+			return {
+				error:
+					"Email sending limit reached. Please upgrade your plan to send more emails.",
+			};
+		}
+
+		const batchId = nanoid();
+		const now = new Date();
+
+		const childIds = validated.map(() => nanoid());
+
+		const parentRow = {
+			id: batchId,
+			userId,
+			status: EMAIL_BATCH_STATUS.QUEUED,
+			totalCount: body.emails.length,
+			publishedCount: 0,
+			idempotencyKey: idempotencyKey ?? null,
+			requestHash,
+			createdAt: now,
+			updatedAt: now,
+		};
+
+		const childRows = validated.map((v, idx) => ({
+			id: childIds[idx],
+			from: v.item.from,
+			fromAddress: v.fromAddress,
+			fromDomain: v.fromDomain,
+			to: JSON.stringify(v.toAddresses),
+			cc: v.ccAddresses.length > 0 ? JSON.stringify(v.ccAddresses) : null,
+			bcc: v.bccAddresses.length > 0 ? JSON.stringify(v.bccAddresses) : null,
+			replyTo:
+				v.replyToAddresses.length > 0
+					? JSON.stringify(v.replyToAddresses)
+					: null,
+			subject: v.item.subject,
+			textBody: v.item.text ?? null,
+			htmlBody: v.item.html ?? null,
+			headers: v.item.headers ? JSON.stringify(v.item.headers) : null,
+			attachments:
+				v.processedAttachments.length > 0
+					? JSON.stringify(v.processedAttachments)
+					: null,
+			tags: v.item.tags ? JSON.stringify(v.item.tags) : null,
+			status: SENT_EMAIL_STATUS.PENDING,
+			userId,
+			batchId,
+			batchIndex: idx,
+			idempotencyKey: idempotencyKey
+				? computeChildIdempotencyHash(idempotencyKey, batchId, idx)
+				: null,
+			qstashPublishAttempt: 0,
+			createdAt: now,
+			updatedAt: now,
+		}));
+
+		try {
+			await db.batch([
+				db.insert(emailBatches).values(parentRow),
+				db.insert(sentEmails).values(childRows),
+			]);
+		} catch (err) {
+			if (isPostgresUniqueViolation(err) && idempotencyKey) {
+				const [raceBatch] = await db
+					.select()
+					.from(emailBatches)
+					.where(
+						and(
+							eq(emailBatches.userId, userId),
+							eq(emailBatches.idempotencyKey, idempotencyKey),
+						),
+					)
+					.limit(1);
+
+				if (raceBatch && raceBatch.requestHash === requestHash) {
+					let refreshed: {
+						status: string;
+						counts: {
+							total: number;
+							pending: number;
+							processing: number;
+							sent: number;
+							failed: number;
+							cancelled: number;
+							provider_unknown: number;
+						};
+					};
+					try {
+						refreshed = await refreshEmailBatchStatus(raceBatch.id, userId);
+					} catch {
+						refreshed = {
+							status: raceBatch.status,
+							counts: {
+								total: raceBatch.totalCount,
+								pending: 0,
+								processing: 0,
+								sent: 0,
+								failed: 0,
+								cancelled: 0,
+								provider_unknown: 0,
+							},
+						};
+					}
+
+					set.status = 202;
+					return {
+						id: raceBatch.id,
+						status: refreshed.status,
+						counts: refreshed.counts,
+						created_at: raceBatch.createdAt?.toISOString() ?? now.toISOString(),
+						updated_at: raceBatch.updatedAt?.toISOString(),
+					};
+				}
+
+				set.status = 409;
+				return {
+					error: "Conflict",
+					details: "Idempotency key already used with different request body",
+				};
+			}
+			throw err;
+		}
+
+		const itemsToQueue: QueueItem[] = childRows.map((row, idx) => ({
+			emailId: row.id,
+			userId,
+			batchId,
+			batchIndex: idx,
+			attempt: 0,
+		}));
+
+		const { lastError } = await publishBatchToQStash(itemsToQueue);
+
+		const finalPublishedCount = await recomputePublishedCount(batchId, userId);
+		const finalLastError =
+			finalPublishedCount >= body.emails.length ? null : lastError;
+
+		await updateBatchStatusWithCAS(
+			batchId,
+			userId,
+			body.emails.length,
+			finalPublishedCount,
+			finalLastError,
+		);
+
+		const refreshed = await refreshEmailBatchStatus(batchId, userId);
+
+		set.status = 202;
+		return {
+			id: batchId,
+			status: refreshed.status,
+			counts: refreshed.counts,
+			created_at: now.toISOString(),
+			updated_at: new Date().toISOString(),
+		};
+	},
+	{
+		body: BatchCreateBodySchema,
+		headers: IdempotencyKeyHeadersSchema,
+		response: {
+			202: BatchResponseSchema,
+			400: BatchErrorResponseSchema,
+			401: BatchErrorResponseSchema,
+			403: BatchErrorResponseSchema,
+			409: BatchErrorResponseSchema,
+			429: BatchErrorResponseSchema,
+			500: BatchErrorResponseSchema,
+			503: BatchErrorResponseSchema,
+		},
+		detail: {
+			tags: ["Emails"],
+			summary: "Send a batch of emails",
+			description:
+				"Send up to 100 emails in a single batch request. All emails are validated before any are queued. Returns immediately with batch status; emails are processed asynchronously.",
+		},
+	},
+);

--- a/app/api/e2/emails/batch-get.ts
+++ b/app/api/e2/emails/batch-get.ts
@@ -1,0 +1,91 @@
+import { and, asc, eq } from "drizzle-orm";
+import { Elysia, t } from "elysia";
+import {
+	BatchDetailResponseSchema,
+	BatchErrorResponseSchema,
+} from "@/app/api/e2/emails/batch-schemas";
+import { refreshEmailBatchStatus } from "@/app/api/e2/emails/batch-state";
+import { validateAndRateLimit } from "@/app/api/e2/lib/auth";
+import { db } from "@/lib/db";
+import { emailBatches, sentEmails } from "@/lib/db/schema";
+
+export const getEmailBatch = new Elysia().get(
+	"/emails/batch/:batchId",
+	async ({ request, params, set }) => {
+		const userId = await validateAndRateLimit(request, set);
+
+		const [batch] = await db
+			.select()
+			.from(emailBatches)
+			.where(
+				and(
+					eq(emailBatches.id, params.batchId),
+					eq(emailBatches.userId, userId),
+				),
+			)
+			.limit(1);
+
+		if (!batch) {
+			set.status = 404;
+			return { error: "Batch not found" };
+		}
+
+		const refreshed = await refreshEmailBatchStatus(params.batchId, userId);
+
+		const items = await db
+			.select({
+				id: sentEmails.id,
+				batchIndex: sentEmails.batchIndex,
+				status: sentEmails.status,
+				messageId: sentEmails.messageId,
+				failureReason: sentEmails.failureReason,
+				createdAt: sentEmails.createdAt,
+				sentAt: sentEmails.sentAt,
+			})
+			.from(sentEmails)
+			.where(
+				and(
+					eq(sentEmails.batchId, params.batchId),
+					eq(sentEmails.userId, userId),
+				),
+			)
+			.orderBy(asc(sentEmails.batchIndex));
+
+		return {
+			id: batch.id,
+			status: refreshed.status,
+			counts: refreshed.counts,
+			items: items.map((item) => ({
+				id: item.id,
+				batch_index: item.batchIndex ?? 0,
+				status: item.status,
+				message_id: item.messageId ?? null,
+				failure_reason: item.failureReason ?? null,
+				created_at: item.createdAt?.toISOString() ?? new Date().toISOString(),
+				sent_at: item.sentAt?.toISOString() ?? null,
+			})),
+			created_at: batch.createdAt?.toISOString() ?? new Date().toISOString(),
+			updated_at: batch.updatedAt?.toISOString(),
+		};
+	},
+	{
+		params: t.Object({
+			batchId: t.String(),
+		}),
+		response: {
+			200: BatchDetailResponseSchema,
+			401: BatchErrorResponseSchema,
+			403: BatchErrorResponseSchema,
+			404: BatchErrorResponseSchema,
+			429: BatchErrorResponseSchema,
+			500: BatchErrorResponseSchema,
+			503: BatchErrorResponseSchema,
+		},
+		detail: {
+			tags: ["Emails"],
+			summary: "Get batch status",
+			description:
+				"Retrieve the current status of a batch email send, including counts and individual item summaries.",
+		},
+	},
+);

--- a/app/api/e2/emails/batch-queue.ts
+++ b/app/api/e2/emails/batch-queue.ts
@@ -1,0 +1,244 @@
+import { Client as QStashClient } from "@upstash/qstash";
+import { and, count, eq, isNotNull, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { SENT_EMAIL_STATUS, sentEmails } from "@/lib/db/schema";
+
+export interface QueueItem {
+	emailId: string;
+	userId: string;
+	batchId: string;
+	batchIndex: number;
+	attempt: number;
+}
+
+interface PublishResult {
+	emailId: string;
+	success: boolean;
+	qstashMessageId?: string;
+	error?: string;
+}
+
+const QSTASH_RETRIES = 3;
+const FLOW_PARALLELISM = 5;
+const FLOW_RATE_PER_SECOND = 10;
+
+export async function incrementPublishAttempt(
+	emailId: string,
+	userId: string,
+	batchId: string,
+): Promise<number> {
+	const result = await db
+		.update(sentEmails)
+		.set({
+			qstashPublishAttempt: sql`${sentEmails.qstashPublishAttempt} + 1`,
+			qstashMessageId: null,
+			updatedAt: new Date(),
+		})
+		.where(
+			and(
+				eq(sentEmails.id, emailId),
+				eq(sentEmails.userId, userId),
+				eq(sentEmails.batchId, batchId),
+				eq(sentEmails.status, SENT_EMAIL_STATUS.PENDING),
+			),
+		)
+		.returning({ attempt: sentEmails.qstashPublishAttempt });
+
+	return result[0]?.attempt ?? 0;
+}
+
+export async function publishBatchToQStash(items: QueueItem[]): Promise<{
+	results: PublishResult[];
+	publishedCount: number;
+	failedCount: number;
+	lastError: string | null;
+}> {
+	const qstashToken = process.env.QSTASH_TOKEN;
+	const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+
+	if (!qstashToken || !appUrl) {
+		const error = "QStash configuration missing";
+		return {
+			results: items.map((item) => ({
+				emailId: item.emailId,
+				success: false,
+				error,
+			})),
+			publishedCount: 0,
+			failedCount: items.length,
+			lastError: error,
+		};
+	}
+
+	const qstashClient = new QStashClient({ token: qstashToken });
+	const webhookUrl = `${appUrl}/api/webhooks/send-email`;
+
+	const results: PublishResult[] = [];
+	let publishedCount = 0;
+	let failedCount = 0;
+	let lastError: string | null = null;
+
+	for (let i = 0; i < items.length; i += FLOW_PARALLELISM) {
+		const batch = items.slice(i, i + FLOW_PARALLELISM);
+
+		const batchResults = await Promise.allSettled(
+			batch.map(async (item) => {
+				const deduplicationId = `${item.batchId}:${item.batchIndex}:${item.attempt}`;
+
+				try {
+					const response = await qstashClient.publishJSON({
+						url: webhookUrl,
+						body: {
+							type: "batch",
+							emailId: item.emailId,
+							userId: item.userId,
+							batchId: item.batchId,
+							batchIndex: item.batchIndex,
+						},
+						retries: QSTASH_RETRIES,
+						deduplicationId,
+						flowControl: {
+							key: `batch-email-${item.userId}`,
+							parallelism: FLOW_PARALLELISM,
+							ratePerSecond: FLOW_RATE_PER_SECOND,
+						},
+					});
+
+					const updateResult = await db
+						.update(sentEmails)
+						.set({
+							qstashMessageId: response.messageId,
+							updatedAt: new Date(),
+						})
+						.where(
+							and(
+								eq(sentEmails.id, item.emailId),
+								eq(sentEmails.userId, item.userId),
+								eq(sentEmails.batchId, item.batchId),
+								eq(sentEmails.status, SENT_EMAIL_STATUS.PENDING),
+								eq(sentEmails.qstashPublishAttempt, item.attempt),
+							),
+						)
+						.returning({ id: sentEmails.id });
+
+					if (updateResult.length === 0) {
+						return {
+							emailId: item.emailId,
+							success: false,
+							error: "Row state changed during publish",
+						};
+					}
+
+					return {
+						emailId: item.emailId,
+						success: true,
+						qstashMessageId: response.messageId,
+					};
+				} catch (err) {
+					const errorMsg =
+						err instanceof Error ? err.message : "Unknown publish error";
+					return {
+						emailId: item.emailId,
+						success: false,
+						error: errorMsg,
+					};
+				}
+			}),
+		);
+
+		for (let j = 0; j < batchResults.length; j++) {
+			const result = batchResults[j];
+			if (result.status === "fulfilled") {
+				results.push(result.value);
+				if (result.value.success) {
+					publishedCount++;
+				} else {
+					failedCount++;
+					lastError = result.value.error ?? null;
+				}
+			} else {
+				const errorMsg =
+					result.reason instanceof Error
+						? result.reason.message
+						: "Promise rejected";
+				const batchItem = batch[j];
+				results.push({
+					emailId: batchItem?.emailId ?? "unknown",
+					success: false,
+					error: errorMsg,
+				});
+				failedCount++;
+				lastError = errorMsg;
+			}
+		}
+	}
+
+	return { results, publishedCount, failedCount, lastError };
+}
+
+export async function recomputePublishedCount(
+	batchId: string,
+	userId: string,
+): Promise<number> {
+	const [result] = await db
+		.select({ count: count() })
+		.from(sentEmails)
+		.where(
+			and(
+				eq(sentEmails.batchId, batchId),
+				eq(sentEmails.userId, userId),
+				isNotNull(sentEmails.qstashMessageId),
+			),
+		);
+	return Number(result?.count ?? 0);
+}
+
+export async function deleteQStashMessages(
+	messageIds: string[],
+): Promise<{ deleted: number; errors: string[] }> {
+	const qstashToken = process.env.QSTASH_TOKEN;
+	if (!qstashToken || messageIds.length === 0) {
+		return { deleted: 0, errors: [] };
+	}
+
+	const qstashClient = new QStashClient({ token: qstashToken });
+	let deleted = 0;
+	const errors: string[] = [];
+
+	for (let i = 0; i < messageIds.length; i += FLOW_PARALLELISM) {
+		const batch = messageIds.slice(i, i + FLOW_PARALLELISM);
+
+		const results = await Promise.allSettled(
+			batch.map(async (messageId) => {
+				await qstashClient.messages.delete(messageId);
+				return messageId;
+			}),
+		);
+
+		for (const result of results) {
+			if (result.status === "fulfilled") {
+				deleted++;
+			} else {
+				const errorMsg =
+					result.reason instanceof Error
+						? result.reason.message
+						: "Delete failed";
+				errors.push(errorMsg);
+			}
+		}
+	}
+
+	return { deleted, errors };
+}
+
+export function collectQstashMessageIds(
+	items: Array<{ qstashMessageId: string | null }>,
+): string[] {
+	const ids: string[] = [];
+	for (const item of items) {
+		if (item.qstashMessageId !== null) {
+			ids.push(item.qstashMessageId);
+		}
+	}
+	return ids;
+}

--- a/app/api/e2/emails/batch-retry.ts
+++ b/app/api/e2/emails/batch-retry.ts
@@ -1,0 +1,172 @@
+import { and, eq, notInArray } from "drizzle-orm";
+import { Elysia, t } from "elysia";
+import {
+	incrementPublishAttempt,
+	publishBatchToQStash,
+	type QueueItem,
+	recomputePublishedCount,
+} from "@/app/api/e2/emails/batch-queue";
+import {
+	BatchErrorResponseSchema,
+	BatchResponseSchema,
+} from "@/app/api/e2/emails/batch-schemas";
+import { refreshEmailBatchStatus } from "@/app/api/e2/emails/batch-state";
+import { validateAndRateLimit } from "@/app/api/e2/lib/auth";
+import { db } from "@/lib/db";
+import {
+	EMAIL_BATCH_STATUS,
+	emailBatches,
+	SENT_EMAIL_STATUS,
+	sentEmails,
+} from "@/lib/db/schema";
+
+const TERMINAL_BATCH_STATUSES = [
+	EMAIL_BATCH_STATUS.COMPLETED,
+	EMAIL_BATCH_STATUS.FAILED,
+	EMAIL_BATCH_STATUS.PARTIALLY_FAILED,
+	EMAIL_BATCH_STATUS.CANCELLED,
+	EMAIL_BATCH_STATUS.REQUIRES_ATTENTION,
+] as const;
+
+const TERMINAL_BATCH_STATUSES_SET: Set<string> = new Set(
+	TERMINAL_BATCH_STATUSES,
+);
+
+export const retryEmailBatch = new Elysia().post(
+	"/emails/batch/:batchId/retry",
+	async ({ request, params, set }) => {
+		const userId = await validateAndRateLimit(request, set);
+
+		const [batch] = await db
+			.select()
+			.from(emailBatches)
+			.where(
+				and(
+					eq(emailBatches.id, params.batchId),
+					eq(emailBatches.userId, userId),
+				),
+			)
+			.limit(1);
+
+		if (!batch) {
+			set.status = 404;
+			return { error: "Batch not found" };
+		}
+
+		const preRefreshed = await refreshEmailBatchStatus(params.batchId, userId);
+
+		if (TERMINAL_BATCH_STATUSES_SET.has(preRefreshed.status)) {
+			set.status = 409;
+			return {
+				error: "Cannot retry batch",
+				details: `Batch is in terminal status: ${preRefreshed.status}`,
+			};
+		}
+
+		const pendingRows = await db
+			.select({
+				id: sentEmails.id,
+				batchIndex: sentEmails.batchIndex,
+			})
+			.from(sentEmails)
+			.where(
+				and(
+					eq(sentEmails.batchId, params.batchId),
+					eq(sentEmails.userId, userId),
+					eq(sentEmails.status, SENT_EMAIL_STATUS.PENDING),
+				),
+			);
+
+		if (pendingRows.length === 0) {
+			const refreshed = await refreshEmailBatchStatus(params.batchId, userId);
+			return {
+				id: batch.id,
+				status: refreshed.status,
+				counts: refreshed.counts,
+				created_at: batch.createdAt?.toISOString() ?? new Date().toISOString(),
+				updated_at: new Date().toISOString(),
+			};
+		}
+
+		const itemsToQueue: QueueItem[] = [];
+		for (const row of pendingRows) {
+			const newAttempt = await incrementPublishAttempt(
+				row.id,
+				userId,
+				params.batchId,
+			);
+			if (newAttempt > 0) {
+				itemsToQueue.push({
+					emailId: row.id,
+					userId,
+					batchId: params.batchId,
+					batchIndex: row.batchIndex ?? 0,
+					attempt: newAttempt,
+				});
+			}
+		}
+
+		if (itemsToQueue.length > 0) {
+			const { lastError } = await publishBatchToQStash(itemsToQueue);
+
+			const newPublishedCount = await recomputePublishedCount(
+				params.batchId,
+				userId,
+			);
+			const newStatus =
+				newPublishedCount < batch.totalCount
+					? EMAIL_BATCH_STATUS.PARTIALLY_QUEUED
+					: EMAIL_BATCH_STATUS.QUEUED;
+
+			const finalLastError =
+				newPublishedCount >= batch.totalCount ? null : lastError;
+
+			await db
+				.update(emailBatches)
+				.set({
+					status: newStatus,
+					publishedCount: newPublishedCount,
+					lastError: finalLastError,
+					updatedAt: new Date(),
+				})
+				.where(
+					and(
+						eq(emailBatches.id, params.batchId),
+						eq(emailBatches.userId, userId),
+						notInArray(emailBatches.status, [...TERMINAL_BATCH_STATUSES]),
+					),
+				);
+		}
+
+		const refreshed = await refreshEmailBatchStatus(params.batchId, userId);
+
+		return {
+			id: batch.id,
+			status: refreshed.status,
+			counts: refreshed.counts,
+			created_at: batch.createdAt?.toISOString() ?? new Date().toISOString(),
+			updated_at: new Date().toISOString(),
+		};
+	},
+	{
+		params: t.Object({
+			batchId: t.String(),
+		}),
+		response: {
+			200: BatchResponseSchema,
+			401: BatchErrorResponseSchema,
+			403: BatchErrorResponseSchema,
+			404: BatchErrorResponseSchema,
+			409: BatchErrorResponseSchema,
+			429: BatchErrorResponseSchema,
+			500: BatchErrorResponseSchema,
+			503: BatchErrorResponseSchema,
+		},
+		detail: {
+			tags: ["Emails"],
+			summary: "Retry failed batch publications",
+			description:
+				"Retry publishing pending items that failed to queue to QStash. Increments publish attempts and requeues all pending items.",
+		},
+	},
+);

--- a/app/api/e2/emails/batch-schemas.ts
+++ b/app/api/e2/emails/batch-schemas.ts
@@ -1,0 +1,151 @@
+import { t } from "elysia";
+
+export const BatchStatusSchema = t.Union([
+	t.Literal("creating"),
+	t.Literal("queued"),
+	t.Literal("partially_queued"),
+	t.Literal("processing"),
+	t.Literal("completed"),
+	t.Literal("partially_failed"),
+	t.Literal("failed"),
+	t.Literal("cancelled"),
+	t.Literal("requires_attention"),
+]);
+
+export const ItemStatusSchema = t.Union([
+	t.Literal("pending"),
+	t.Literal("processing"),
+	t.Literal("sent"),
+	t.Literal("failed"),
+	t.Literal("cancelled"),
+	t.Literal("provider_unknown"),
+]);
+
+export const NonNegativeInteger = t.Integer({ minimum: 0 });
+
+export const AttachmentSchema = t.Object({
+	filename: t.String({ maxLength: 255 }),
+	content: t.String({
+		description: "Base64 encoded content (required for batch)",
+	}),
+	content_type: t.Optional(t.String({ maxLength: 127 })),
+	content_id: t.Optional(t.String({ maxLength: 128 })),
+});
+
+export const TagSchema = t.Object({
+	name: t.String({ maxLength: 64 }),
+	value: t.String({ maxLength: 256 }),
+});
+
+export const BatchEmailItemSchema = t.Object({
+	from: t.String({ maxLength: 500, description: "Sender email address" }),
+	to: t.Union(
+		[
+			t.String({ maxLength: 500 }),
+			t.Array(t.String({ maxLength: 500 }), { maxItems: 50 }),
+		],
+		{
+			description: "Recipient email address(es), max 50",
+		},
+	),
+	subject: t.String({ maxLength: 998, description: "Email subject" }),
+	html: t.Optional(t.String({ description: "HTML content of the email" })),
+	text: t.Optional(
+		t.String({ description: "Plain text content of the email" }),
+	),
+	cc: t.Optional(
+		t.Union([
+			t.String({ maxLength: 500 }),
+			t.Array(t.String({ maxLength: 500 }), { maxItems: 50 }),
+		]),
+	),
+	bcc: t.Optional(
+		t.Union([
+			t.String({ maxLength: 500 }),
+			t.Array(t.String({ maxLength: 500 }), { maxItems: 50 }),
+		]),
+	),
+	reply_to: t.Optional(
+		t.Union([
+			t.String({ maxLength: 500 }),
+			t.Array(t.String({ maxLength: 500 }), { maxItems: 10 }),
+		]),
+	),
+	headers: t.Optional(
+		t.Record(t.String({ maxLength: 126 }), t.String({ maxLength: 998 }), {
+			description: "Custom email headers, max 50",
+		}),
+	),
+	attachments: t.Optional(t.Array(AttachmentSchema, { maxItems: 100 })),
+	tags: t.Optional(t.Array(TagSchema, { maxItems: 20 })),
+});
+
+export const BatchCreateBodySchema = t.Object({
+	emails: t.Array(BatchEmailItemSchema, {
+		minItems: 1,
+		maxItems: 100,
+		description: "Array of 1-100 emails to send",
+	}),
+});
+
+export const IdempotencyKeyHeadersSchema = t.Object(
+	{
+		"idempotency-key": t.Optional(
+			t.String({ maxLength: 256, description: "Optional idempotency key" }),
+		),
+	},
+	{ additionalProperties: true },
+);
+
+export const BatchItemSummarySchema = t.Object({
+	id: t.String(),
+	batch_index: NonNegativeInteger,
+	status: ItemStatusSchema,
+	message_id: t.Optional(t.Nullable(t.String())),
+	failure_reason: t.Optional(t.Nullable(t.String())),
+	created_at: t.String(),
+	sent_at: t.Optional(t.Nullable(t.String())),
+});
+
+export const BatchCountsSchema = t.Object({
+	total: NonNegativeInteger,
+	pending: NonNegativeInteger,
+	processing: NonNegativeInteger,
+	sent: NonNegativeInteger,
+	failed: NonNegativeInteger,
+	cancelled: NonNegativeInteger,
+	provider_unknown: NonNegativeInteger,
+});
+
+export const BatchResponseSchema = t.Object({
+	id: t.String(),
+	status: BatchStatusSchema,
+	counts: BatchCountsSchema,
+	created_at: t.String(),
+	updated_at: t.Optional(t.String()),
+});
+
+export const BatchDetailResponseSchema = t.Object({
+	id: t.String(),
+	status: BatchStatusSchema,
+	counts: BatchCountsSchema,
+	items: t.Array(BatchItemSummarySchema),
+	created_at: t.String(),
+	updated_at: t.Optional(t.String()),
+});
+
+export const BatchCancelResponseSchema = t.Object({
+	id: t.String(),
+	status: BatchStatusSchema,
+	cancelled_count: NonNegativeInteger,
+	counts: BatchCountsSchema,
+});
+
+export const BatchErrorResponseSchema = t.Object({
+	error: t.String(),
+	details: t.Optional(t.String()),
+});
+
+export type BatchEmailItem = typeof BatchEmailItemSchema.static;
+export type BatchItemSummary = typeof BatchItemSummarySchema.static;
+export type BatchCounts = typeof BatchCountsSchema.static;

--- a/app/api/e2/emails/batch-state.ts
+++ b/app/api/e2/emails/batch-state.ts
@@ -1,0 +1,164 @@
+import { and, count, eq, notInArray } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import {
+	EMAIL_BATCH_STATUS,
+	emailBatches,
+	SENT_EMAIL_STATUS,
+	sentEmails,
+} from "@/lib/db/schema";
+
+export interface BatchStatusResult {
+	status: string;
+	counts: {
+		total: number;
+		pending: number;
+		processing: number;
+		sent: number;
+		failed: number;
+		cancelled: number;
+		provider_unknown: number;
+	};
+}
+
+const IMMUTABLE_STATUSES: readonly string[] = [
+	EMAIL_BATCH_STATUS.COMPLETED,
+	EMAIL_BATCH_STATUS.PARTIALLY_FAILED,
+	EMAIL_BATCH_STATUS.FAILED,
+	EMAIL_BATCH_STATUS.CANCELLED,
+];
+
+const IMMUTABLE_STATUS_SET = new Set<string>(IMMUTABLE_STATUSES);
+
+export async function refreshEmailBatchStatus(
+	batchId: string,
+	userId: string,
+): Promise<BatchStatusResult> {
+	const [batch] = await db
+		.select({
+			id: emailBatches.id,
+			status: emailBatches.status,
+			totalCount: emailBatches.totalCount,
+			publishedCount: emailBatches.publishedCount,
+		})
+		.from(emailBatches)
+		.where(and(eq(emailBatches.id, batchId), eq(emailBatches.userId, userId)))
+		.limit(1);
+
+	if (!batch) {
+		throw new Error(`Batch not found: ${batchId}`);
+	}
+
+	const statusCounts = await db
+		.select({
+			status: sentEmails.status,
+			count: count(),
+		})
+		.from(sentEmails)
+		.where(and(eq(sentEmails.batchId, batchId), eq(sentEmails.userId, userId)))
+		.groupBy(sentEmails.status);
+
+	let childTotal = 0;
+	const counts = {
+		total: batch.totalCount,
+		pending: 0,
+		processing: 0,
+		sent: 0,
+		failed: 0,
+		cancelled: 0,
+		provider_unknown: 0,
+	};
+
+	for (const row of statusCounts) {
+		const statusCount = Number(row.count);
+		childTotal += statusCount;
+		switch (row.status) {
+			case SENT_EMAIL_STATUS.PENDING:
+				counts.pending = statusCount;
+				break;
+			case SENT_EMAIL_STATUS.PROCESSING:
+				counts.processing = statusCount;
+				break;
+			case SENT_EMAIL_STATUS.SENT:
+				counts.sent = statusCount;
+				break;
+			case SENT_EMAIL_STATUS.FAILED:
+				counts.failed = statusCount;
+				break;
+			case SENT_EMAIL_STATUS.CANCELLED:
+				counts.cancelled = statusCount;
+				break;
+			case SENT_EMAIL_STATUS.PROVIDER_UNKNOWN:
+				counts.provider_unknown = statusCount;
+				break;
+		}
+	}
+
+	if (IMMUTABLE_STATUS_SET.has(batch.status)) {
+		return { status: batch.status, counts };
+	}
+
+	let derivedStatus: string;
+	const publishedCount = batch.publishedCount ?? 0;
+	const parentTotalCount = batch.totalCount;
+	const hasPendingOrProcessing = counts.pending > 0 || counts.processing > 0;
+	const hasProviderUnknown = counts.provider_unknown > 0;
+	const allChildrenResolved =
+		childTotal === parentTotalCount &&
+		!hasPendingOrProcessing &&
+		!hasProviderUnknown;
+
+	if (hasPendingOrProcessing) {
+		if (counts.pending > 0 && publishedCount < parentTotalCount) {
+			derivedStatus = EMAIL_BATCH_STATUS.PARTIALLY_QUEUED;
+		} else if (counts.pending > 0 && counts.processing > 0) {
+			derivedStatus = EMAIL_BATCH_STATUS.PROCESSING;
+		} else if (counts.pending > 0) {
+			derivedStatus = EMAIL_BATCH_STATUS.QUEUED;
+		} else {
+			derivedStatus = EMAIL_BATCH_STATUS.PROCESSING;
+		}
+	} else if (hasProviderUnknown) {
+		derivedStatus = EMAIL_BATCH_STATUS.REQUIRES_ATTENTION;
+	} else if (allChildrenResolved && parentTotalCount > 0) {
+		if (counts.sent === parentTotalCount) {
+			derivedStatus = EMAIL_BATCH_STATUS.COMPLETED;
+		} else if (counts.cancelled === parentTotalCount) {
+			derivedStatus = EMAIL_BATCH_STATUS.CANCELLED;
+		} else if (counts.failed === parentTotalCount) {
+			derivedStatus = EMAIL_BATCH_STATUS.FAILED;
+		} else if (counts.sent > 0 || counts.failed > 0) {
+			derivedStatus = EMAIL_BATCH_STATUS.PARTIALLY_FAILED;
+		} else {
+			derivedStatus = batch.status;
+		}
+	} else {
+		derivedStatus = batch.status;
+	}
+
+	const isImmutable = IMMUTABLE_STATUS_SET.has(derivedStatus);
+
+	if (derivedStatus !== batch.status) {
+		const updateData: Record<string, unknown> = {
+			status: derivedStatus,
+			updatedAt: new Date(),
+		};
+
+		if (isImmutable) {
+			updateData.completedAt = new Date();
+		}
+
+		await db
+			.update(emailBatches)
+			.set(updateData)
+			.where(
+				and(
+					eq(emailBatches.id, batchId),
+					eq(emailBatches.userId, userId),
+					notInArray(emailBatches.status, [...IMMUTABLE_STATUSES]),
+				),
+			);
+	}
+
+	return { status: derivedStatus, counts };
+}

--- a/app/api/e2/emails/batch-utils.test.ts
+++ b/app/api/e2/emails/batch-utils.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import type { BatchEmailItem } from "@/app/api/e2/emails/batch-schemas";
 import {
 	computeCanonicalHash,
 	computeChildIdempotencyHash,
-	validateEmailItem,
-	validateAggregateBatchAttachments,
 	isPostgresUniqueViolation,
 	type ProcessedAttachmentSize,
+	validateAggregateBatchAttachments,
+	validateEmailItem,
 } from "@/app/api/e2/emails/batch-utils";
 
 const minimalValidEmail: BatchEmailItem = {

--- a/app/api/e2/emails/batch-utils.test.ts
+++ b/app/api/e2/emails/batch-utils.test.ts
@@ -1,0 +1,498 @@
+import { describe, it, expect } from "bun:test";
+import type { BatchEmailItem } from "@/app/api/e2/emails/batch-schemas";
+import {
+	computeCanonicalHash,
+	computeChildIdempotencyHash,
+	validateEmailItem,
+	validateAggregateBatchAttachments,
+	isPostgresUniqueViolation,
+	type ProcessedAttachmentSize,
+} from "@/app/api/e2/emails/batch-utils";
+
+const minimalValidEmail: BatchEmailItem = {
+	from: "sender@example.com",
+	to: "recipient@example.com",
+	subject: "Test subject",
+	html: "<p>Hello</p>",
+};
+
+describe("computeCanonicalHash", () => {
+	it("produces stable hash across recipient ordering", () => {
+		const emailA: BatchEmailItem = {
+			from: "sender@example.com",
+			to: ["z@example.com", "a@example.com"],
+			subject: "Test",
+			text: "body",
+		};
+		const emailB: BatchEmailItem = {
+			from: "sender@example.com",
+			to: ["a@example.com", "z@example.com"],
+			subject: "Test",
+			text: "body",
+		};
+		expect(computeCanonicalHash([emailA])).toBe(computeCanonicalHash([emailB]));
+	});
+
+	it("produces stable hash across header object key ordering", () => {
+		const emailA: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			text: "body",
+			headers: { "X-Custom-A": "val1", "X-Custom-B": "val2" },
+		};
+		const emailB: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			text: "body",
+			headers: { "X-Custom-B": "val2", "X-Custom-A": "val1" },
+		};
+		expect(computeCanonicalHash([emailA])).toBe(computeCanonicalHash([emailB]));
+	});
+
+	it("does not mutate original arrays", () => {
+		const toArray = ["z@example.com", "a@example.com"];
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: [...toArray],
+			subject: "Test",
+			text: "body",
+		};
+		computeCanonicalHash([email]);
+		expect(email.to).toEqual(toArray);
+	});
+
+	it("does not mutate original headers object", () => {
+		const headers = { "X-Custom-B": "val2", "X-Custom-A": "val1" };
+		const originalKeys = Object.keys(headers);
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			text: "body",
+			headers: { ...headers },
+		};
+		computeCanonicalHash([email]);
+		expect(Object.keys(email.headers!)).toEqual(originalKeys);
+	});
+
+	it("changes hash when subject changes", () => {
+		const emailA: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Subject A",
+			text: "body",
+		};
+		const emailB: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Subject B",
+			text: "body",
+		};
+		expect(computeCanonicalHash([emailA])).not.toBe(
+			computeCanonicalHash([emailB]),
+		);
+	});
+
+	it("changes hash when html content changes", () => {
+		const emailA: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			html: "<p>Content A</p>",
+		};
+		const emailB: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			html: "<p>Content B</p>",
+		};
+		expect(computeCanonicalHash([emailA])).not.toBe(
+			computeCanonicalHash([emailB]),
+		);
+	});
+
+	it("changes hash when text content changes", () => {
+		const emailA: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			text: "Content A",
+		};
+		const emailB: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			text: "Content B",
+		};
+		expect(computeCanonicalHash([emailA])).not.toBe(
+			computeCanonicalHash([emailB]),
+		);
+	});
+});
+
+describe("computeChildIdempotencyHash", () => {
+	it("returns a fixed 64-character hex string", () => {
+		const result = computeChildIdempotencyHash("parent-key", "batch-id-123", 0);
+		expect(result).toHaveLength(64);
+		expect(result).toMatch(/^[a-f0-9]{64}$/);
+	});
+
+	it("is index-sensitive", () => {
+		const hash0 = computeChildIdempotencyHash("parent-key", "batch-id-123", 0);
+		const hash1 = computeChildIdempotencyHash("parent-key", "batch-id-123", 1);
+		const hash2 = computeChildIdempotencyHash("parent-key", "batch-id-123", 2);
+		expect(hash0).not.toBe(hash1);
+		expect(hash1).not.toBe(hash2);
+		expect(hash0).not.toBe(hash2);
+	});
+
+	it("is sensitive to parent idempotency key", () => {
+		const hashA = computeChildIdempotencyHash("parent-A", "batch-id", 0);
+		const hashB = computeChildIdempotencyHash("parent-B", "batch-id", 0);
+		expect(hashA).not.toBe(hashB);
+	});
+
+	it("is sensitive to batch id", () => {
+		const hashA = computeChildIdempotencyHash("parent", "batch-A", 0);
+		const hashB = computeChildIdempotencyHash("parent", "batch-B", 0);
+		expect(hashA).not.toBe(hashB);
+	});
+});
+
+describe("validateEmailItem", () => {
+	it("accepts a valid minimal email with html", () => {
+		const result = validateEmailItem(minimalValidEmail, 0);
+		expect(result.valid).toBe(true);
+		expect(result.error).toBeUndefined();
+	});
+
+	it("accepts a valid minimal email with text only", () => {
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			text: "Plain text body",
+		};
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(true);
+	});
+
+	it("rejects email missing both html and text", () => {
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+		};
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("html or text");
+	});
+
+	it("rejects invalid recipient email format", () => {
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "not-an-email",
+			subject: "Test",
+			html: "<p>body</p>",
+		};
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Invalid email format");
+	});
+
+	it("rejects CRLF in subject", () => {
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test\r\nInjection",
+			html: "<p>body</p>",
+		};
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("line breaks");
+	});
+
+	it("rejects newline in subject", () => {
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test\nInjection",
+			html: "<p>body</p>",
+		};
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("line breaks");
+	});
+
+	it("rejects CRLF in from address", () => {
+		const email: BatchEmailItem = {
+			from: "sender@example.com\r\nBcc: attacker@evil.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			html: "<p>body</p>",
+		};
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Invalid characters");
+	});
+
+	it("rejects CRLF in recipient address", () => {
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com\r\nBcc: attacker@evil.com",
+			subject: "Test",
+			html: "<p>body</p>",
+		};
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Invalid characters");
+	});
+
+	it("rejects CRLF in header name", () => {
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			html: "<p>body</p>",
+			headers: { "X-Bad\r\nHeader": "value" },
+		};
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Invalid characters in header name");
+	});
+
+	it("rejects CRLF in header value", () => {
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			html: "<p>body</p>",
+			headers: { "X-Custom": "value\r\ninjected" },
+		};
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Invalid characters in header value");
+	});
+
+	it("rejects protected header override (from)", () => {
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			html: "<p>body</p>",
+			headers: { From: "attacker@evil.com" },
+		};
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Protected header cannot be overridden");
+	});
+
+	it("rejects protected header override (subject)", () => {
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			html: "<p>body</p>",
+			headers: { Subject: "Evil Subject" },
+		};
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Protected header cannot be overridden");
+	});
+
+	it("rejects protected header override (DKIM-Signature)", () => {
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			html: "<p>body</p>",
+			headers: { "DKIM-Signature": "forged-signature" },
+		};
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Protected header cannot be overridden");
+	});
+
+	it("rejects more than 50 total recipients", () => {
+		const recipients = Array.from(
+			{ length: 51 },
+			(_, i) => `user${i}@example.com`,
+		);
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: recipients,
+			subject: "Test",
+			html: "<p>body</p>",
+		};
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Too many recipients");
+	});
+
+	it("accepts exactly 50 total recipients", () => {
+		const recipients = Array.from(
+			{ length: 50 },
+			(_, i) => `user${i}@example.com`,
+		);
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: recipients,
+			subject: "Test",
+			html: "<p>body</p>",
+		};
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(true);
+	});
+
+	it("rejects more than 50 headers", () => {
+		const headers: Record<string, string> = {};
+		for (let i = 0; i < 51; i++) {
+			headers[`X-Custom-${i}`] = `value${i}`;
+		}
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			html: "<p>body</p>",
+			headers,
+		};
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Too many headers");
+	});
+
+	it("rejects more than 20 tags", () => {
+		const tags = Array.from({ length: 21 }, (_, i) => ({
+			name: `tag${i}`,
+			value: `val${i}`,
+		}));
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			html: "<p>body</p>",
+			tags,
+		};
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Too many tags");
+	});
+
+	it("rejects attachment missing content", () => {
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			html: "<p>body</p>",
+			attachments: [{ filename: "file.txt", content: "" }],
+		};
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("missing required content");
+	});
+
+	it("rejects remote path attachment via safe unknown cast", () => {
+		const email: BatchEmailItem = {
+			from: "sender@example.com",
+			to: "recipient@example.com",
+			subject: "Test",
+			html: "<p>body</p>",
+			attachments: [
+				{
+					filename: "file.txt",
+					content: "base64data",
+				} as BatchEmailItem["attachments"] extends (infer U)[]
+					? U & { path?: string }
+					: never,
+			],
+		};
+		(
+			email.attachments as unknown as Array<{ filename: string; path: string }>
+		)[0].path = "s3://bucket/key";
+		const result = validateEmailItem(email, 0);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Remote path attachments not allowed");
+	});
+});
+
+describe("validateAggregateBatchAttachments", () => {
+	it("accepts attachments under 100MB total", () => {
+		const attachments: ProcessedAttachmentSize[][] = [
+			[{ size: 10 * 1024 * 1024 }, { size: 20 * 1024 * 1024 }],
+			[{ size: 30 * 1024 * 1024 }],
+		];
+		const result = validateAggregateBatchAttachments(attachments);
+		expect(result.valid).toBe(true);
+	});
+
+	it("rejects attachments over 100MB total", () => {
+		const attachments: ProcessedAttachmentSize[][] = [
+			[{ size: 50 * 1024 * 1024 }],
+			[{ size: 51 * 1024 * 1024 }],
+		];
+		const result = validateAggregateBatchAttachments(attachments);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("100MB");
+	});
+
+	it("rejects when total attachment count exceeds 100", () => {
+		const attachments: ProcessedAttachmentSize[][] = [
+			Array.from({ length: 101 }, () => ({ size: 1 })),
+		];
+		const result = validateAggregateBatchAttachments(attachments);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("exceed limit");
+	});
+
+	it("accepts exactly 100 attachments", () => {
+		const attachments: ProcessedAttachmentSize[][] = [
+			Array.from({ length: 100 }, () => ({ size: 100 })),
+		];
+		const result = validateAggregateBatchAttachments(attachments);
+		expect(result.valid).toBe(true);
+	});
+
+	it("accepts exactly 100MB total", () => {
+		const attachments: ProcessedAttachmentSize[][] = [
+			[{ size: 100 * 1024 * 1024 }],
+		];
+		const result = validateAggregateBatchAttachments(attachments);
+		expect(result.valid).toBe(true);
+	});
+});
+
+describe("isPostgresUniqueViolation", () => {
+	it("recognizes error with code 23505", () => {
+		const err = { code: "23505", message: "unique violation" };
+		expect(isPostgresUniqueViolation(err)).toBe(true);
+	});
+
+	it("rejects error with different code", () => {
+		const err = { code: "23502", message: "not null violation" };
+		expect(isPostgresUniqueViolation(err)).toBe(false);
+	});
+
+	it("rejects null", () => {
+		expect(isPostgresUniqueViolation(null)).toBe(false);
+	});
+
+	it("rejects undefined", () => {
+		expect(isPostgresUniqueViolation(undefined)).toBe(false);
+	});
+
+	it("rejects non-object", () => {
+		expect(isPostgresUniqueViolation("23505")).toBe(false);
+	});
+
+	it("rejects object without code property", () => {
+		const err = { message: "some error" };
+		expect(isPostgresUniqueViolation(err)).toBe(false);
+	});
+
+	it("rejects object with numeric code", () => {
+		const err = { code: 23505 };
+		expect(isPostgresUniqueViolation(err)).toBe(false);
+	});
+});

--- a/app/api/e2/emails/batch-utils.ts
+++ b/app/api/e2/emails/batch-utils.ts
@@ -1,0 +1,334 @@
+import { createHash } from "node:crypto";
+import type { BatchEmailItem } from "@/app/api/e2/emails/batch-schemas";
+
+const MAX_RECIPIENTS_PER_ITEM = 50;
+const MAX_HEADERS_PER_ITEM = 50;
+const MAX_TAGS_PER_ITEM = 20;
+const MAX_TOTAL_ATTACHMENTS = 100;
+const MAX_AGGREGATE_ATTACHMENT_BYTES = 100 * 1024 * 1024;
+
+const PROTECTED_HEADERS = new Set([
+	"from",
+	"to",
+	"cc",
+	"bcc",
+	"subject",
+	"date",
+	"message-id",
+	"mime-version",
+	"content-type",
+	"content-transfer-encoding",
+	"return-path",
+	"received",
+	"dkim-signature",
+	"x-ses-message-id",
+	"x-ses-outbound-source-arn",
+]);
+
+const CONTROL_CHAR_REGEX = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/;
+const HEADER_INJECTION_REGEX = /[\r\n]/;
+
+export function toArray(value: string | string[] | undefined): string[] {
+	if (!value) return [];
+	return Array.isArray(value) ? value : [value];
+}
+
+export function extractEmailAddress(email: string): string {
+	const match = email.match(/<([^>]+)>/);
+	return match ? match[1] : email;
+}
+
+export function extractDomain(email: string): string {
+	const address = extractEmailAddress(email);
+	const parts = address.split("@");
+	return parts.length === 2 ? parts[1].toLowerCase() : "";
+}
+
+export function validateEmailFormat(email: string): boolean {
+	const address = extractEmailAddress(email);
+	const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+	return regex.test(address);
+}
+
+function hasControlChars(str: string): boolean {
+	return CONTROL_CHAR_REGEX.test(str);
+}
+
+function hasHeaderInjection(str: string): boolean {
+	return HEADER_INJECTION_REGEX.test(str);
+}
+
+export function validateHeaderSafety(
+	name: string,
+	value: string,
+): string | null {
+	const lowerName = name.toLowerCase();
+	if (PROTECTED_HEADERS.has(lowerName)) {
+		return `Protected header cannot be overridden: ${name}`;
+	}
+	if (hasControlChars(name) || hasHeaderInjection(name)) {
+		return `Invalid characters in header name: ${name}`;
+	}
+	if (hasControlChars(value) || hasHeaderInjection(value)) {
+		return `Invalid characters in header value for: ${name}`;
+	}
+	return null;
+}
+
+export function validateAddressSafety(
+	address: string,
+	field: string,
+): string | null {
+	if (hasControlChars(address) || hasHeaderInjection(address)) {
+		return `Invalid characters in ${field} address: ${address}`;
+	}
+	return null;
+}
+
+export function validateSubjectSafety(subject: string): string | null {
+	if (hasControlChars(subject)) {
+		return "Invalid control characters in subject";
+	}
+	if (subject.includes("\r") || subject.includes("\n")) {
+		return "Subject cannot contain line breaks";
+	}
+	return null;
+}
+
+export interface ValidationResult {
+	valid: boolean;
+	error?: string;
+}
+
+export function validateEmailItem(
+	item: BatchEmailItem,
+	index: number,
+): ValidationResult {
+	if (!item.html && !item.text) {
+		return {
+			valid: false,
+			error: `Email at index ${index}: Either html or text content must be provided`,
+		};
+	}
+
+	const subjectCheck = validateSubjectSafety(item.subject);
+	if (subjectCheck) {
+		return { valid: false, error: `Email at index ${index}: ${subjectCheck}` };
+	}
+
+	const fromCheck = validateAddressSafety(item.from, "from");
+	if (fromCheck) {
+		return { valid: false, error: `Email at index ${index}: ${fromCheck}` };
+	}
+
+	const toAddresses = toArray(item.to);
+	const ccAddresses = toArray(item.cc);
+	const bccAddresses = toArray(item.bcc);
+	const replyToAddresses = toArray(item.reply_to);
+
+	const totalRecipients =
+		toAddresses.length + ccAddresses.length + bccAddresses.length;
+	if (totalRecipients > MAX_RECIPIENTS_PER_ITEM) {
+		return {
+			valid: false,
+			error: `Email at index ${index}: Too many recipients (${totalRecipients} > ${MAX_RECIPIENTS_PER_ITEM})`,
+		};
+	}
+
+	if (toAddresses.length === 0) {
+		return {
+			valid: false,
+			error: `Email at index ${index}: At least one recipient is required`,
+		};
+	}
+
+	for (const addr of [
+		...toAddresses,
+		...ccAddresses,
+		...bccAddresses,
+		...replyToAddresses,
+	]) {
+		const addrCheck = validateAddressSafety(addr, "recipient");
+		if (addrCheck) {
+			return { valid: false, error: `Email at index ${index}: ${addrCheck}` };
+		}
+		if (!validateEmailFormat(addr)) {
+			return {
+				valid: false,
+				error: `Email at index ${index}: Invalid email format: ${addr}`,
+			};
+		}
+	}
+
+	if (item.headers) {
+		const headerKeys = Object.keys(item.headers);
+		if (headerKeys.length > MAX_HEADERS_PER_ITEM) {
+			return {
+				valid: false,
+				error: `Email at index ${index}: Too many headers (${headerKeys.length} > ${MAX_HEADERS_PER_ITEM})`,
+			};
+		}
+		for (const [name, value] of Object.entries(item.headers)) {
+			const headerCheck = validateHeaderSafety(name, value);
+			if (headerCheck) {
+				return {
+					valid: false,
+					error: `Email at index ${index}: ${headerCheck}`,
+				};
+			}
+		}
+	}
+
+	if (item.tags && item.tags.length > MAX_TAGS_PER_ITEM) {
+		return {
+			valid: false,
+			error: `Email at index ${index}: Too many tags (${item.tags.length} > ${MAX_TAGS_PER_ITEM})`,
+		};
+	}
+
+	if (item.attachments) {
+		for (const att of item.attachments) {
+			if ("path" in att && att.path) {
+				return {
+					valid: false,
+					error: `Email at index ${index}: Remote path attachments not allowed in batch; use base64 content`,
+				};
+			}
+			if (!att.content) {
+				return {
+					valid: false,
+					error: `Email at index ${index}: Attachment "${att.filename}" missing required content`,
+				};
+			}
+		}
+	}
+
+	return { valid: true };
+}
+
+export interface ProcessedAttachmentSize {
+	size: number;
+}
+
+export function validateAggregateBatchAttachments(
+	allProcessedAttachments: ProcessedAttachmentSize[][],
+): ValidationResult {
+	let totalAttachments = 0;
+	let totalBytes = 0;
+
+	for (const attachments of allProcessedAttachments) {
+		totalAttachments += attachments.length;
+		if (totalAttachments > MAX_TOTAL_ATTACHMENTS) {
+			return {
+				valid: false,
+				error: `Total attachments exceed limit (${totalAttachments} > ${MAX_TOTAL_ATTACHMENTS})`,
+			};
+		}
+
+		for (const att of attachments) {
+			totalBytes += att.size;
+			if (totalBytes > MAX_AGGREGATE_ATTACHMENT_BYTES) {
+				return {
+					valid: false,
+					error: "Total attachment size exceeds 100MB limit",
+				};
+			}
+		}
+	}
+
+	return { valid: true };
+}
+
+function canonicalizeValue(value: unknown): unknown {
+	if (value === null || value === undefined) {
+		return null;
+	}
+	if (Array.isArray(value)) {
+		return value.map(canonicalizeValue);
+	}
+	if (typeof value === "object") {
+		const sorted: Record<string, unknown> = {};
+		const keys = Object.keys(value as Record<string, unknown>).sort();
+		for (const key of keys) {
+			sorted[key] = canonicalizeValue((value as Record<string, unknown>)[key]);
+		}
+		return sorted;
+	}
+	return value;
+}
+
+export function computeCanonicalHash(
+	emails: readonly BatchEmailItem[],
+): string {
+	const canonical = emails.map((e) => {
+		const toArr = toArray(e.to);
+		const ccArr = e.cc ? toArray(e.cc) : null;
+		const bccArr = e.bcc ? toArray(e.bcc) : null;
+		const replyToArr = e.reply_to ? toArray(e.reply_to) : null;
+
+		return {
+			from: e.from,
+			to: [...toArr].sort(),
+			subject: e.subject,
+			html: e.html ?? null,
+			text: e.text ?? null,
+			cc: ccArr ? [...ccArr].sort() : null,
+			bcc: bccArr ? [...bccArr].sort() : null,
+			reply_to: replyToArr ? [...replyToArr].sort() : null,
+			headers: e.headers ? canonicalizeValue(e.headers) : null,
+			attachments: e.attachments
+				? e.attachments.map((a) => ({
+						filename: a.filename,
+						content: a.content ?? null,
+						content_type: a.content_type ?? null,
+						content_id: a.content_id ?? null,
+					}))
+				: null,
+			tags: e.tags
+				? [...e.tags]
+						.map((t) => ({ name: t.name, value: t.value }))
+						.sort((a, b) => a.name.localeCompare(b.name))
+				: null,
+		};
+	});
+
+	const jsonStr = JSON.stringify(canonical);
+	return createHash("sha256").update(jsonStr).digest("hex");
+}
+
+export function computeChildIdempotencyHash(
+	parentIdempotencyKey: string,
+	batchId: string,
+	index: number,
+): string {
+	const input = `${parentIdempotencyKey}:${batchId}:${index}`;
+	return createHash("sha256").update(input).digest("hex");
+}
+
+export function getAllRecipients(item: BatchEmailItem): string[] {
+	const to = toArray(item.to);
+	const cc = toArray(item.cc);
+	const bcc = toArray(item.bcc);
+	return [...to, ...cc, ...bcc];
+}
+
+export function getDistinctSenders(
+	emails: readonly BatchEmailItem[],
+): Array<{ address: string; domain: string }> {
+	const seen = new Map<string, { address: string; domain: string }>();
+	for (const email of emails) {
+		const address = extractEmailAddress(email.from).toLowerCase();
+		if (!seen.has(address)) {
+			seen.set(address, { address, domain: extractDomain(email.from) });
+		}
+	}
+	return Array.from(seen.values());
+}
+
+export function isPostgresUniqueViolation(err: unknown): boolean {
+	if (err == null || typeof err !== "object") {
+		return false;
+	}
+	const record = err as Record<string, unknown>;
+	return record.code === "23505";
+}

--- a/app/api/inbound/health/tenant/accepted-event.test.ts
+++ b/app/api/inbound/health/tenant/accepted-event.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "bun:test";
+
+import { SENT_EMAIL_ID_TAG } from "@/app/api/e2/helper/ses-email-tags";
+import { parseAcceptedEvent } from "@/app/api/inbound/health/tenant/accepted-event";
+
+describe("parseAcceptedEvent", () => {
+	it("parses a send event with sent_email_id tag", () => {
+		const parsed = parseAcceptedEvent({
+			eventType: "Send",
+			mail: {
+				messageId: "ses-message-id-123",
+				timestamp: "2026-08-16T12:30:00.000Z",
+				tags: { [SENT_EMAIL_ID_TAG]: ["email_abc123"] },
+			},
+		});
+
+		expect(parsed).toEqual({
+			sentEmailId: "email_abc123",
+			sesMessageId: "ses-message-id-123",
+			acceptedAt: new Date("2026-08-16T12:30:00.000Z"),
+		});
+	});
+
+	it("parses a delivery event with sent_email_id tag", () => {
+		const parsed = parseAcceptedEvent({
+			eventType: "Delivery",
+			mail: {
+				messageId: "ses-message-id-456",
+				timestamp: "2026-08-16T12:35:00.000Z",
+				tags: { [SENT_EMAIL_ID_TAG]: ["email_xyz789"] },
+			},
+		});
+
+		expect(parsed).toEqual({
+			sentEmailId: "email_xyz789",
+			sesMessageId: "ses-message-id-456",
+			acceptedAt: new Date("2026-08-16T12:35:00.000Z"),
+		});
+	});
+
+	it("handles lowercase eventType", () => {
+		const parsed = parseAcceptedEvent({
+			eventType: "send",
+			mail: {
+				messageId: "ses-message-id",
+				timestamp: "2026-08-16T12:30:00.000Z",
+				tags: { [SENT_EMAIL_ID_TAG]: ["email_123"] },
+			},
+		});
+
+		expect(parsed).not.toBeNull();
+		expect(parsed?.sentEmailId).toBe("email_123");
+	});
+
+	it("returns null for invalid timestamp", () => {
+		const parsed = parseAcceptedEvent({
+			eventType: "send",
+			mail: {
+				messageId: "ses-message-id",
+				timestamp: "invalid-timestamp",
+				tags: { [SENT_EMAIL_ID_TAG]: ["email_123"] },
+			},
+		});
+
+		expect(parsed).toBeNull();
+	});
+
+	it("returns null for missing timestamp", () => {
+		const parsed = parseAcceptedEvent({
+			eventType: "send",
+			mail: {
+				messageId: "ses-message-id",
+				timestamp: "",
+				tags: { [SENT_EMAIL_ID_TAG]: ["email_123"] },
+			},
+		});
+
+		expect(parsed).toBeNull();
+	});
+
+	it("returns null for missing sent_email_id tag", () => {
+		const parsed = parseAcceptedEvent({
+			eventType: "send",
+			mail: {
+				messageId: "ses-message-id",
+				timestamp: "2026-08-16T12:30:00.000Z",
+				tags: {},
+			},
+		});
+
+		expect(parsed).toBeNull();
+	});
+
+	it("returns null when tags object is missing", () => {
+		const parsed = parseAcceptedEvent({
+			eventType: "send",
+			mail: {
+				messageId: "ses-message-id",
+				timestamp: "2026-08-16T12:30:00.000Z",
+			},
+		});
+
+		expect(parsed).toBeNull();
+	});
+
+	it("returns null for unrelated event types", () => {
+		expect(
+			parseAcceptedEvent({
+				eventType: "bounce",
+				mail: {
+					messageId: "ses-message-id",
+					timestamp: "2026-08-16T12:30:00.000Z",
+					tags: { [SENT_EMAIL_ID_TAG]: ["email_123"] },
+				},
+			}),
+		).toBeNull();
+
+		expect(
+			parseAcceptedEvent({
+				eventType: "complaint",
+				mail: {
+					messageId: "ses-message-id",
+					timestamp: "2026-08-16T12:30:00.000Z",
+					tags: { [SENT_EMAIL_ID_TAG]: ["email_123"] },
+				},
+			}),
+		).toBeNull();
+
+		expect(
+			parseAcceptedEvent({
+				eventType: "open",
+				mail: {
+					messageId: "ses-message-id",
+					timestamp: "2026-08-16T12:30:00.000Z",
+					tags: { [SENT_EMAIL_ID_TAG]: ["email_123"] },
+				},
+			}),
+		).toBeNull();
+	});
+
+	it("returns null when messageId is missing", () => {
+		const parsed = parseAcceptedEvent({
+			eventType: "send",
+			mail: {
+				messageId: "",
+				timestamp: "2026-08-16T12:30:00.000Z",
+				tags: { [SENT_EMAIL_ID_TAG]: ["email_123"] },
+			},
+		});
+
+		expect(parsed).toBeNull();
+	});
+});

--- a/app/api/inbound/health/tenant/accepted-event.ts
+++ b/app/api/inbound/health/tenant/accepted-event.ts
@@ -1,0 +1,169 @@
+import { and, eq, inArray, sql } from "drizzle-orm";
+
+import { refreshEmailBatchStatus } from "@/app/api/e2/emails/batch-state";
+import { SENT_EMAIL_ID_TAG } from "@/app/api/e2/helper/ses-email-tags";
+import { db } from "@/lib/db";
+import { SENT_EMAIL_STATUS, sentEmails } from "@/lib/db/schema";
+
+export interface SesAcceptedEvent {
+	eventType: string;
+	mail: {
+		messageId: string;
+		timestamp: string;
+		tags?: Record<string, string[]>;
+	};
+}
+
+export interface ParsedAcceptedEvent {
+	sentEmailId: string;
+	sesMessageId: string;
+	acceptedAt: Date;
+}
+
+export function parseAcceptedEvent(
+	event: SesAcceptedEvent,
+): ParsedAcceptedEvent | null {
+	const eventTypeLower = event.eventType.toLowerCase();
+	if (eventTypeLower !== "send" && eventTypeLower !== "delivery") {
+		return null;
+	}
+
+	if (!event.mail.messageId) {
+		return null;
+	}
+
+	const acceptedAt = new Date(event.mail.timestamp);
+	if (Number.isNaN(acceptedAt.getTime())) {
+		return null;
+	}
+
+	const sentEmailId = event.mail.tags?.[SENT_EMAIL_ID_TAG]?.[0];
+	if (!sentEmailId) {
+		return null;
+	}
+
+	return {
+		sentEmailId,
+		sesMessageId: event.mail.messageId,
+		acceptedAt,
+	};
+}
+
+export async function handleAcceptedEvent(
+	event: SesAcceptedEvent,
+): Promise<void> {
+	const parsed = parseAcceptedEvent(event);
+	if (!parsed) {
+		return;
+	}
+
+	const { sentEmailId, sesMessageId, acceptedAt } = parsed;
+
+	const [updatedRow] = await db
+		.update(sentEmails)
+		.set({
+			status: SENT_EMAIL_STATUS.SENT,
+			messageId: sesMessageId,
+			sesMessageId: sesMessageId,
+			sentAt: acceptedAt,
+			failureReason: null,
+			processingToken: null,
+			processingStartedAt: null,
+			providerSubmittedAt: sql`COALESCE(${sentEmails.providerSubmittedAt}, ${acceptedAt})`,
+			updatedAt: new Date(),
+		})
+		.where(
+			and(
+				eq(sentEmails.id, sentEmailId),
+				inArray(sentEmails.status, [
+					SENT_EMAIL_STATUS.PROCESSING,
+					SENT_EMAIL_STATUS.PROVIDER_UNKNOWN,
+				]),
+			),
+		)
+		.returning({
+			id: sentEmails.id,
+			userId: sentEmails.userId,
+			batchId: sentEmails.batchId,
+			usageTrackedAt: sentEmails.usageTrackedAt,
+		});
+
+	if (!updatedRow) {
+		return;
+	}
+
+	if (!updatedRow.batchId) {
+		return;
+	}
+
+	if (!updatedRow.usageTrackedAt) {
+		const { Autumn: autumn } = await import("autumn-js");
+
+		try {
+			const { error: trackError } = await autumn.track({
+				customer_id: updatedRow.userId,
+				feature_id: "emails_sent",
+				value: 1,
+				idempotency_key: sentEmailId,
+			});
+
+			if (trackError) {
+				console.error(
+					"❌ handleAcceptedEvent - Failed to track email usage:",
+					trackError,
+				);
+				await db
+					.update(sentEmails)
+					.set({
+						usageTrackingError: String(trackError),
+						updatedAt: new Date(),
+					})
+					.where(
+						and(
+							eq(sentEmails.id, sentEmailId),
+							eq(sentEmails.userId, updatedRow.userId),
+							eq(sentEmails.batchId, updatedRow.batchId),
+						),
+					);
+			} else {
+				await db
+					.update(sentEmails)
+					.set({
+						usageTrackedAt: new Date(),
+						usageTrackingError: null,
+						updatedAt: new Date(),
+					})
+					.where(
+						and(
+							eq(sentEmails.id, sentEmailId),
+							eq(sentEmails.userId, updatedRow.userId),
+							eq(sentEmails.batchId, updatedRow.batchId),
+						),
+					);
+			}
+		} catch (trackError) {
+			console.error(
+				"❌ handleAcceptedEvent - Failed to track email usage:",
+				trackError,
+			);
+			await db
+				.update(sentEmails)
+				.set({
+					usageTrackingError:
+						trackError instanceof Error
+							? trackError.message
+							: String(trackError),
+					updatedAt: new Date(),
+				})
+				.where(
+					and(
+						eq(sentEmails.id, sentEmailId),
+						eq(sentEmails.userId, updatedRow.userId),
+						eq(sentEmails.batchId, updatedRow.batchId),
+					),
+				);
+		}
+	}
+
+	await refreshEmailBatchStatus(updatedRow.batchId, updatedRow.userId);
+}

--- a/app/api/inbound/health/tenant/route.ts
+++ b/app/api/inbound/health/tenant/route.ts
@@ -1,5 +1,7 @@
 import { eq, or, sql } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
+
+import { handleAcceptedEvent } from "@/app/api/inbound/health/tenant/accepted-event";
 import { parseOpenEvent } from "@/app/api/inbound/health/tenant/open-event";
 import {
 	isTrustedSnsUrl,
@@ -251,6 +253,21 @@ export async function POST(request: NextRequest) {
 
 				if (event.eventType === "open") {
 					await handleSESOpen(event);
+					continue;
+				}
+
+				if (
+					event.eventType === "send" ||
+					event.eventType === "delivery"
+				) {
+					try {
+						await handleAcceptedEvent(event);
+					} catch (acceptedErr) {
+						console.error(
+							"❌ handleAcceptedEvent error (non-fatal):",
+							acceptedErr,
+						);
+					}
 					continue;
 				}
 

--- a/app/api/inbound/health/tenant/route.ts
+++ b/app/api/inbound/health/tenant/route.ts
@@ -58,13 +58,7 @@ interface CloudWatchAlarmMessage {
 
 // SES Event notification format
 interface SESEvent {
-	eventType:
-		| "send"
-		| "reject"
-		| "bounce"
-		| "complaint"
-		| "delivery"
-		| "open";
+	eventType: "send" | "reject" | "bounce" | "complaint" | "delivery" | "open";
 	mail: {
 		timestamp: string;
 		messageId: string;
@@ -256,10 +250,7 @@ export async function POST(request: NextRequest) {
 					continue;
 				}
 
-				if (
-					event.eventType === "send" ||
-					event.eventType === "delivery"
-				) {
+				if (event.eventType === "send" || event.eventType === "delivery") {
 					try {
 						await handleAcceptedEvent(event);
 					} catch (acceptedErr) {
@@ -881,8 +872,7 @@ async function confirmSuspendWithDbRates(
 	const events =
 		alertType === "bounce" ? rates.totalBounces : rates.totalComplaints;
 	const criticalAlert = checkRateThresholds(rates).find(
-		(alert) =>
-			alert.alertType === alertType && alert.severity === "critical",
+		(alert) => alert.alertType === alertType && alert.severity === "critical",
 	);
 
 	if (!criticalAlert) {
@@ -917,7 +907,10 @@ async function handleRateAlert(alert: RateAlert, configSetName: string) {
 
 		const rateDisplay = `${(alert.currentRate * 100).toFixed(2)}%`;
 		const thresholdDisplay = `${(alert.threshold * 100).toFixed(2)}%`;
-		if (alert.severity === "critical" && tenantOwner.tenantStatus === "suspended") {
+		if (
+			alert.severity === "critical" &&
+			tenantOwner.tenantStatus === "suspended"
+		) {
 			console.log(
 				"⏭️ handleRateAlert - Tenant already suspended; skipping repeat enforcement",
 			);

--- a/app/api/webhooks/send-email/route.ts
+++ b/app/api/webhooks/send-email/route.ts
@@ -1,11 +1,12 @@
 import { SESv2Client, SendEmailCommand } from "@aws-sdk/client-sesv2";
 import { Receiver } from "@upstash/qstash";
 import { waitUntil } from "@vercel/functions";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull, lt } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { type NextRequest, NextResponse } from "next/server";
+
+import { refreshEmailBatchStatus } from "@/app/api/e2/emails/batch-state";
 import { buildSentEmailTags } from "@/app/api/e2/helper/ses-email-tags";
-import type { PostEmailsRequest } from "@/lib/api-types";
 import {
 	getAgentIdentityArn,
 	getTenantSendingInfoForDomainOrParent,
@@ -13,6 +14,8 @@ import {
 } from "@/lib/aws-ses/identity-arn-helper";
 import { db } from "@/lib/db";
 import {
+	EMAIL_BATCH_STATUS,
+	emailBatches,
 	SCHEDULED_EMAIL_STATUS,
 	SENT_EMAIL_STATUS,
 	scheduledEmails,
@@ -23,29 +26,18 @@ import {
 	canUserSendFromEmail,
 	extractEmailAddress,
 } from "@/lib/email-management/agent-email-helper";
+import { checkRecipientsAgainstBlocklist } from "@/lib/email-management/email-blocking";
 import { evaluateSending } from "@/lib/email-management/email-evaluation";
 import { enforceOutboundSendGuard } from "@/lib/email-management/outbound-send-guard";
 import { checkSendingSpike } from "@/lib/email-management/sending-spike-detector";
 import { buildRawEmailMessage } from "../../e2/helper/email-builder";
 
-/**
- * POST /api/webhooks/send-email
- * QStash webhook for processing scheduled emails
- *
- * This endpoint is called by QStash when a scheduled email is due to be sent.
- *
- * Security: Protected by QStash signature verification
- * Has tests? ❌ (TODO)
- * Has logging? ✅
- * Has types? ✅
- */
-
-// Initialize SES client
 const awsRegion = process.env.AWS_REGION || "us-east-2";
 const awsAccessKeyId = process.env.AWS_ACCESS_KEY_ID;
 const awsSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
 
 let sesClient: SESv2Client | null = null;
+let batchSesClient: SESv2Client | null = null;
 
 if (awsAccessKeyId && awsSecretAccessKey) {
 	sesClient = new SESv2Client({
@@ -55,47 +47,140 @@ if (awsAccessKeyId && awsSecretAccessKey) {
 			secretAccessKey: awsSecretAccessKey,
 		},
 	});
+	batchSesClient = new SESv2Client({
+		region: awsRegion,
+		credentials: {
+			accessKeyId: awsAccessKeyId,
+			secretAccessKey: awsSecretAccessKey,
+		},
+		maxAttempts: 1,
+	});
 } else {
 	console.warn(
 		"⚠️ AWS credentials not configured. Scheduled email processing will not work.",
 	);
 }
 
-// Initialize QStash receiver for signature verification
 const qstashReceiver = new Receiver({
 	currentSigningKey: process.env.QSTASH_CURRENT_SIGNING_KEY!,
 	nextSigningKey: process.env.QSTASH_NEXT_SIGNING_KEY!,
 });
 
+const PROCESSING_LEASE_TIMEOUT_MS = 10 * 60 * 1000;
+
 interface QStashPayload {
 	type: "scheduled" | "batch";
-	scheduledEmailId?: string; // for scheduled
-	emailId?: string; // for batch
-	userId?: string; // for batch
-	emailData?: PostEmailsRequest; // for batch
-	batchId?: string; // for batch
-	batchIndex?: number; // for batch
+	scheduledEmailId?: string;
+	emailId?: string;
+	userId?: string;
+	batchId?: string;
+	batchIndex?: number;
 }
 
 interface StoredAttachment {
 	filename?: string;
 	contentType?: string;
 	content_type?: string;
-	[key: string]: unknown;
+	content?: string;
+	size?: number;
+	content_id?: string;
+}
+
+function parseJsonArraySafe<T>(jsonString: string | null): T[] {
+	if (!jsonString) return [];
+	try {
+		const parsed: unknown = JSON.parse(jsonString);
+		return Array.isArray(parsed) ? (parsed as T[]) : [];
+	} catch {
+		return [];
+	}
+}
+
+function parseJsonObjectSafe<T extends Record<string, unknown>>(
+	jsonString: string | null,
+): T | undefined {
+	if (!jsonString) return undefined;
+	try {
+		const parsed: unknown = JSON.parse(jsonString);
+		return typeof parsed === "object" &&
+			parsed !== null &&
+			!Array.isArray(parsed)
+			? (parsed as T)
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function isSesRetryableError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+
+	const errorName = (error as { name?: string }).name ?? "";
+	const errorCode = (error as { $metadata?: { httpStatusCode?: number } })
+		.$metadata?.httpStatusCode;
+
+	if (errorCode === 429 || errorCode === 503) return true;
+
+	const retryableNames = [
+		"Throttling",
+		"ThrottlingException",
+		"TooManyRequestsException",
+		"ServiceUnavailableException",
+		"ServiceUnavailable",
+	];
+
+	return retryableNames.some(
+		(name) => errorName.includes(name) || error.message.includes(name),
+	);
+}
+
+function getContentTypeForAttachment(
+	att: StoredAttachment,
+	index: number,
+): string {
+	if (att.contentType) return att.contentType;
+	if (att.content_type) return att.content_type;
+
+	console.log(`⚠️ Attachment ${index + 1} missing contentType, using fallback`);
+	const filename = att.filename || "unknown";
+	const ext = filename.toLowerCase().split(".").pop();
+
+	const contentTypeMap: Record<string, string> = {
+		pdf: "application/pdf",
+		jpg: "image/jpeg",
+		jpeg: "image/jpeg",
+		png: "image/png",
+		gif: "image/gif",
+		txt: "text/plain",
+		html: "text/html",
+		json: "application/json",
+		zip: "application/zip",
+		doc: "application/msword",
+		docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		xls: "application/vnd.ms-excel",
+		xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+	};
+
+	return contentTypeMap[ext || ""] || "application/octet-stream";
+}
+
+function generateDeterministicMessageId(
+	emailId: string,
+	fromDomain: string,
+): string {
+	return `<${emailId}@${fromDomain}>`;
 }
 
 export async function POST(request: NextRequest) {
 	console.log("📨 QStash Webhook - Received scheduled email request");
 
 	try {
-		// Verify QStash signature
 		const signature = request.headers.get("upstash-signature");
 		if (!signature) {
 			console.error("❌ QStash Webhook - Missing signature");
 			return NextResponse.json({ error: "Missing signature" }, { status: 401 });
 		}
 
-		// Get raw body for signature verification
 		const body = await request.text();
 
 		try {
@@ -109,12 +194,10 @@ export async function POST(request: NextRequest) {
 			return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
 		}
 
-		// Parse the payload
 		const payload: QStashPayload = JSON.parse(body);
 
-		// Route to appropriate handler based on type
 		if (payload.type === "batch") {
-			return handleBatchEmail(request, payload, body);
+			return handleBatchEmail(payload);
 		} else if (payload.type === "scheduled") {
 			return handleScheduledEmail(payload);
 		} else {
@@ -136,7 +219,6 @@ export async function POST(request: NextRequest) {
 	}
 }
 
-// Handler for scheduled emails
 async function handleScheduledEmail(payload: QStashPayload) {
 	if (!payload.scheduledEmailId) {
 		console.error("❌ QStash Webhook - Missing scheduledEmailId");
@@ -150,7 +232,6 @@ async function handleScheduledEmail(payload: QStashPayload) {
 	console.log("📧 Processing scheduled email:", scheduledEmailId);
 
 	try {
-		// Check if SES is configured
 		if (!sesClient) {
 			console.error("❌ AWS SES not configured");
 			return NextResponse.json(
@@ -161,7 +242,6 @@ async function handleScheduledEmail(payload: QStashPayload) {
 			);
 		}
 
-		// Fetch the scheduled email from database
 		const [scheduledEmail] = await db
 			.select()
 			.from(scheduledEmails)
@@ -170,14 +250,12 @@ async function handleScheduledEmail(payload: QStashPayload) {
 
 		if (!scheduledEmail) {
 			console.error("❌ Scheduled email not found:", scheduledEmailId);
-			// Return 400 so QStash doesn't retry (email was deleted/doesn't exist)
 			return NextResponse.json(
 				{ error: "Scheduled email not found" },
 				{ status: 400 },
 			);
 		}
 
-		// Check if already processed
 		if (scheduledEmail.status === SCHEDULED_EMAIL_STATUS.SENT) {
 			console.log("✅ Email already sent, skipping:", scheduledEmailId);
 			return NextResponse.json(
@@ -209,7 +287,6 @@ async function handleScheduledEmail(payload: QStashPayload) {
 				`🚫 Blocking scheduled email for user ${scheduledEmail.userId}: ${scheduledGuard.reasonCode}`,
 			);
 
-			// Update scheduled email status to failed
 			await db
 				.update(scheduledEmails)
 				.set({
@@ -219,7 +296,6 @@ async function handleScheduledEmail(payload: QStashPayload) {
 				})
 				.where(eq(scheduledEmails.id, scheduledEmailId));
 
-			// Return 200 so QStash doesn't retry - this is intentional blocking
 			return NextResponse.json(
 				{
 					error: scheduledGuard.error || "Email blocked",
@@ -229,7 +305,6 @@ async function handleScheduledEmail(payload: QStashPayload) {
 			);
 		}
 
-		// Mark as processing to prevent duplicate processing
 		await db
 			.update(scheduledEmails)
 			.set({
@@ -239,7 +314,6 @@ async function handleScheduledEmail(payload: QStashPayload) {
 			})
 			.where(eq(scheduledEmails.id, scheduledEmailId));
 
-		// Parse email data
 		const toAddresses = JSON.parse(scheduledEmail.toAddresses);
 		const ccAddresses = scheduledEmail.ccAddresses
 			? JSON.parse(scheduledEmail.ccAddresses)
@@ -257,74 +331,13 @@ async function handleScheduledEmail(payload: QStashPayload) {
 			? JSON.parse(scheduledEmail.attachments)
 			: [];
 
-		// Validate and fix attachment data - ensure contentType is set
 		const attachments = rawAttachments.map(
-			(att: StoredAttachment, index: number) => {
-				if (!att.contentType && !att.content_type) {
-					console.log(
-						`⚠️ Attachment ${index + 1} missing contentType, using fallback`,
-					);
-					const filename = att.filename || "unknown";
-					const ext = filename.toLowerCase().split(".").pop();
-					let contentType = "application/octet-stream";
-
-					// Common file type mappings
-					switch (ext) {
-						case "pdf":
-							contentType = "application/pdf";
-							break;
-						case "jpg":
-						case "jpeg":
-							contentType = "image/jpeg";
-							break;
-						case "png":
-							contentType = "image/png";
-							break;
-						case "gif":
-							contentType = "image/gif";
-							break;
-						case "txt":
-							contentType = "text/plain";
-							break;
-						case "html":
-							contentType = "text/html";
-							break;
-						case "json":
-							contentType = "application/json";
-							break;
-						case "zip":
-							contentType = "application/zip";
-							break;
-						case "doc":
-							contentType = "application/msword";
-							break;
-						case "docx":
-							contentType =
-								"application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-							break;
-						case "xls":
-							contentType = "application/vnd.ms-excel";
-							break;
-						case "xlsx":
-							contentType =
-								"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-							break;
-					}
-
-					return {
-						...att,
-						contentType: contentType,
-					};
-				}
-
-				return {
-					...att,
-					contentType: att.contentType || att.content_type,
-				};
-			},
+			(att: StoredAttachment, index: number) => ({
+				...att,
+				contentType: getContentTypeForAttachment(att, index),
+			}),
 		);
 
-		// Create sent email record first (for tracking)
 		const sentEmailId = nanoid();
 		const sentEmailData = {
 			id: sentEmailId,
@@ -354,7 +367,6 @@ async function handleScheduledEmail(payload: QStashPayload) {
 			.values(sentEmailData)
 			.returning();
 
-		// Build raw email message
 		console.log("📧 Building raw email message for scheduled email");
 		const rawMessage = buildRawEmailMessage({
 			from: scheduledEmail.fromAddress,
@@ -370,7 +382,6 @@ async function handleScheduledEmail(payload: QStashPayload) {
 			date: new Date(),
 		});
 
-		// Get the tenant sending info (identity ARN, configuration set, and tenant name) for tenant-level tracking
 		const fromDomain = scheduledEmail.fromDomain;
 
 		let tenantSendingInfo: TenantSendingInfo = {
@@ -425,9 +436,6 @@ async function handleScheduledEmail(payload: QStashPayload) {
 			);
 		}
 
-		// Send via AWS SES using SESv2 SendEmailCommand with TenantName
-		// Per AWS docs: https://docs.aws.amazon.com/ses/latest/dg/tenants.html
-		// Use full fromAddress (with display name) for proper sender name display
 		const rawCommand = new SendEmailCommand({
 			FromEmailAddress: scheduledEmail.fromAddress,
 			...(tenantSendingInfo.identityArn && {
@@ -463,9 +471,7 @@ async function handleScheduledEmail(payload: QStashPayload) {
 
 		console.log("✅ Scheduled email sent successfully via SES:", messageId);
 
-		// Update both records with success
 		await Promise.all([
-			// Update scheduled email
 			db
 				.update(scheduledEmails)
 				.set({
@@ -476,7 +482,6 @@ async function handleScheduledEmail(payload: QStashPayload) {
 				})
 				.where(eq(scheduledEmails.id, scheduledEmailId)),
 
-			// Update sent email
 			db
 				.update(sentEmails)
 				.set({
@@ -490,7 +495,6 @@ async function handleScheduledEmail(payload: QStashPayload) {
 				.where(eq(sentEmails.id, createdSentEmail.id)),
 		]);
 
-		// Evaluate email for security risks (non-blocking)
 		waitUntil(
 			evaluateSending(createdSentEmail.id, scheduledEmail.userId, {
 				from: scheduledEmail.fromAddress,
@@ -501,7 +505,6 @@ async function handleScheduledEmail(payload: QStashPayload) {
 			}),
 		);
 
-		// Check for sending spikes (non-blocking)
 		waitUntil(checkSendingSpike(scheduledEmail.userId));
 
 		console.log("✅ Scheduled email processed successfully:", scheduledEmailId);
@@ -523,7 +526,6 @@ async function handleScheduledEmail(payload: QStashPayload) {
 		const errorMessage =
 			error instanceof Error ? error.message : "Unknown error";
 
-		// Try to update the scheduled email with error info
 		try {
 			if (payload.scheduledEmailId) {
 				await db
@@ -538,7 +540,6 @@ async function handleScheduledEmail(payload: QStashPayload) {
 			console.error("❌ Failed to update error in database:", updateError);
 		}
 
-		// Return 500 so QStash will retry
 		return NextResponse.json(
 			{
 				error: "Failed to process scheduled email",
@@ -549,73 +550,233 @@ async function handleScheduledEmail(payload: QStashPayload) {
 	}
 }
 
-// Handler for batch emails
-async function handleBatchEmail(
-	_request: NextRequest,
-	payload: QStashPayload,
-	_body: string,
-) {
-	if (!payload.emailId || !payload.userId || !payload.emailData) {
-		console.error("❌ QStash Webhook - Missing required batch fields");
+async function handleBatchEmail(payload: QStashPayload) {
+	const { emailId, userId, batchId, batchIndex } = payload;
+
+	if (
+		!emailId ||
+		!userId ||
+		!batchId ||
+		batchIndex === undefined ||
+		batchIndex === null
+	) {
+		console.error("❌ QStash Webhook - Missing required batch fields", {
+			emailId,
+			userId,
+			batchId,
+			batchIndex,
+		});
 		return NextResponse.json(
-			{ error: "Missing required batch fields" },
+			{
+				error:
+					"Missing required batch fields: emailId, userId, batchId, batchIndex",
+			},
 			{ status: 400 },
 		);
 	}
 
-	const { emailId, userId, batchId, batchIndex } = payload;
 	console.log("📧 Processing batch email:", { emailId, batchId, batchIndex });
 
-	// Check if SES is configured
-	if (!sesClient) {
+	if (!batchSesClient) {
 		console.error("❌ AWS SES not configured");
 		return NextResponse.json(
-			{
-				error: "AWS SES not configured",
-			},
+			{ error: "AWS SES not configured" },
 			{ status: 500 },
 		);
 	}
 
-	// Fetch the pending sent email record
 	const [sentEmail] = await db
 		.select()
 		.from(sentEmails)
-		.where(eq(sentEmails.id, emailId))
+		.where(and(eq(sentEmails.id, emailId), eq(sentEmails.userId, userId)))
 		.limit(1);
 
 	if (!sentEmail) {
-		console.error("❌ Sent email not found:", emailId);
+		console.error("❌ Sent email not found or user mismatch:", emailId);
 		return NextResponse.json(
 			{ error: "Sent email not found" },
 			{ status: 400 },
 		);
 	}
 
-	const effectiveUserId = sentEmail.userId;
-	if (effectiveUserId !== userId) {
-		console.error("❌ QStash Webhook - Payload userId mismatch", {
+	if (sentEmail.batchId !== batchId || sentEmail.batchIndex !== batchIndex) {
+		console.error("❌ QStash Webhook - Batch metadata mismatch", {
 			emailId,
-			payloadUserId: userId,
-			recordUserId: effectiveUserId,
+			expectedBatchId: batchId,
+			actualBatchId: sentEmail.batchId,
+			expectedBatchIndex: batchIndex,
+			actualBatchIndex: sentEmail.batchIndex,
 		});
 		return NextResponse.json(
-			{ error: "Invalid batch payload user association" },
+			{ error: "Batch metadata mismatch" },
 			{ status: 400 },
 		);
 	}
 
-	// Check if already processed
-	if (sentEmail.status === SENT_EMAIL_STATUS.SENT) {
-		console.log("✅ Email already sent, skipping:", emailId);
+	const [batch] = await db
+		.select({
+			id: emailBatches.id,
+			status: emailBatches.status,
+		})
+		.from(emailBatches)
+		.where(and(eq(emailBatches.id, batchId), eq(emailBatches.userId, userId)))
+		.limit(1);
+
+	if (!batch) {
+		console.error("❌ Batch not found or user mismatch:", batchId);
+		return NextResponse.json({ error: "Batch not found" }, { status: 400 });
+	}
+
+	if (batch.status === EMAIL_BATCH_STATUS.CANCELLED) {
+		if (sentEmail.status === SENT_EMAIL_STATUS.PENDING) {
+			await db
+				.update(sentEmails)
+				.set({
+					status: SENT_EMAIL_STATUS.CANCELLED,
+					updatedAt: new Date(),
+				})
+				.where(
+					and(
+						eq(sentEmails.id, emailId),
+						eq(sentEmails.userId, userId),
+						eq(sentEmails.batchId, batchId),
+						eq(sentEmails.status, SENT_EMAIL_STATUS.PENDING),
+					),
+				);
+			waitUntil(refreshEmailBatchStatus(batchId, userId).catch(console.error));
+		}
+		console.log("⏭️ Parent batch cancelled, skipping:", emailId);
 		return NextResponse.json(
-			{ message: "Email already sent" },
+			{ message: "Parent batch cancelled" },
 			{ status: 200 },
 		);
 	}
 
-	if (sentEmail.status === SENT_EMAIL_STATUS.FAILED) {
-		console.log("⚠️ Email previously failed, retrying:", emailId);
+	const currentStatus = sentEmail.status;
+
+	if (
+		currentStatus === SENT_EMAIL_STATUS.SENT ||
+		currentStatus === SENT_EMAIL_STATUS.FAILED ||
+		currentStatus === SENT_EMAIL_STATUS.CANCELLED ||
+		currentStatus === SENT_EMAIL_STATUS.PROVIDER_UNKNOWN
+	) {
+		console.log(`⏭️ Email already ${currentStatus}, skipping:`, emailId);
+		return NextResponse.json(
+			{ message: `Email already ${currentStatus}` },
+			{ status: 200 },
+		);
+	}
+
+	const processingToken = nanoid();
+	const now = new Date();
+	let claimedEmail: { id: string } | undefined;
+
+	if (currentStatus === SENT_EMAIL_STATUS.PENDING) {
+		const [claimed] = await db
+			.update(sentEmails)
+			.set({
+				status: SENT_EMAIL_STATUS.PROCESSING,
+				processingToken: processingToken,
+				processingStartedAt: now,
+				providerSubmittedAt: null,
+				failureReason: null,
+				updatedAt: now,
+			})
+			.where(
+				and(
+					eq(sentEmails.id, emailId),
+					eq(sentEmails.userId, userId),
+					eq(sentEmails.batchId, batchId),
+					eq(sentEmails.status, SENT_EMAIL_STATUS.PENDING),
+				),
+			)
+			.returning({ id: sentEmails.id });
+		claimedEmail = claimed;
+	} else if (currentStatus === SENT_EMAIL_STATUS.PROCESSING) {
+		if (sentEmail.providerSubmittedAt) {
+			console.log("⏭️ Processing with provider submitted, skipping:", emailId);
+			return NextResponse.json(
+				{ message: "Provider outcome unresolved" },
+				{ status: 200 },
+			);
+		}
+
+		const staleThreshold = new Date(
+			now.getTime() - PROCESSING_LEASE_TIMEOUT_MS,
+		);
+		if (
+			sentEmail.processingStartedAt &&
+			sentEmail.processingStartedAt > staleThreshold
+		) {
+			console.log("⏭️ Processing lease still valid, skipping:", emailId);
+			return NextResponse.json(
+				{ message: "Processing lease still valid" },
+				{ status: 200 },
+			);
+		}
+
+		console.log("🔄 Reclaiming stale processing lease:", emailId);
+		const [claimed] = await db
+			.update(sentEmails)
+			.set({
+				processingToken: processingToken,
+				processingStartedAt: now,
+				providerSubmittedAt: null,
+				failureReason: null,
+				updatedAt: now,
+			})
+			.where(
+				and(
+					eq(sentEmails.id, emailId),
+					eq(sentEmails.userId, userId),
+					eq(sentEmails.batchId, batchId),
+					eq(sentEmails.status, SENT_EMAIL_STATUS.PROCESSING),
+					isNull(sentEmails.providerSubmittedAt),
+					lt(sentEmails.processingStartedAt, staleThreshold),
+				),
+			)
+			.returning({ id: sentEmails.id });
+		claimedEmail = claimed;
+	}
+
+	if (!claimedEmail) {
+		console.log("⏭️ Lost race to claim email, skipping:", emailId);
+		return NextResponse.json(
+			{ message: "Lost race to claim email" },
+			{ status: 200 },
+		);
+	}
+
+	const [parentAfterClaim] = await db
+		.select({ status: emailBatches.status })
+		.from(emailBatches)
+		.where(and(eq(emailBatches.id, batchId), eq(emailBatches.userId, userId)))
+		.limit(1);
+
+	if (parentAfterClaim?.status === EMAIL_BATCH_STATUS.CANCELLED) {
+		console.log("⏭️ Parent cancelled after claim, reverting:", emailId);
+		await db
+			.update(sentEmails)
+			.set({
+				status: SENT_EMAIL_STATUS.CANCELLED,
+				processingToken: null,
+				processingStartedAt: null,
+				updatedAt: new Date(),
+			})
+			.where(
+				and(
+					eq(sentEmails.id, emailId),
+					eq(sentEmails.userId, userId),
+					eq(sentEmails.batchId, batchId),
+					eq(sentEmails.status, SENT_EMAIL_STATUS.PROCESSING),
+					eq(sentEmails.processingToken, processingToken),
+				),
+			);
+		waitUntil(refreshEmailBatchStatus(batchId, userId).catch(console.error));
+		return NextResponse.json(
+			{ message: "Parent batch cancelled after claim" },
+			{ status: 200 },
+		);
 	}
 
 	const batchFromAddress = extractEmailAddress(sentEmail.from);
@@ -623,27 +784,64 @@ async function handleBatchEmail(
 		sentEmail.from,
 	);
 	const batchGuard = await enforceOutboundSendGuard({
-		userId: effectiveUserId,
+		userId,
 		fromAddress: batchFromAddress,
 		fromDomain: sentEmail.fromDomain,
 		isAgentEmail: batchIsAgentEmail,
 	});
+
 	if (!batchGuard.allowed) {
 		console.log(
-			`🚫 Blocking batch email for user ${effectiveUserId}: ${batchGuard.reasonCode}`,
+			`🚫 Blocking batch email for user ${userId}: ${batchGuard.reasonCode}`,
 		);
 
-		// Update sent email status to failed
+		if (batchGuard.statusCode >= 500) {
+			console.log("🔄 Guard retryable error, resetting to pending:", emailId);
+			await db
+				.update(sentEmails)
+				.set({
+					status: SENT_EMAIL_STATUS.PENDING,
+					processingToken: null,
+					processingStartedAt: null,
+					providerSubmittedAt: null,
+					qstashMessageId: null,
+					updatedAt: new Date(),
+				})
+				.where(
+					and(
+						eq(sentEmails.id, emailId),
+						eq(sentEmails.userId, userId),
+						eq(sentEmails.batchId, batchId),
+						eq(sentEmails.status, SENT_EMAIL_STATUS.PROCESSING),
+						eq(sentEmails.processingToken, processingToken),
+					),
+				);
+			return NextResponse.json(
+				{ error: "Guard check temporarily unavailable" },
+				{ status: 500 },
+			);
+		}
+
 		await db
 			.update(sentEmails)
 			.set({
 				status: SENT_EMAIL_STATUS.FAILED,
 				failureReason: `Email blocked: ${batchGuard.error || "Outbound security guard"}`,
+				processingToken: null,
 				updatedAt: new Date(),
 			})
-			.where(eq(sentEmails.id, emailId));
+			.where(
+				and(
+					eq(sentEmails.id, emailId),
+					eq(sentEmails.userId, userId),
+					eq(sentEmails.batchId, batchId),
+					eq(sentEmails.status, SENT_EMAIL_STATUS.PROCESSING),
+					eq(sentEmails.processingToken, processingToken),
+				),
+			);
 
-		// Return 200 so QStash doesn't retry - this is intentional blocking
+		waitUntil(refreshEmailBatchStatus(batchId, userId).catch(console.error));
+
 		return NextResponse.json(
 			{
 				error: batchGuard.error || "Email blocked",
@@ -653,91 +851,166 @@ async function handleBatchEmail(
 		);
 	}
 
-	try {
-		// Parse email data
-		const toAddresses = JSON.parse(sentEmail.to);
-		const ccAddresses = sentEmail.cc ? JSON.parse(sentEmail.cc) : [];
-		const bccAddresses = sentEmail.bcc ? JSON.parse(sentEmail.bcc) : [];
-		const replyToAddresses = sentEmail.replyTo
-			? JSON.parse(sentEmail.replyTo)
-			: [];
-		const headers = sentEmail.headers
-			? JSON.parse(sentEmail.headers)
-			: undefined;
-		const rawAttachments = sentEmail.attachments
-			? JSON.parse(sentEmail.attachments)
-			: [];
+	const toAddresses = parseJsonArraySafe<string>(sentEmail.to);
+	const ccAddresses = parseJsonArraySafe<string>(sentEmail.cc);
+	const bccAddresses = parseJsonArraySafe<string>(sentEmail.bcc);
+	const allRecipients = [...toAddresses, ...ccAddresses, ...bccAddresses];
 
-		// Validate and fix attachment data - ensure contentType is set
-		const attachments = rawAttachments.map(
-			(att: StoredAttachment, index: number) => {
-				if (!att.contentType && !att.content_type) {
-					console.log(
-						`⚠️ Attachment ${index + 1} missing contentType, using fallback`,
-					);
-					const filename = att.filename || "unknown";
-					const ext = filename.toLowerCase().split(".").pop();
-					let contentType = "application/octet-stream";
-
-					// Common file type mappings
-					switch (ext) {
-						case "pdf":
-							contentType = "application/pdf";
-							break;
-						case "jpg":
-						case "jpeg":
-							contentType = "image/jpeg";
-							break;
-						case "png":
-							contentType = "image/png";
-							break;
-						case "gif":
-							contentType = "image/gif";
-							break;
-						case "txt":
-							contentType = "text/plain";
-							break;
-						case "html":
-							contentType = "text/html";
-							break;
-						case "json":
-							contentType = "application/json";
-							break;
-						case "zip":
-							contentType = "application/zip";
-							break;
-						case "doc":
-							contentType = "application/msword";
-							break;
-						case "docx":
-							contentType =
-								"application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-							break;
-						case "xls":
-							contentType = "application/vnd.ms-excel";
-							break;
-						case "xlsx":
-							contentType =
-								"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-							break;
-					}
-
-					return {
-						...att,
-						contentType: contentType,
-					};
-				}
-
-				return {
-					...att,
-					contentType: att.contentType || att.content_type,
-				};
-			},
+	const blocklistCheck = await checkRecipientsAgainstBlocklist(allRecipients);
+	if (blocklistCheck.hasBlockedRecipients) {
+		console.log(
+			`🚫 Blocked recipients found for batch email ${emailId}: ${blocklistCheck.blockedAddresses.join(", ")}`,
 		);
 
-		// Build raw email message
+		await db
+			.update(sentEmails)
+			.set({
+				status: SENT_EMAIL_STATUS.FAILED,
+				failureReason: `Cannot send to blocked recipient(s): ${blocklistCheck.blockedAddresses.join(", ")}`,
+				processingToken: null,
+				updatedAt: new Date(),
+			})
+			.where(
+				and(
+					eq(sentEmails.id, emailId),
+					eq(sentEmails.userId, userId),
+					eq(sentEmails.batchId, batchId),
+					eq(sentEmails.status, SENT_EMAIL_STATUS.PROCESSING),
+					eq(sentEmails.processingToken, processingToken),
+				),
+			);
+
+		waitUntil(refreshEmailBatchStatus(batchId, userId).catch(console.error));
+
+		return NextResponse.json(
+			{
+				error: `Blocked recipients: ${blocklistCheck.blockedAddresses.join(", ")}`,
+			},
+			{ status: 200 },
+		);
+	}
+
+	const { Autumn: autumn } = await import("autumn-js");
+
+	try {
+		const { data: emailCheck, error: emailCheckError } = await autumn.check({
+			customer_id: userId,
+			feature_id: "emails_sent",
+			required_balance: 1,
+		});
+
+		if (emailCheckError) {
+			console.error(
+				"❌ Autumn email check error (retryable):",
+				emailCheckError,
+			);
+			await db
+				.update(sentEmails)
+				.set({
+					status: SENT_EMAIL_STATUS.PENDING,
+					processingToken: null,
+					processingStartedAt: null,
+					providerSubmittedAt: null,
+					qstashMessageId: null,
+					updatedAt: new Date(),
+				})
+				.where(
+					and(
+						eq(sentEmails.id, emailId),
+						eq(sentEmails.userId, userId),
+						eq(sentEmails.batchId, batchId),
+						eq(sentEmails.status, SENT_EMAIL_STATUS.PROCESSING),
+						eq(sentEmails.processingToken, processingToken),
+					),
+				);
+
+			return NextResponse.json(
+				{ error: "Billing check temporarily unavailable" },
+				{ status: 500 },
+			);
+		}
+
+		if (!emailCheck.allowed) {
+			console.log("❌ Email sending quota exceeded for user:", userId);
+			await db
+				.update(sentEmails)
+				.set({
+					status: SENT_EMAIL_STATUS.FAILED,
+					failureReason: "Email sending quota exceeded",
+					processingToken: null,
+					updatedAt: new Date(),
+				})
+				.where(
+					and(
+						eq(sentEmails.id, emailId),
+						eq(sentEmails.userId, userId),
+						eq(sentEmails.batchId, batchId),
+						eq(sentEmails.status, SENT_EMAIL_STATUS.PROCESSING),
+						eq(sentEmails.processingToken, processingToken),
+					),
+				);
+
+			waitUntil(refreshEmailBatchStatus(batchId, userId).catch(console.error));
+
+			return NextResponse.json(
+				{ error: "Email sending quota exceeded" },
+				{ status: 200 },
+			);
+		}
+	} catch (autumnError) {
+		console.error("❌ Autumn check failed (retryable):", autumnError);
+		await db
+			.update(sentEmails)
+			.set({
+				status: SENT_EMAIL_STATUS.PENDING,
+				processingToken: null,
+				processingStartedAt: null,
+				providerSubmittedAt: null,
+				qstashMessageId: null,
+				updatedAt: new Date(),
+			})
+			.where(
+				and(
+					eq(sentEmails.id, emailId),
+					eq(sentEmails.userId, userId),
+					eq(sentEmails.batchId, batchId),
+					eq(sentEmails.status, SENT_EMAIL_STATUS.PROCESSING),
+					eq(sentEmails.processingToken, processingToken),
+				),
+			);
+
+		return NextResponse.json(
+			{ error: "Billing check temporarily unavailable" },
+			{ status: 500 },
+		);
+	}
+
+	let rawMessage: string;
+	let batchTenantInfo: TenantSendingInfo;
+	const deterministicMessageId = generateDeterministicMessageId(
+		emailId,
+		sentEmail.fromDomain,
+	);
+
+	try {
+		const replyToAddresses = parseJsonArraySafe<string>(sentEmail.replyTo);
+		const headers = parseJsonObjectSafe<Record<string, string>>(
+			sentEmail.headers,
+		);
+		const rawAttachments = parseJsonArraySafe<StoredAttachment>(
+			sentEmail.attachments,
+		);
+
+		const attachments = rawAttachments.map((att, index) => ({
+			...att,
+			contentType: getContentTypeForAttachment(att, index),
+			filename: att.filename || "attachment",
+			content: att.content || "",
+			size: att.size || 0,
+		}));
+
 		console.log("📧 Building raw email message for batch email");
-		const rawMessage = buildRawEmailMessage({
+		rawMessage = buildRawEmailMessage({
 			from: sentEmail.from,
 			to: toAddresses,
 			cc: ccAddresses.length > 0 ? ccAddresses : undefined,
@@ -748,13 +1021,13 @@ async function handleBatchEmail(
 			htmlBody: sentEmail.htmlBody || undefined,
 			customHeaders: headers,
 			attachments: attachments,
+			messageId: deterministicMessageId,
 			date: new Date(),
 		});
 
-		// Get the tenant sending info (identity ARN, configuration set, and tenant name) for tenant-level tracking
 		const batchFromDomain = sentEmail.fromDomain;
 
-		let batchTenantInfo: TenantSendingInfo = {
+		batchTenantInfo = {
 			identityArn: null,
 			configurationSetName: null,
 			tenantName: null,
@@ -770,7 +1043,7 @@ async function handleBatchEmail(
 				? getRootDomain(batchFromDomain)
 				: undefined;
 			batchTenantInfo = await getTenantSendingInfoForDomainOrParent(
-				effectiveUserId,
+				userId,
 				batchFromDomain,
 				batchParentDomain || undefined,
 			);
@@ -805,10 +1078,61 @@ async function handleBatchEmail(
 				"⚠️ No TenantName available - batch email will NOT appear in tenant dashboard!",
 			);
 		}
+	} catch (prepError) {
+		console.error("❌ Pre-SES preparation error (retryable):", prepError);
+		await db
+			.update(sentEmails)
+			.set({
+				status: SENT_EMAIL_STATUS.PENDING,
+				processingToken: null,
+				processingStartedAt: null,
+				providerSubmittedAt: null,
+				qstashMessageId: null,
+				updatedAt: new Date(),
+			})
+			.where(
+				and(
+					eq(sentEmails.id, emailId),
+					eq(sentEmails.userId, userId),
+					eq(sentEmails.batchId, batchId),
+					eq(sentEmails.status, SENT_EMAIL_STATUS.PROCESSING),
+					eq(sentEmails.processingToken, processingToken),
+				),
+			);
 
-		// Send via AWS SES using SESv2 SendEmailCommand with TenantName
-		// Per AWS docs: https://docs.aws.amazon.com/ses/latest/dg/tenants.html
-		// Use sentEmail.from (with display name) for proper sender name display
+		return NextResponse.json(
+			{ error: "Email preparation temporarily unavailable" },
+			{ status: 500 },
+		);
+	}
+
+	const [tokenValid] = await db
+		.update(sentEmails)
+		.set({
+			providerSubmittedAt: new Date(),
+			messageId: deterministicMessageId,
+			updatedAt: new Date(),
+		})
+		.where(
+			and(
+				eq(sentEmails.id, emailId),
+				eq(sentEmails.userId, userId),
+				eq(sentEmails.batchId, batchId),
+				eq(sentEmails.status, SENT_EMAIL_STATUS.PROCESSING),
+				eq(sentEmails.processingToken, processingToken),
+			),
+		)
+		.returning({ id: sentEmails.id });
+
+	if (!tokenValid) {
+		console.log("⏭️ Token lost before SES submission, aborting:", emailId);
+		return NextResponse.json(
+			{ message: "Token lost before submission" },
+			{ status: 200 },
+		);
+	}
+
+	try {
 		const rawCommand = new SendEmailCommand({
 			FromEmailAddress: sentEmail.from,
 			...(batchTenantInfo.identityArn && {
@@ -839,53 +1163,86 @@ async function handleBatchEmail(
 			EmailTags: buildSentEmailTags(emailId),
 		});
 
-		const sesResponse = await sesClient.send(rawCommand);
-		const messageId = sesResponse.MessageId;
+		const sesResponse = await batchSesClient.send(rawCommand);
+		const sesMessageId = sesResponse.MessageId;
 
-		console.log("✅ Batch email sent successfully via SES:", messageId);
+		console.log("✅ Batch email sent successfully via SES:", sesMessageId);
 
-		// Update sent email record with success
-		await db
+		const [updatedEmail] = await db
 			.update(sentEmails)
 			.set({
 				status: SENT_EMAIL_STATUS.SENT,
-				messageId: messageId,
-				sesMessageId: messageId,
+				sesMessageId: sesMessageId,
 				providerResponse: JSON.stringify(sesResponse),
 				sentAt: new Date(),
+				processingToken: null,
 				updatedAt: new Date(),
 			})
-			.where(eq(sentEmails.id, emailId));
+			.where(
+				and(
+					eq(sentEmails.id, emailId),
+					eq(sentEmails.userId, userId),
+					eq(sentEmails.batchId, batchId),
+					eq(sentEmails.status, SENT_EMAIL_STATUS.PROCESSING),
+					eq(sentEmails.processingToken, processingToken),
+				),
+			)
+			.returning({ id: sentEmails.id });
 
-		// Track email usage with Autumn (blocking - every email must count towards quota)
+		if (!updatedEmail) {
+			console.warn(
+				"⚠️ Token lost after SES success, another worker may have taken over:",
+				emailId,
+			);
+			return NextResponse.json(
+				{ message: "Token lost after SES success" },
+				{ status: 200 },
+			);
+		}
+
 		try {
-			const { Autumn: autumn } = await import("autumn-js");
-			const { data: emailCheck } = await autumn.check({
-				customer_id: effectiveUserId,
+			const { error: trackError } = await autumn.track({
+				customer_id: userId,
 				feature_id: "emails_sent",
+				value: 1,
+				idempotency_key: emailId,
 			});
 
-			if (emailCheck && !emailCheck.unlimited) {
-				console.log("📊 Tracking email usage with Autumn");
-				const { error: trackError } = await autumn.track({
-					customer_id: effectiveUserId,
-					feature_id: "emails_sent",
-					value: 1,
-				});
-
-				if (trackError) {
-					console.error("❌ Failed to track email usage:", trackError);
-					// Don't fail the request if tracking fails, but log it
-				}
+			if (trackError) {
+				console.error("❌ Failed to track email usage:", trackError);
+				await db
+					.update(sentEmails)
+					.set({
+						usageTrackingError: String(trackError),
+						updatedAt: new Date(),
+					})
+					.where(eq(sentEmails.id, emailId));
+			} else {
+				await db
+					.update(sentEmails)
+					.set({
+						usageTrackedAt: new Date(),
+						usageTrackingError: null,
+						updatedAt: new Date(),
+					})
+					.where(eq(sentEmails.id, emailId));
 			}
 		} catch (trackError) {
 			console.error("❌ Failed to track email usage:", trackError);
-			// Don't fail the request if tracking fails
+			await db
+				.update(sentEmails)
+				.set({
+					usageTrackingError:
+						trackError instanceof Error
+							? trackError.message
+							: String(trackError),
+					updatedAt: new Date(),
+				})
+				.where(eq(sentEmails.id, emailId));
 		}
 
-		// Evaluate email for security risks (non-blocking)
 		waitUntil(
-			evaluateSending(emailId, effectiveUserId, {
+			evaluateSending(emailId, userId, {
 				from: sentEmail.from,
 				to: toAddresses,
 				subject: sentEmail.subject,
@@ -894,8 +1251,9 @@ async function handleBatchEmail(
 			}),
 		);
 
-		// Check for sending spikes (non-blocking)
-		waitUntil(checkSendingSpike(effectiveUserId));
+		waitUntil(checkSendingSpike(userId));
+
+		waitUntil(refreshEmailBatchStatus(batchId, userId).catch(console.error));
 
 		console.log("✅ Batch email processed successfully:", emailId);
 
@@ -903,38 +1261,73 @@ async function handleBatchEmail(
 			{
 				success: true,
 				emailId: emailId,
-				messageId: messageId,
+				messageId: sesMessageId,
 			},
 			{ status: 200 },
 		);
-	} catch (error) {
-		console.error("❌ QStash Webhook - Error processing batch email:", error);
+	} catch (sesError) {
+		console.error("❌ SES submission error:", sesError);
 
-		const errorMessage =
-			error instanceof Error ? error.message : "Unknown error";
-
-		// Update sent email record with error
-		try {
+		if (isSesRetryableError(sesError)) {
+			console.log("🔄 Retryable SES error, resetting to pending:", emailId);
 			await db
 				.update(sentEmails)
 				.set({
-					status: SENT_EMAIL_STATUS.FAILED,
-					failureReason: errorMessage,
-					providerResponse: JSON.stringify(error),
+					status: SENT_EMAIL_STATUS.PENDING,
+					processingToken: null,
+					processingStartedAt: null,
+					providerSubmittedAt: null,
+					messageId: null,
+					qstashMessageId: null,
 					updatedAt: new Date(),
 				})
-				.where(eq(sentEmails.id, emailId));
-		} catch (updateError) {
-			console.error("❌ Failed to update error in database:", updateError);
+				.where(
+					and(
+						eq(sentEmails.id, emailId),
+						eq(sentEmails.userId, userId),
+						eq(sentEmails.batchId, batchId),
+						eq(sentEmails.status, SENT_EMAIL_STATUS.PROCESSING),
+						eq(sentEmails.processingToken, processingToken),
+					),
+				);
+
+			return NextResponse.json(
+				{ error: "SES temporarily unavailable, will retry" },
+				{ status: 500 },
+			);
 		}
 
-		// Return 500 so QStash will retry
+		const errorMessage =
+			sesError instanceof Error ? sesError.message : "Unknown error";
+
+		console.log("⚠️ Ambiguous SES error, marking PROVIDER_UNKNOWN:", emailId);
+		await db
+			.update(sentEmails)
+			.set({
+				status: SENT_EMAIL_STATUS.PROVIDER_UNKNOWN,
+				failureReason: `Provider outcome unknown: ${errorMessage}`,
+				processingToken: null,
+				providerResponse: JSON.stringify(sesError),
+				updatedAt: new Date(),
+			})
+			.where(
+				and(
+					eq(sentEmails.id, emailId),
+					eq(sentEmails.userId, userId),
+					eq(sentEmails.batchId, batchId),
+					eq(sentEmails.status, SENT_EMAIL_STATUS.PROCESSING),
+					eq(sentEmails.processingToken, processingToken),
+				),
+			);
+
+		waitUntil(refreshEmailBatchStatus(batchId, userId).catch(console.error));
+
 		return NextResponse.json(
 			{
-				error: "Failed to process batch email",
+				error: "Provider outcome unknown",
 				details: errorMessage,
 			},
-			{ status: 500 },
+			{ status: 200 },
 		);
 	}
 }

--- a/drizzle/0072_batch_email_api.sql
+++ b/drizzle/0072_batch_email_api.sql
@@ -1,0 +1,32 @@
+CREATE TABLE IF NOT EXISTS "email_batches" (
+	"id" varchar(255) PRIMARY KEY NOT NULL,
+	"user_id" varchar(255) NOT NULL,
+	"status" varchar(50) DEFAULT 'creating' NOT NULL,
+	"idempotency_key" varchar(256),
+	"request_hash" varchar(64) NOT NULL,
+	"total_count" integer NOT NULL,
+	"published_count" integer DEFAULT 0 NOT NULL,
+	"last_error" text,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	"completed_at" timestamp,
+	CONSTRAINT "email_batches_user_idempotency_unique" UNIQUE("user_id", "idempotency_key")
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "email_batches_user_created_idx" ON "email_batches" USING btree ("user_id","created_at");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "email_batches_user_status_idx" ON "email_batches" USING btree ("user_id","status");
+--> statement-breakpoint
+ALTER TABLE "sent_emails" ADD COLUMN IF NOT EXISTS "qstash_message_id" varchar(255);
+--> statement-breakpoint
+ALTER TABLE "sent_emails" ADD COLUMN IF NOT EXISTS "qstash_publish_attempt" integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE "sent_emails" ADD COLUMN IF NOT EXISTS "processing_token" varchar(255);
+--> statement-breakpoint
+ALTER TABLE "sent_emails" ADD COLUMN IF NOT EXISTS "processing_started_at" timestamp;
+--> statement-breakpoint
+ALTER TABLE "sent_emails" ADD COLUMN IF NOT EXISTS "provider_submitted_at" timestamp;
+--> statement-breakpoint
+ALTER TABLE "sent_emails" ADD COLUMN IF NOT EXISTS "usage_tracked_at" timestamp;
+--> statement-breakpoint
+ALTER TABLE "sent_emails" ADD COLUMN IF NOT EXISTS "usage_tracking_error" text;

--- a/drizzle/manual/0072_batch_email_indexes.sql
+++ b/drizzle/manual/0072_batch_email_indexes.sql
@@ -1,0 +1,39 @@
+DO $$
+DECLARE
+	dup_count INTEGER;
+BEGIN
+	SELECT COUNT(*) INTO dup_count
+	FROM (
+		SELECT batch_id, batch_index
+		FROM sent_emails
+		WHERE batch_id IS NOT NULL
+		GROUP BY batch_id, batch_index
+		HAVING COUNT(*) > 1
+	) duplicates;
+
+	IF dup_count > 0 THEN
+		RAISE EXCEPTION 'Cannot create unique index: % duplicate batch_id/batch_index pairs exist in sent_emails', dup_count;
+	END IF;
+END $$;
+
+DO $$
+DECLARE
+	idx_rec RECORD;
+BEGIN
+	FOR idx_rec IN
+		SELECT indexrelid::regclass AS idx_name
+		FROM pg_index
+		JOIN pg_class ON pg_class.oid = pg_index.indexrelid
+		WHERE pg_class.relname IN ('sent_emails_user_batch_idx', 'sent_emails_batch_idx_unique')
+		  AND NOT pg_index.indisvalid
+	LOOP
+		EXECUTE format('DROP INDEX IF EXISTS %s', idx_rec.idx_name);
+		RAISE NOTICE 'Dropped invalid index: %', idx_rec.idx_name;
+	END LOOP;
+END $$;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "sent_emails_user_batch_idx"
+	ON "sent_emails" USING btree ("user_id", "batch_id", "batch_index");
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "sent_emails_batch_idx_unique"
+	ON "sent_emails" ("batch_id", "batch_index");

--- a/drizzle/meta/0072_snapshot.json
+++ b/drizzle/meta/0072_snapshot.json
@@ -1,0 +1,6418 @@
+{
+  "id": "72b8e3f1-4a5c-4d2e-b6f0-8c9a7d3e1b0f",
+  "prevId": "409c204c-e259-4886-ab80-852d1de0a3ef",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 86400000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_config_id_idx": {
+          "name": "apikey_config_id_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_reference_id_idx": {
+          "name": "apikey_reference_id_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocked_emails": {
+      "name": "blocked_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blocked_emails_email_address_unique": {
+          "name": "blocked_emails_email_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocked_signup_domains": {
+      "name": "blocked_signup_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocked_signup_domains_active_idx": {
+          "name": "blocked_signup_domains_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blocked_signup_domains_domain_unique": {
+          "name": "blocked_signup_domains_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaign_links": {
+      "name": "campaign_links",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign": {
+          "name": "campaign",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_clicks": {
+          "name": "home_clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "checkout_clicks": {
+          "name": "checkout_clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_clicked_at": {
+          "name": "first_clicked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_clicked_at": {
+          "name": "last_clicked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaign_links_campaign_idx": {
+          "name": "campaign_links_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "campaign_links_customer_id_idx": {
+          "name": "campaign_links_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "device_code_device_code_idx": {
+          "name": "device_code_device_code_idx",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_code_user_code_idx": {
+          "name": "device_code_user_code_idx",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_code_user_id_idx": {
+          "name": "device_code_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_code_expires_at_idx": {
+          "name": "device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_dns_records": {
+      "name": "domain_dns_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_type": {
+          "name": "record_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_addresses": {
+      "name": "email_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_receipt_rule_configured": {
+          "name": "is_receipt_rule_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "receipt_rule_name": {
+          "name": "receipt_rule_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_addresses_address_unique": {
+          "name": "email_addresses_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_batches": {
+      "name": "email_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'creating'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_count": {
+          "name": "published_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_batches_user_created_idx": {
+          "name": "email_batches_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_batches_user_status_idx": {
+          "name": "email_batches_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_batches_user_idempotency_unique": {
+          "name": "email_batches_user_idempotency_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_delivery_events": {
+      "name": "email_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bounce_type": {
+          "name": "bounce_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounce_sub_type": {
+          "name": "bounce_sub_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_class": {
+          "name": "status_class",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_category": {
+          "name": "status_category",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_code": {
+          "name": "diagnostic_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_recipient": {
+          "name": "failed_recipient",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_recipient_domain": {
+          "name": "failed_recipient_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_message_id": {
+          "name": "original_message_id",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_sent_email_id": {
+          "name": "original_sent_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_from": {
+          "name": "original_from",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_to": {
+          "name": "original_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_subject": {
+          "name": "original_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_sent_at": {
+          "name": "original_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dsn_email_id": {
+          "name": "dsn_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dsn_received_at": {
+          "name": "dsn_received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporting_mta": {
+          "name": "reporting_mta",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_mta": {
+          "name": "remote_mta",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_name": {
+          "name": "domain_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_name": {
+          "name": "tenant_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_taken_at": {
+          "name": "action_taken_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_to_blocklist": {
+          "name": "added_to_blocklist",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "blocklist_id": {
+          "name": "blocklist_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_dsn_content": {
+          "name": "raw_dsn_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_delivery_events_event_type_idx": {
+          "name": "email_delivery_events_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_bounce_type_idx": {
+          "name": "email_delivery_events_bounce_type_idx",
+          "columns": [
+            {
+              "expression": "bounce_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_failed_recipient_idx": {
+          "name": "email_delivery_events_failed_recipient_idx",
+          "columns": [
+            {
+              "expression": "failed_recipient",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_failed_recipient_domain_idx": {
+          "name": "email_delivery_events_failed_recipient_domain_idx",
+          "columns": [
+            {
+              "expression": "failed_recipient_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_user_id_idx": {
+          "name": "email_delivery_events_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_domain_id_idx": {
+          "name": "email_delivery_events_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_tenant_id_idx": {
+          "name": "email_delivery_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_status_code_idx": {
+          "name": "email_delivery_events_status_code_idx",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_created_at_idx": {
+          "name": "email_delivery_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_original_message_id_idx": {
+          "name": "email_delivery_events_original_message_id_idx",
+          "columns": [
+            {
+              "expression": "original_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_domains": {
+      "name": "email_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_receive_emails": {
+          "name": "can_receive_emails",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "has_mx_records": {
+          "name": "has_mx_records",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "domain_provider": {
+          "name": "domain_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_confidence": {
+          "name": "provider_confidence",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dns_check": {
+          "name": "last_dns_check",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ses_check": {
+          "name": "last_ses_check",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mail_from_domain": {
+          "name": "mail_from_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mail_from_domain_status": {
+          "name": "mail_from_domain_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mail_from_domain_verified_at": {
+          "name": "mail_from_domain_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_catch_all_enabled": {
+          "name": "is_catch_all_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "catch_all_webhook_id": {
+          "name": "catch_all_webhook_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catch_all_endpoint_id": {
+          "name": "catch_all_endpoint_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catch_all_receipt_rule_name": {
+          "name": "catch_all_receipt_rule_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receive_dmarc_emails": {
+          "name": "receive_dmarc_emails",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_domains_domain_unique": {
+          "name": "email_domains_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_groups": {
+      "name": "email_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_sending_evaluations": {
+      "name": "email_sending_evaluations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluation_result": {
+          "name": "evaluation_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flags": {
+          "name": "flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_time": {
+          "name": "evaluation_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_sending_evaluations_email_id_idx": {
+          "name": "email_sending_evaluations_email_id_idx",
+          "columns": [
+            {
+              "expression": "email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_sending_evaluations_user_id_idx": {
+          "name": "email_sending_evaluations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_sending_evaluations_created_at_idx": {
+          "name": "email_sending_evaluations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_threads": {
+      "name": "email_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_subject": {
+          "name": "normalized_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_emails": {
+          "name": "participant_emails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_threads_root_message_id_idx": {
+          "name": "email_threads_root_message_id_idx",
+          "columns": [
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_threads_user_id_idx": {
+          "name": "email_threads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_threads_last_message_at_idx": {
+          "name": "email_threads_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.endpoint_deliveries": {
+      "name": "endpoint_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_type": {
+          "name": "delivery_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_data": {
+          "name": "response_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "endpoint_deliveries_email_status_idx": {
+          "name": "endpoint_deliveries_email_status_idx",
+          "columns": [
+            {
+              "expression": "email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "endpoint_deliveries_email_id_idx": {
+          "name": "endpoint_deliveries_email_id_idx",
+          "columns": [
+            {
+              "expression": "email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "endpoint_deliveries_email_endpoint_unique": {
+          "name": "endpoint_deliveries_email_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email_id",
+            "endpoint_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.endpoints": {
+      "name": "endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_format": {
+          "name": "webhook_format",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'inbound'"
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guard_rules": {
+      "name": "guard_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_count": {
+          "name": "trigger_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "guard_rules_user_id_idx": {
+          "name": "guard_rules_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guard_rules_priority_idx": {
+          "name": "guard_rules_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.imap_appended_messages": {
+      "name": "imap_appended_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_content": {
+          "name": "raw_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "imap_appended_messages_user_id_idx": {
+          "name": "imap_appended_messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "imap_appended_messages_user_id_user_id_fk": {
+          "name": "imap_appended_messages_user_id_user_id_fk",
+          "tableFrom": "imap_appended_messages",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.imap_credential_scopes": {
+      "name": "imap_credential_scopes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "imap_credential_scopes_credential_id_idx": {
+          "name": "imap_credential_scopes_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "imap_credential_scopes_domain_id_idx": {
+          "name": "imap_credential_scopes_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "imap_credential_scopes_credential_id_imap_credentials_id_fk": {
+          "name": "imap_credential_scopes_credential_id_imap_credentials_id_fk",
+          "tableFrom": "imap_credential_scopes",
+          "tableTo": "imap_credentials",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "imap_credential_scopes_domain_id_email_domains_id_fk": {
+          "name": "imap_credential_scopes_domain_id_email_domains_id_fk",
+          "tableFrom": "imap_credential_scopes",
+          "tableTo": "email_domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "imap_credential_scopes_credential_scope_key_unique": {
+          "name": "imap_credential_scopes_credential_scope_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id",
+            "scope_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.imap_credentials": {
+      "name": "imap_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_address": {
+          "name": "login_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mailbox'"
+        },
+        "access_mode": {
+          "name": "access_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sending_mode": {
+          "name": "sending_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scoped_domains'"
+        },
+        "sending_name": {
+          "name": "sending_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sending_address": {
+          "name": "sending_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "imap_credentials_user_id_idx": {
+          "name": "imap_credentials_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "imap_credentials_user_id_user_id_fk": {
+          "name": "imap_credentials_user_id_user_id_fk",
+          "tableFrom": "imap_credentials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "imap_credentials_api_key_id_apikey_id_fk": {
+          "name": "imap_credentials_api_key_id_apikey_id_fk",
+          "tableFrom": "imap_credentials",
+          "tableTo": "apikey",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "imap_credentials_api_key_id_unique": {
+          "name": "imap_credentials_api_key_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "api_key_id"
+          ]
+        },
+        "imap_credentials_user_login_address_unique": {
+          "name": "imap_credentials_user_login_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "login_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.imap_mailbox_messages": {
+      "name": "imap_mailbox_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structured_email_id": {
+          "name": "structured_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uid": {
+          "name": "uid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_source": {
+          "name": "raw_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'structured'"
+        },
+        "flags": {
+          "name": "flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "internal_date": {
+          "name": "internal_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modseq": {
+          "name": "modseq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "imap_mailbox_messages_mailbox_uid_idx": {
+          "name": "imap_mailbox_messages_mailbox_uid_idx",
+          "columns": [
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "imap_mailbox_messages_appended_reference_idx": {
+          "name": "imap_mailbox_messages_appended_reference_idx",
+          "columns": [
+            {
+              "expression": "raw_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "structured_email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "imap_mailbox_messages_mailbox_id_imap_mailboxes_id_fk": {
+          "name": "imap_mailbox_messages_mailbox_id_imap_mailboxes_id_fk",
+          "tableFrom": "imap_mailbox_messages",
+          "tableTo": "imap_mailboxes",
+          "columnsFrom": [
+            "mailbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "imap_mailbox_messages_mailbox_uid_unique": {
+          "name": "imap_mailbox_messages_mailbox_uid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mailbox_id",
+            "uid"
+          ]
+        },
+        "imap_mailbox_messages_mailbox_email_unique": {
+          "name": "imap_mailbox_messages_mailbox_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mailbox_id",
+            "structured_email_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.imap_mailboxes": {
+      "name": "imap_mailboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INBOX'"
+        },
+        "uid_validity": {
+          "name": "uid_validity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uid_next": {
+          "name": "uid_next",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "modseq": {
+          "name": "modseq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribed": {
+          "name": "subscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "imap_mailboxes_user_id_idx": {
+          "name": "imap_mailboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "imap_mailboxes_credential_id_idx": {
+          "name": "imap_mailboxes_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "imap_mailboxes_user_id_user_id_fk": {
+          "name": "imap_mailboxes_user_id_user_id_fk",
+          "tableFrom": "imap_mailboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "imap_mailboxes_credential_id_imap_credentials_id_fk": {
+          "name": "imap_mailboxes_credential_id_imap_credentials_id_fk",
+          "tableFrom": "imap_mailboxes",
+          "tableTo": "imap_credentials",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "imap_mailboxes_scope_id_imap_credential_scopes_id_fk": {
+          "name": "imap_mailboxes_scope_id_imap_credential_scopes_id_fk",
+          "tableFrom": "imap_mailboxes",
+          "tableTo": "imap_credential_scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "imap_mailboxes_user_address_path_unique": {
+          "name": "imap_mailboxes_user_address_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "address",
+            "path"
+          ]
+        },
+        "imap_mailboxes_credential_path_unique": {
+          "name": "imap_mailboxes_credential_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id",
+            "path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_oauth_grants": {
+      "name": "inbound_oauth_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_ids": {
+          "name": "domain_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "inbound_oauth_grants_user_id_idx": {
+          "name": "inbound_oauth_grants_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inbound_oauth_grants_session_client_idx": {
+          "name": "inbound_oauth_grants_session_client_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbound_oauth_grants_user_id_user_id_fk": {
+          "name": "inbound_oauth_grants_user_id_user_id_fk",
+          "tableFrom": "inbound_oauth_grants",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbound_oauth_grants_session_id_session_id_fk": {
+          "name": "inbound_oauth_grants_session_id_session_id_fk",
+          "tableFrom": "inbound_oauth_grants",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_oauth_grants_client_id_oauth_client_client_id_fk": {
+          "name": "inbound_oauth_grants_client_id_oauth_client_client_id_fk",
+          "tableFrom": "inbound_oauth_grants",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_access_token_token_idx": {
+          "name": "oauth_access_token_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_session_id_idx": {
+          "name": "oauth_access_token_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_refresh_id_idx": {
+          "name": "oauth_access_token_refresh_id_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_client_user_id_idx": {
+          "name": "oauth_client_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_token_idx": {
+          "name": "oauth_refresh_token_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_client_id_idx": {
+          "name": "oauth_refresh_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_session_id_idx": {
+          "name": "oauth_refresh_token_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_user_id_idx": {
+          "name": "oauth_refresh_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_demo_emails": {
+      "name": "onboarding_demo_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "reply_received": {
+          "name": "reply_received",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "reply_from": {
+          "name": "reply_from",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_subject": {
+          "name": "reply_subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_body": {
+          "name": "reply_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_received_at": {
+          "name": "reply_received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parsed_emails": {
+      "name": "parsed_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_text": {
+          "name": "from_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_text": {
+          "name": "to_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cc_text": {
+          "name": "cc_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc_text": {
+          "name": "bcc_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc_addresses": {
+          "name": "bcc_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_text": {
+          "name": "reply_to_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_addresses": {
+          "name": "reply_to_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "references": {
+          "name": "references",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_date": {
+          "name": "email_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachment_count": {
+          "name": "attachment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "has_attachments": {
+          "name": "has_attachments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_text_body": {
+          "name": "has_text_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "has_html_body": {
+          "name": "has_html_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "parse_success": {
+          "name": "parse_success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "parse_error": {
+          "name": "parse_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_user_id_idx": {
+          "name": "passkey_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credential_id_idx": {
+          "name": "passkey_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_overrides": {
+      "name": "rate_limit_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hourly_limit": {
+          "name": "hourly_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rate_limit_overrides_user_id_unique": {
+          "name": "rate_limit_overrides_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.received_emails": {
+      "name": "received_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ses_event_id": {
+          "name": "ses_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_parsed": {
+          "name": "from_parsed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_parsed": {
+          "name": "to_parsed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cc_parsed": {
+          "name": "cc_parsed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc_parsed": {
+          "name": "bcc_parsed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_parsed": {
+          "name": "reply_to_parsed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_email_content": {
+          "name": "raw_email_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "references": {
+          "name": "references",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_date": {
+          "name": "email_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduled_emails": {
+      "name": "scheduled_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_domain": {
+          "name": "from_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc_addresses": {
+          "name": "bcc_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_addresses": {
+          "name": "reply_to_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qstash_schedule_id": {
+          "name": "qstash_schedule_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qstash_dlq_id": {
+          "name": "qstash_dlq_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_email_id": {
+          "name": "sent_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sent_emails": {
+      "name": "sent_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_domain": {
+          "name": "from_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc": {
+          "name": "cc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ses_message_id": {
+          "name": "ses_message_id",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ses'"
+        },
+        "provider_response": {
+          "name": "provider_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_opened_at": {
+          "name": "first_opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_position": {
+          "name": "thread_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_index": {
+          "name": "batch_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qstash_message_id": {
+          "name": "qstash_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qstash_publish_attempt": {
+          "name": "qstash_publish_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processing_token": {
+          "name": "processing_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_submitted_at": {
+          "name": "provider_submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_tracked_at": {
+          "name": "usage_tracked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_tracking_error": {
+          "name": "usage_tracking_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sent_emails_thread_id_idx": {
+          "name": "sent_emails_thread_id_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sent_emails_user_created_idx": {
+          "name": "sent_emails_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sent_emails_user_status_created_idx": {
+          "name": "sent_emails_user_status_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sent_emails_user_first_opened_idx": {
+          "name": "sent_emails_user_first_opened_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_opened_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sent_emails_user_batch_idx": {
+          "name": "sent_emails_user_batch_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "batch_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sent_emails_batch_idx_unique": {
+          "name": "sent_emails_batch_idx_unique",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "batch_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ses_events": {
+      "name": "ses_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_source": {
+          "name": "event_source",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_version": {
+          "name": "event_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receipt_timestamp": {
+          "name": "receipt_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processing_time_millis": {
+          "name": "processing_time_millis",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipients": {
+          "name": "recipients",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spam_verdict": {
+          "name": "spam_verdict",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "virus_verdict": {
+          "name": "virus_verdict",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spf_verdict": {
+          "name": "spf_verdict",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_verdict": {
+          "name": "dkim_verdict",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dmarc_verdict": {
+          "name": "dmarc_verdict",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket_name": {
+          "name": "s3_bucket_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_object_key": {
+          "name": "s3_object_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_content": {
+          "name": "email_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_content_fetched": {
+          "name": "s3_content_fetched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "s3_content_size": {
+          "name": "s3_content_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_error": {
+          "name": "s3_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "common_headers": {
+          "name": "common_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_ses_event": {
+          "name": "raw_ses_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lambda_context": {
+          "name": "lambda_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_payload": {
+          "name": "webhook_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ses_receipt_rules": {
+      "name": "ses_receipt_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_set_name": {
+          "name": "rule_set_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_count": {
+          "name": "domain_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_capacity": {
+          "name": "max_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ses_receipt_rules_rule_name_unique": {
+          "name": "ses_receipt_rules_rule_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rule_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ses_tenants": {
+      "name": "ses_tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aws_tenant_id": {
+          "name": "aws_tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_name": {
+          "name": "tenant_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_set_name": {
+          "name": "configuration_set_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "reputation_policy": {
+          "name": "reputation_policy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'strict'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ses_tenants_user_id_unique": {
+          "name": "ses_tenants_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "ses_tenants_aws_tenant_id_unique": {
+          "name": "ses_tenants_aws_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "aws_tenant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structured_emails": {
+      "name": "structured_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ses_event_id": {
+          "name": "ses_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_data": {
+          "name": "from_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_data": {
+          "name": "to_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cc_data": {
+          "name": "cc_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc_data": {
+          "name": "bcc_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_data": {
+          "name": "reply_to_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "references": {
+          "name": "references",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_content": {
+          "name": "raw_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parse_success": {
+          "name": "parse_success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "parse_error": {
+          "name": "parse_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guard_blocked": {
+          "name": "guard_blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "guard_reason": {
+          "name": "guard_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guard_rule_id": {
+          "name": "guard_rule_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guard_action": {
+          "name": "guard_action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guard_metadata": {
+          "name": "guard_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_position": {
+          "name": "thread_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "structured_emails_message_id_idx": {
+          "name": "structured_emails_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structured_emails_thread_id_idx": {
+          "name": "structured_emails_thread_id_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structured_emails_user_created_idx": {
+          "name": "structured_emails_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structured_emails_user_id_idx": {
+          "name": "structured_emails_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structured_emails_guard_blocked_idx": {
+          "name": "structured_emails_guard_blocked_idx",
+          "columns": [
+            {
+              "expression": "guard_blocked",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "structured_emails_user_message_recipient_unique": {
+          "name": "structured_emails_user_message_recipient_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "message_id",
+            "recipient"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_start": {
+          "name": "trial_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhooks_to_endpoints_migrated": {
+          "name": "webhooks_to_endpoints_migrated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "feature_flags": {
+          "name": "feature_flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "svix_app_id": {
+          "name": "svix_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_accounts": {
+      "name": "user_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_restricted_key": {
+          "name": "stripe_restricted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_onboarding": {
+      "name": "user_onboarding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_endpoint_created": {
+          "name": "default_endpoint_created",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_onboarding_user_id_unique": {
+          "name": "user_onboarding_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_time": {
+          "name": "delivery_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "retry_attempts": {
+          "name": "retry_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_deliveries": {
+          "name": "total_deliveries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "successful_deliveries": {
+          "name": "successful_deliveries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "failed_deliveries": {
+          "name": "failed_deliveries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -505,6 +505,13 @@
       "when": 1786220537623,
       "tag": "0071_add_sent_email_open_tracking",
       "breakpoints": true
+    },
+    {
+      "idx": 72,
+      "version": "7",
+      "when": 1786740000000,
+      "tag": "0072_batch_email_api",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -6,6 +6,7 @@ import {
 	text,
 	timestamp,
 	unique,
+	uniqueIndex,
 	varchar,
 } from "drizzle-orm/pg-core";
 import {
@@ -587,8 +588,15 @@ export const sentEmails = pgTable(
 		threadPosition: integer("thread_position"), // Position in thread
 
 		// Batch sending fields
-		batchId: varchar("batch_id", { length: 255 }), // For grouping batch sends
-		batchIndex: integer("batch_index"), // Order within batch
+		batchId: varchar("batch_id", { length: 255 }),
+		batchIndex: integer("batch_index"),
+		qstashMessageId: varchar("qstash_message_id", { length: 255 }),
+		qstashPublishAttempt: integer("qstash_publish_attempt").notNull().default(0),
+		processingToken: varchar("processing_token", { length: 255 }),
+		processingStartedAt: timestamp("processing_started_at"),
+		providerSubmittedAt: timestamp("provider_submitted_at"),
+		usageTrackedAt: timestamp("usage_tracked_at"),
+		usageTrackingError: text("usage_tracking_error"),
 
 		// User and timestamps
 		userId: varchar("user_id", { length: 255 }).notNull(),
@@ -609,6 +617,46 @@ export const sentEmails = pgTable(
 		userFirstOpenedIdx: index("sent_emails_user_first_opened_idx").on(
 			table.userId,
 			table.firstOpenedAt,
+		),
+		userBatchIdx: index("sent_emails_user_batch_idx").on(
+			table.userId,
+			table.batchId,
+			table.batchIndex,
+		),
+		batchIdxUnique: uniqueIndex("sent_emails_batch_idx_unique").on(
+			table.batchId,
+			table.batchIndex,
+		),
+	}),
+);
+
+export const emailBatches = pgTable(
+	"email_batches",
+	{
+		id: varchar("id", { length: 255 }).primaryKey(),
+		userId: varchar("user_id", { length: 255 }).notNull(),
+		status: varchar("status", { length: 50 }).notNull().default("creating"),
+		idempotencyKey: varchar("idempotency_key", { length: 256 }),
+		requestHash: varchar("request_hash", { length: 64 }).notNull(),
+		totalCount: integer("total_count").notNull(),
+		publishedCount: integer("published_count").notNull().default(0),
+		lastError: text("last_error"),
+		createdAt: timestamp("created_at").defaultNow(),
+		updatedAt: timestamp("updated_at").defaultNow(),
+		completedAt: timestamp("completed_at"),
+	},
+	(table) => ({
+		userCreatedIdx: index("email_batches_user_created_idx").on(
+			table.userId,
+			table.createdAt,
+		),
+		userStatusIdx: index("email_batches_user_status_idx").on(
+			table.userId,
+			table.status,
+		),
+		userIdempotencyUnique: unique("email_batches_user_idempotency_unique").on(
+			table.userId,
+			table.idempotencyKey,
 		),
 	}),
 );
@@ -861,8 +909,23 @@ export const DELIVERY_STATUS = {
 
 export const SENT_EMAIL_STATUS = {
 	PENDING: "pending",
+	PROCESSING: "processing",
 	SENT: "sent",
 	FAILED: "failed",
+	CANCELLED: "cancelled",
+	PROVIDER_UNKNOWN: "provider_unknown",
+} as const;
+
+export const EMAIL_BATCH_STATUS = {
+	CREATING: "creating",
+	QUEUED: "queued",
+	PARTIALLY_QUEUED: "partially_queued",
+	PROCESSING: "processing",
+	COMPLETED: "completed",
+	PARTIALLY_FAILED: "partially_failed",
+	FAILED: "failed",
+	CANCELLED: "cancelled",
+	REQUIRES_ATTENTION: "requires_attention",
 } as const;
 
 // Email Delivery Events table - tracks bounces, complaints, and delivery failures from DSNs
@@ -1070,6 +1133,10 @@ export type DeliveryStatus =
 	(typeof DELIVERY_STATUS)[keyof typeof DELIVERY_STATUS];
 export type SentEmailStatus =
 	(typeof SENT_EMAIL_STATUS)[keyof typeof SENT_EMAIL_STATUS];
+export type EmailBatchStatus =
+	(typeof EMAIL_BATCH_STATUS)[keyof typeof EMAIL_BATCH_STATUS];
+export type EmailBatch = typeof emailBatches.$inferSelect;
+export type NewEmailBatch = typeof emailBatches.$inferInsert;
 
 // Guard Rules types
 export type GuardRule = typeof guardRules.$inferSelect;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -591,7 +591,9 @@ export const sentEmails = pgTable(
 		batchId: varchar("batch_id", { length: 255 }),
 		batchIndex: integer("batch_index"),
 		qstashMessageId: varchar("qstash_message_id", { length: 255 }),
-		qstashPublishAttempt: integer("qstash_publish_attempt").notNull().default(0),
+		qstashPublishAttempt: integer("qstash_publish_attempt")
+			.notNull()
+			.default(0),
 		processingToken: varchar("processing_token", { length: 255 }),
 		processingStartedAt: timestamp("processing_started_at"),
 		providerSubmittedAt: timestamp("provider_submitted_at"),

--- a/stainless.yml
+++ b/stainless.yml
@@ -89,6 +89,10 @@ resources:
       delete: delete /api/e2/emails/{id}
       reply: post /api/e2/emails/{id}/reply
       retry: post /api/e2/emails/{id}/retry
+      send_batch: post /api/e2/emails/batch
+      retrieve_batch: get /api/e2/emails/batch/{batchId}
+      cancel_batch: delete /api/e2/emails/batch/{batchId}
+      retry_batch: post /api/e2/emails/batch/{batchId}/retry
   mail:
     methods:
       list: get /api/e2/mail/threads


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add public batch email create, status, cancel, and retry endpoints
- persist batch lifecycle and items with atomic Neon HTTP batch creation
- publish flow-controlled, deduplicated QStash jobs with recoverable attempts
- add leased worker claims, cancellation checks, provider-unknown handling, and SES event reconciliation
- preserve outbound guard, blocklist, attachment, tenant, billing, tagging, and monitoring enforcement

## API
- `POST /api/e2/emails/batch`
- `GET /api/e2/emails/batch/:batchId`
- `DELETE /api/e2/emails/batch/:batchId`
- `POST /api/e2/emails/batch/:batchId/retry`
- maximum 100 messages per batch
- batch-level `Idempotency-Key`

## Database
- journaled migration `0072_batch_email_api.sql` creates batch state and adds worker metadata
- manual non-transactional migration `drizzle/manual/0072_batch_email_indexes.sql` creates concurrent indexes on the large `sent_emails` table
- neither migration has been applied

## Safety
- parent and child records commit atomically
- worker uses tokenized leases and a provider-submission boundary
- ambiguous SES outcomes are not automatically retried
- SES send/delivery events reconcile provider-unknown items
- cancellation is checked before and after worker claims

## Verification
- focused batch, SES tag, open-event, and accepted-event tests: 55 passed
- changed-file Biome check: passed
- OpenAPI generation: passed; 29 paths
- OpenAPI production comparison: expected undeployed batch paths plus pre-existing schema differences
- in-memory Elysia smoke: 4 operations present, idempotency header present, unauthenticated POST returns 401
- repository-wide lint remains blocked by 297 pre-existing errors outside this diff
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80c9917a-b110-4483-a533-7d60caeb7aef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80c9917a-b110-4483-a533-7d60caeb7aef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

