### PR TITLE
Prevent concurrent E2 idempotency-key sends

### DIFF
--- a/app/api/e2/e2e.test.ts
+++ b/app/api/e2/e2e.test.ts
@@ -1618,6 +1618,71 @@ describe("E2 API - Email E2E", () => {
 	);
 
 	it(
+		"prevents duplicate outbound records for concurrent idempotency-key sends",
+		async () => {
+			const token = makeToken("idem-race");
+			const subject = `[[[DEV||| E2E Idempotency Race ${token}`;
+			const idempotencyKey = `e2e-idempotency-race-${token}`;
+			const payload = {
+				from: E2E_SENDER_ADDRESS,
+				to: E2E_RECIPIENT_ADDRESS,
+				subject,
+				text: `Idempotency race text marker ${token}`,
+				html: `<p>Idempotency race html marker <strong>${token}</strong></p>`,
+			};
+			const requestOptions: RequestInit = {
+				method: "POST",
+				headers: {
+					"Idempotency-Key": idempotencyKey,
+				},
+				body: JSON.stringify(payload),
+			};
+
+			const [firstSend, secondSend] = await Promise.all([
+				apiJsonWithKey<SendEmailResponse | { error: string }>(
+					"/emails",
+					API_KEY as string,
+					requestOptions,
+				),
+				apiJsonWithKey<SendEmailResponse | { error: string }>(
+					"/emails",
+					API_KEY as string,
+					requestOptions,
+				),
+			]);
+
+			const sends = [firstSend, secondSend];
+			expect(
+				sends.every(
+					(send) => send.response.status === 200 || send.response.status === 503,
+				),
+			).toBe(true);
+
+			const successfulIds = sends.flatMap((send) =>
+				send.response.status === 200 && "id" in send.data
+					? [send.data.id]
+					: [],
+			);
+			expect(successfulIds.length).toBeGreaterThanOrEqual(1);
+			expect(new Set(successfulIds).size).toBe(1);
+
+			const sentMatches = await waitForExactSubjectEmailCount(
+				"sent",
+				subject,
+				1,
+			);
+			expect(sentMatches).toBeDefined();
+			if (!sentMatches) {
+				return;
+			}
+
+			expect(sentMatches.length).toBe(1);
+			expect(sentMatches[0]?.id).toBe(successfulIds[0]);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
 		"deduplicates repeated inbound webhook payloads for the same message",
 		async () => {
 			const token = makeToken("dedupe");

--- a/app/api/e2/emails/send.ts
+++ b/app/api/e2/emails/send.ts
@@ -3,6 +3,7 @@ import { Client as QStashClient } from "@upstash/qstash";
 import { waitUntil } from "@vercel/functions";
 import { Autumn as autumn } from "autumn-js";
 import { and, eq } from "drizzle-orm";
+import type { InferSelectModel } from "drizzle-orm";
 import { Elysia, t } from "elysia";
 import { nanoid } from "nanoid";
 import { buildSentEmailTags } from "@/app/api/e2/helper/ses-email-tags";
@@ -185,10 +186,12 @@ export const sendEmail = new Elysia().post(
 
 		// Check for idempotency key
 		const idempotencyKey = request.headers.get("Idempotency-Key");
-		if (idempotencyKey) {
-			console.log("🔑 Idempotency key provided:", idempotencyKey);
+		const findExistingIdempotencyEmail = async () => {
+			if (!idempotencyKey) {
+				return undefined;
+			}
 
-			const existingEmail = await db
+			const [existingEmail] = await db
 				.select()
 				.from(sentEmails)
 				.where(
@@ -199,21 +202,33 @@ export const sendEmail = new Elysia().post(
 				)
 				.limit(1);
 
-			if (existingEmail.length > 0) {
-				if (existingEmail[0].status !== SENT_EMAIL_STATUS.SENT) {
-					set.status = 503;
-					set.headers["Retry-After"] = "60";
-					return {
-						error:
-							"An email with this idempotency key has not been successfully sent. Please try again later.",
-					};
-				}
+			return existingEmail;
+		};
+		const returnExistingIdempotencyResponse = (
+			existingEmail: InferSelectModel<typeof sentEmails>,
+		) => {
+			if (existingEmail.status !== SENT_EMAIL_STATUS.SENT) {
+				set.status = 503;
+				set.headers["Retry-After"] = "60";
+				return {
+					error:
+						"An email with this idempotency key has not been successfully sent. Please try again later.",
+				};
+			}
 
-				console.log(
-					"♻️ Idempotent request - returning existing email:",
-					existingEmail[0].id,
-				);
-				return { id: existingEmail[0].id };
+			console.log(
+				"♻️ Idempotent request - returning existing email:",
+				existingEmail.id,
+			);
+			return { id: existingEmail.id };
+		};
+
+		if (idempotencyKey) {
+			console.log("🔑 Idempotency key provided:", idempotencyKey);
+
+			const existingEmail = await findExistingIdempotencyEmail();
+			if (existingEmail) {
+				return returnExistingIdempotencyResponse(existingEmail);
 			}
 		}
 
@@ -490,31 +505,46 @@ export const sendEmail = new Elysia().post(
 		const emailId = nanoid();
 		console.log("💾 Creating sent email record:", emailId);
 
-		await db.insert(sentEmails).values({
-			id: emailId,
-			from: body.from,
-			fromAddress,
-			fromDomain,
-			to: JSON.stringify(toAddresses),
-			cc: ccAddresses.length > 0 ? JSON.stringify(ccAddresses) : null,
-			bcc: bccAddresses.length > 0 ? JSON.stringify(bccAddresses) : null,
-			replyTo:
-				replyToAddresses.length > 0 ? JSON.stringify(replyToAddresses) : null,
-			subject: body.subject,
-			textBody: body.text,
-			htmlBody: body.html,
-			headers: body.headers ? JSON.stringify(body.headers) : null,
-			attachments:
-				processedAttachments.length > 0
-					? JSON.stringify(attachmentsToStorageFormat(processedAttachments))
-					: null,
-			tags: body.tags ? JSON.stringify(body.tags) : null,
-			status: SENT_EMAIL_STATUS.PENDING,
-			userId,
-			idempotencyKey,
-			createdAt: new Date(),
-			updatedAt: new Date(),
-		});
+		const [createdEmail] = await db
+			.insert(sentEmails)
+			.values({
+				id: emailId,
+				from: body.from,
+				fromAddress,
+				fromDomain,
+				to: JSON.stringify(toAddresses),
+				cc: ccAddresses.length > 0 ? JSON.stringify(ccAddresses) : null,
+				bcc: bccAddresses.length > 0 ? JSON.stringify(bccAddresses) : null,
+				replyTo:
+					replyToAddresses.length > 0 ? JSON.stringify(replyToAddresses) : null,
+				subject: body.subject,
+				textBody: body.text,
+				htmlBody: body.html,
+				headers: body.headers ? JSON.stringify(body.headers) : null,
+				attachments:
+					processedAttachments.length > 0
+						? JSON.stringify(attachmentsToStorageFormat(processedAttachments))
+						: null,
+				tags: body.tags ? JSON.stringify(body.tags) : null,
+				status: SENT_EMAIL_STATUS.PENDING,
+				userId,
+				idempotencyKey: idempotencyKey || null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			})
+			.onConflictDoNothing({
+				target: [sentEmails.userId, sentEmails.idempotencyKey],
+			})
+			.returning({ id: sentEmails.id });
+
+		if (!createdEmail) {
+			const existingEmail = await findExistingIdempotencyEmail();
+			if (!existingEmail) {
+				throw new Error("Sent email insert returned no row");
+			}
+
+			return returnExistingIdempotencyResponse(existingEmail);
+		}
 
 		// Check if SES is configured
 		if (!sesClient) {

--- a/app/api/e2/emails/send.ts
+++ b/app/api/e2/emails/send.ts
@@ -67,6 +67,7 @@ const AttachmentSchema = t.Object({
 	filename: t.String(),
 	content: t.String(),
 	content_type: t.Optional(t.String()),
+	content_id: t.Optional(t.String({ maxLength: 128 })),
 	path: t.Optional(t.String()),
 });
 
@@ -199,6 +200,15 @@ export const sendEmail = new Elysia().post(
 				.limit(1);
 
 			if (existingEmail.length > 0) {
+				if (existingEmail[0].status !== SENT_EMAIL_STATUS.SENT) {
+					set.status = 503;
+					set.headers["Retry-After"] = "60";
+					return {
+						error:
+							"An email with this idempotency key has not been successfully sent. Please try again later.",
+					};
+				}
+
 				console.log(
 					"♻️ Idempotent request - returning existing email:",
 					existingEmail[0].id,
@@ -297,6 +307,11 @@ export const sendEmail = new Elysia().post(
 		// Validate email addresses
 		const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 		const allRecipients = [...toAddresses, ...ccAddresses, ...bccAddresses];
+
+		if (allRecipients.length === 0) {
+			set.status = 400;
+			return { error: "At least one recipient is required in to, cc, or bcc" };
+		}
 
 		for (const email of allRecipients) {
 			const address = extractEmailAddress(email);
@@ -682,6 +697,7 @@ export const sendEmail = new Elysia().post(
 			403: ErrorResponse,
 			429: ErrorResponse,
 			500: ErrorResponse,
+			503: ErrorResponse,
 		},
 		detail: {
 			tags: ["Emails"],

--- a/app/api/e2/helper/email-builder.test.ts
+++ b/app/api/e2/helper/email-builder.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import { buildRawEmailMessage } from "@/app/api/e2/helper/email-builder";
+
+describe("buildRawEmailMessage recipient headers", () => {
+	it("preserves visible To and Cc recipients without exposing Bcc", () => {
+		const message = buildRawEmailMessage({
+			from: "sender@example.com",
+			to: ["visible@example.com"],
+			cc: ["copied@example.com"],
+			bcc: ["blind@example.com"],
+			subject: "Subject",
+			textBody: "Body",
+		});
+
+		expect(message).toContain("To: visible@example.com\r\n");
+		expect(message).toContain("Cc: copied@example.com\r\n");
+		expect(message).not.toContain("blind@example.com");
+		expect(message).not.toMatch(/^Bcc:/m);
+	});
+
+	it("uses undisclosed recipients for Bcc-only mail", () => {
+		const message = buildRawEmailMessage({
+			from: "sender@example.com",
+			to: [],
+			bcc: ["blind@example.com"],
+			subject: "Subject",
+			textBody: "Body",
+		});
+
+		expect(message).toContain("To: undisclosed-recipients:;\r\n");
+		expect(message).not.toContain("blind@example.com");
+		expect(message).not.toMatch(/^Bcc:/m);
+	});
+
+	it("uses undisclosed recipients for Cc-only mail while preserving Cc", () => {
+		const message = buildRawEmailMessage({
+			from: "sender@example.com",
+			to: [],
+			cc: ["copied@example.com"],
+			subject: "Subject",
+			textBody: "Body",
+		});
+
+		expect(message).toContain("To: undisclosed-recipients:;\r\n");
+		expect(message).toContain("Cc: copied@example.com\r\n");
+	});
+
+	it("renders attachment content IDs inline without exposing Bcc", () => {
+		const message = buildRawEmailMessage({
+			from: "sender@example.com",
+			to: [],
+			bcc: ["blind@example.com"],
+			subject: "Subject",
+			htmlBody: '<img src="cid:logo">',
+			attachments: [
+				{
+					filename: "logo.png",
+					content: "aGVsbG8=",
+					contentType: "image/png",
+					size: 5,
+					content_id: "logo",
+				},
+			],
+		});
+
+		expect(message).toContain("To: undisclosed-recipients:;\r\n");
+		expect(message).toContain("Content-ID: <logo>\r\n");
+		expect(message).toContain(
+			'Content-Disposition: inline; filename="logo.png"',
+		);
+		expect(message).not.toContain("blind@example.com");
+	});
+});

--- a/app/api/e2/helper/email-builder.ts
+++ b/app/api/e2/helper/email-builder.ts
@@ -78,7 +78,6 @@ export function buildRawEmailMessage(params: EmailMessageParams): string {
     from,
     to,
     cc,
-    bcc,
     replyTo,
     subject,
     textBody,
@@ -93,7 +92,6 @@ export function buildRawEmailMessage(params: EmailMessageParams): string {
 
   const hasText = !!textBody
   const hasHtml = !!htmlBody
-  const hasAttachments = attachments.length > 0
   
   // Separate CID attachments from regular attachments
   const cidAttachments = attachments.filter(att => att.content_id)
@@ -147,7 +145,7 @@ export function buildRawEmailMessage(params: EmailMessageParams): string {
   // Build headers
   const headers = [
     `From: ${from}`,
-    `To: ${to.join(', ')}`,
+    `To: ${to.length > 0 ? to.join(', ') : 'undisclosed-recipients:;'}`,
     cc && cc.length > 0 ? `Cc: ${cc.join(', ')}` : null,
     replyTo && replyTo.length > 0 ? `Reply-To: ${replyTo.join(', ')}` : null,
     `Subject: ${subject}`,

--- a/app/api/e2/lib/auth.ts
+++ b/app/api/e2/lib/auth.ts
@@ -9,6 +9,8 @@ import { apikey, user } from "@/lib/db/auth-schema";
 // Only initialize if env vars are present
 let redis: Redis | null = null;
 let ratelimit: Ratelimit | null = null;
+let mailboxLoginRatelimit: Ratelimit | null = null;
+let mailboxIpRatelimit: Ratelimit | null = null;
 
 // SECURITY: Controls fail-closed behavior when rate limiting is unavailable
 // Set to "true" ONLY in development environments
@@ -31,6 +33,18 @@ if (
 		limiter: Ratelimit.slidingWindow(10, "1 s"),
 		analytics: true,
 		prefix: "e2:ratelimit",
+	});
+	mailboxLoginRatelimit = new Ratelimit({
+		redis,
+		limiter: Ratelimit.slidingWindow(60, "1 m"),
+		analytics: true,
+		prefix: "e2:mailbox-auth:login",
+	});
+	mailboxIpRatelimit = new Ratelimit({
+		redis,
+		limiter: Ratelimit.slidingWindow(3000, "1 m"),
+		analytics: true,
+		prefix: "e2:mailbox-auth:ip",
 	});
 } else {
 	if (ALLOW_REQUESTS_WITHOUT_RATE_LIMIT) {
@@ -83,6 +97,258 @@ function getHeaderRecord(headers: unknown): Record<string, string> {
 	return {};
 }
 
+function getClientIp(request: Request): string {
+	return (
+		request.headers
+			.get("x-vercel-forwarded-for")
+			?.split(",")[0]
+			?.trim()
+			.toLowerCase() ||
+		request.headers.get("cf-connecting-ip")?.trim().toLowerCase() ||
+		request.headers.get("x-real-ip")?.trim().toLowerCase() ||
+		request.headers
+			.get("x-forwarded-for")
+			?.split(",")[0]
+			?.trim()
+			.toLowerCase() ||
+		"unknown"
+	);
+}
+
+export async function enforceAuthenticatedUserAndRateLimit(
+	userId: string,
+	set: { status?: number | string; headers?: unknown },
+): Promise<void> {
+	const [userRecord] = await db
+		.select({
+			banned: user.banned,
+			banReason: user.banReason,
+			banExpires: user.banExpires,
+		})
+		.from(user)
+		.where(eq(user.id, userId))
+		.limit(1);
+
+	if (!userRecord) {
+		set.status = 401;
+		const userNotFoundHeaders = {
+			...getHeaderRecord(set.headers),
+			"WWW-Authenticate": 'Bearer realm="API", charset="UTF-8"',
+			"Content-Type": "application/json; charset=utf-8",
+		};
+		set.headers = userNotFoundHeaders;
+		throw new AuthError(
+			{
+				error: "Unauthorized",
+				message: "User not found.",
+				statusCode: 401,
+			},
+			userNotFoundHeaders,
+		);
+	}
+
+	if (userRecord.banned) {
+		const banExpiresAt = userRecord.banExpires
+			? new Date(userRecord.banExpires)
+			: null;
+		const banStillActive = banExpiresAt
+			? banExpiresAt.getTime() >= Date.now()
+			: true;
+
+		if (banStillActive) {
+			set.status = 403;
+			const bannedHeaders = {
+				...getHeaderRecord(set.headers),
+				"Content-Type": "application/json; charset=utf-8",
+			};
+			set.headers = bannedHeaders;
+			throw new AuthError(
+				{
+					error: "Forbidden",
+					message:
+						userRecord.banReason ||
+						"Account suspended. Please contact support.",
+					statusCode: 403,
+				},
+				bannedHeaders,
+			);
+		}
+	}
+
+	if (ratelimit) {
+		let rateLimitResult: Awaited<ReturnType<typeof ratelimit.limit>>;
+
+		try {
+			rateLimitResult = await ratelimit.limit(userId);
+		} catch (error) {
+			console.error("🚨 Rate limiting service failure:", error);
+			set.status = 503;
+			const unavailableHeaders = {
+				"Content-Type": "application/json; charset=utf-8",
+				"Retry-After": "60",
+			};
+			set.headers = unavailableHeaders;
+			throw new AuthError(
+				{
+					error: "Service Unavailable",
+					message:
+						"Rate limiting service is temporarily unavailable. Please try again later.",
+					statusCode: 503,
+				},
+				unavailableHeaders,
+			);
+		}
+
+		const {
+			success: rateLimitSuccess,
+			limit,
+			remaining,
+			reset,
+		} = rateLimitResult;
+
+		console.log("📊 Rate limit check:", {
+			success: rateLimitSuccess,
+			limit,
+			remaining,
+			reset: new Date(reset).toISOString(),
+		});
+
+		set.headers = {
+			...getHeaderRecord(set.headers),
+			"X-RateLimit-Limit": limit.toString(),
+			"X-RateLimit-Remaining": remaining.toString(),
+			"X-RateLimit-Reset": reset.toString(),
+		};
+
+		if (!rateLimitSuccess) {
+			console.log("⚠️ Rate limit exceeded for userId:", userId);
+			const retryAfterSeconds = Math.ceil((reset - Date.now()) / 1000);
+			set.status = 429;
+			const rateLimitHeaders = {
+				...getHeaderRecord(set.headers),
+				"Retry-After": retryAfterSeconds.toString(),
+				"Content-Type": "application/json; charset=utf-8",
+			};
+			set.headers = rateLimitHeaders;
+			throw new AuthError(
+				{
+					error: "Too Many Requests",
+					message: `Rate limit exceeded. Maximum ${limit} requests per second. Retry after ${retryAfterSeconds} seconds.`,
+					statusCode: 429,
+				},
+				rateLimitHeaders,
+			);
+		}
+	} else {
+		if (!ALLOW_REQUESTS_WITHOUT_RATE_LIMIT) {
+			console.error(
+				"🚨 SECURITY: Blocking request - rate limiting unavailable and ALLOW_REQUESTS_WITHOUT_RATE_LIMIT is not enabled",
+			);
+			set.status = 503;
+			const unavailableHeaders = {
+				"Content-Type": "application/json; charset=utf-8",
+				"Retry-After": "60",
+			};
+			set.headers = unavailableHeaders;
+			throw new AuthError(
+				{
+					error: "Service Unavailable",
+					message:
+						"Rate limiting service is temporarily unavailable. Please try again later.",
+					statusCode: 503,
+				},
+				unavailableHeaders,
+			);
+		}
+		console.warn(
+			"⚠️ [DEV MODE] Rate limiting bypassed - ALLOW_REQUESTS_WITHOUT_RATE_LIMIT=true",
+		);
+	}
+}
+
+export async function enforceMailboxAuthenticationRateLimit(
+	request: Request,
+	loginAddress: string,
+	set: { status?: number | string; headers?: unknown },
+): Promise<void> {
+	if (!mailboxLoginRatelimit || !mailboxIpRatelimit) {
+		if (ALLOW_REQUESTS_WITHOUT_RATE_LIMIT) return;
+
+		set.status = 503;
+		const headers = {
+			"Content-Type": "application/json; charset=utf-8",
+			"Retry-After": "60",
+		};
+		set.headers = headers;
+		throw new AuthError(
+			{
+				error: "Service Unavailable",
+				message:
+					"Rate limiting service is temporarily unavailable. Please try again later.",
+				statusCode: 503,
+			},
+			headers,
+		);
+	}
+
+	const clientIp = getClientIp(request);
+	const normalizedLoginAddress = loginAddress.trim().toLowerCase();
+	let results: Awaited<ReturnType<typeof mailboxLoginRatelimit.limit>>[];
+	try {
+		results = await Promise.all([
+			mailboxLoginRatelimit.limit(`${clientIp}:${normalizedLoginAddress}`),
+			mailboxIpRatelimit.limit(clientIp),
+		]);
+	} catch (error) {
+		console.error("Mailbox authentication rate limiting service failure:", error);
+		set.status = 503;
+		const headers = {
+			"Content-Type": "application/json; charset=utf-8",
+			"Retry-After": "60",
+		};
+		set.headers = headers;
+		throw new AuthError(
+			{
+				error: "Service Unavailable",
+				message:
+					"Rate limiting service is temporarily unavailable. Please try again later.",
+				statusCode: 503,
+			},
+			headers,
+		);
+	}
+
+	const result = results.find(({ success }) => !success) ?? results[0];
+	set.headers = {
+		...getHeaderRecord(set.headers),
+		"X-RateLimit-Limit": result.limit.toString(),
+		"X-RateLimit-Remaining": result.remaining.toString(),
+		"X-RateLimit-Reset": result.reset.toString(),
+	};
+
+	if (!result.success) {
+		const retryAfterSeconds = Math.max(
+			1,
+			Math.ceil((result.reset - Date.now()) / 1000),
+		);
+		set.status = 429;
+		const headers = {
+			...getHeaderRecord(set.headers),
+			"Retry-After": retryAfterSeconds.toString(),
+			"Content-Type": "application/json; charset=utf-8",
+		};
+		set.headers = headers;
+		throw new AuthError(
+			{
+				error: "Too Many Requests",
+				message: "Too many authentication attempts. Please try again later.",
+				statusCode: 429,
+			},
+			headers,
+		);
+	}
+}
+
 /**
  * Validates authentication (session or API key) and checks rate limits
  * Throws AuthError with RFC-compliant headers on failure
@@ -107,11 +373,7 @@ export async function validateAndRateLimit(
 ): Promise<string> {
 	try {
 		// Get client IP from various headers (Vercel/Cloudflare/etc)
-		const clientIp =
-			request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-			request.headers.get("x-real-ip") ||
-			request.headers.get("cf-connecting-ip") ||
-			"unknown";
+		const clientIp = getClientIp(request);
 		console.log("🌐 [E2] Client IP:", clientIp);
 		console.log("🔐 Validating request authentication and rate limit");
 
@@ -208,155 +470,7 @@ export async function validateAndRateLimit(
 			);
 		}
 
-		const [userRecord] = await db
-			.select({
-				banned: user.banned,
-				banReason: user.banReason,
-				banExpires: user.banExpires,
-			})
-			.from(user)
-			.where(eq(user.id, userId))
-			.limit(1);
-
-		if (!userRecord) {
-			set.status = 401;
-			const userNotFoundHeaders = {
-				...getHeaderRecord(set.headers),
-				"WWW-Authenticate": 'Bearer realm="API", charset="UTF-8"',
-				"Content-Type": "application/json; charset=utf-8",
-			};
-			set.headers = userNotFoundHeaders;
-			throw new AuthError(
-				{
-					error: "Unauthorized",
-					message: "User not found.",
-					statusCode: 401,
-				},
-				userNotFoundHeaders,
-			);
-		}
-
-		if (userRecord.banned) {
-			const banExpiresAt = userRecord.banExpires
-				? new Date(userRecord.banExpires)
-				: null;
-			const banStillActive = banExpiresAt
-				? banExpiresAt.getTime() >= Date.now()
-				: true;
-
-			if (banStillActive) {
-				set.status = 403;
-				const bannedHeaders = {
-					...getHeaderRecord(set.headers),
-					"Content-Type": "application/json; charset=utf-8",
-				};
-				set.headers = bannedHeaders;
-				throw new AuthError(
-					{
-						error: "Forbidden",
-						message:
-							userRecord.banReason ||
-							"Account suspended. Please contact support.",
-						statusCode: 403,
-					},
-					bannedHeaders,
-				);
-			}
-		}
-
-		// Check rate limit for this userId (if configured)
-		if (ratelimit) {
-			let rateLimitResult: Awaited<ReturnType<typeof ratelimit.limit>>;
-
-			try {
-				rateLimitResult = await ratelimit.limit(userId);
-			} catch (error) {
-				console.error("🚨 Rate limiting service failure:", error);
-				set.status = 503;
-				const unavailableHeaders = {
-					"Content-Type": "application/json; charset=utf-8",
-					"Retry-After": "60",
-				};
-				set.headers = unavailableHeaders;
-				throw new AuthError(
-					{
-						error: "Service Unavailable",
-						message:
-							"Rate limiting service is temporarily unavailable. Please try again later.",
-						statusCode: 503,
-					},
-					unavailableHeaders,
-				);
-			}
-
-			const {
-				success: rateLimitSuccess,
-				limit,
-				remaining,
-				reset,
-			} = rateLimitResult;
-
-			console.log("📊 Rate limit check:", {
-				success: rateLimitSuccess,
-				limit,
-				remaining,
-				reset: new Date(reset).toISOString(),
-			});
-
-			// Set rate limit headers on all requests (RFC 6585 recommendation)
-			set.headers = {
-				...getHeaderRecord(set.headers),
-				"X-RateLimit-Limit": limit.toString(),
-				"X-RateLimit-Remaining": remaining.toString(),
-				"X-RateLimit-Reset": reset.toString(),
-			};
-
-			if (!rateLimitSuccess) {
-				console.log("⚠️ Rate limit exceeded for userId:", userId);
-				// RFC 6585: 429 responses SHOULD include Retry-After header
-				const retryAfterSeconds = Math.ceil((reset - Date.now()) / 1000);
-				set.status = 429;
-				const rateLimitHeaders = {
-					...getHeaderRecord(set.headers),
-					"Retry-After": retryAfterSeconds.toString(),
-					"Content-Type": "application/json; charset=utf-8",
-				};
-				set.headers = rateLimitHeaders;
-				throw new AuthError(
-					{
-						error: "Too Many Requests",
-						message: `Rate limit exceeded. Maximum ${limit} requests per second. Retry after ${retryAfterSeconds} seconds.`,
-						statusCode: 429,
-					},
-					rateLimitHeaders,
-				);
-			}
-		} else {
-			// SECURITY: Fail-closed pattern - block requests when rate limiting is unavailable
-			if (!ALLOW_REQUESTS_WITHOUT_RATE_LIMIT) {
-				console.error(
-					"🚨 SECURITY: Blocking request - rate limiting unavailable and ALLOW_REQUESTS_WITHOUT_RATE_LIMIT is not enabled",
-				);
-				set.status = 503;
-				const unavailableHeaders = {
-					"Content-Type": "application/json; charset=utf-8",
-					"Retry-After": "60",
-				};
-				set.headers = unavailableHeaders;
-				throw new AuthError(
-					{
-						error: "Service Unavailable",
-						message:
-							"Rate limiting service is temporarily unavailable. Please try again later.",
-						statusCode: 503,
-					},
-					unavailableHeaders,
-				);
-			}
-			console.warn(
-				"⚠️ [DEV MODE] Rate limiting bypassed - ALLOW_REQUESTS_WITHOUT_RATE_LIMIT=true",
-			);
-		}
+		await enforceAuthenticatedUserAndRateLimit(userId, set);
 
 		return userId;
 	} catch (error) {

--- a/app/api/e2/lib/mailbox-rate-limit.test.ts
+++ b/app/api/e2/lib/mailbox-rate-limit.test.ts
@@ -1,0 +1,352 @@
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "bun:test";
+
+type MailboxEndpoint = "mailbox" | "smtp";
+
+interface ScenarioRequest {
+	endpoint: MailboxEndpoint;
+	loginAddress: string;
+	headers: Record<string, string>;
+}
+
+interface Scenario {
+	requests: ScenarioRequest[];
+	blockSource?: boolean;
+	unavailable?: boolean;
+	missingRedis?: boolean;
+}
+
+interface ScenarioResult {
+	calls: Array<{ prefix: string; identifier: string }>;
+	responses: Array<{
+		status: number;
+		retryAfter: string | null;
+		limit: string | null;
+		body: { error: string; message?: string; statusCode?: number };
+	}>;
+}
+
+const scenarioScript = `
+import { mock } from "bun:test";
+
+const scenario = JSON.parse(process.env.MAILBOX_RATE_LIMIT_SCENARIO);
+const calls = [];
+
+class MockRatelimit {
+  constructor(options) {
+    this.prefix = options.prefix;
+  }
+
+  static slidingWindow() {
+    return {};
+  }
+
+  async limit(identifier) {
+    calls.push({ prefix: this.prefix, identifier });
+    if (scenario.unavailable) throw new Error("Redis unavailable");
+
+    const sourceLimiter = this.prefix.endsWith(":ip");
+    const blocked = scenario.blockSource ? sourceLimiter : !sourceLimiter;
+    return {
+      success: !blocked,
+      limit: sourceLimiter ? 3000 : 60,
+      remaining: blocked ? 0 : sourceLimiter ? 2999 : 59,
+      reset: Date.now() + 60000,
+      pending: Promise.resolve(),
+    };
+  }
+}
+
+mock.module("@upstash/ratelimit", () => ({ Ratelimit: MockRatelimit }));
+
+const { Elysia } = await import("elysia");
+const { AuthError } = await import("./app/api/e2/lib/auth");
+const { authenticateMailbox } = await import("./app/api/e2/mailboxes/authenticate");
+const { authenticateSmtp } = await import("./app/api/e2/mailboxes/authenticate-smtp");
+const app = new Elysia()
+  .onError(({ error }) => {
+    if (error instanceof AuthError) return error.response;
+  })
+  .use(authenticateMailbox)
+  .use(authenticateSmtp);
+const responses = [];
+
+for (const entry of scenario.requests) {
+  const smtp = entry.endpoint === "smtp";
+  const path = smtp ? "/mailboxes/authenticate-smtp" : "/mailboxes/authenticate";
+  const response = await app.handle(
+    new Request("http://localhost" + path, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...entry.headers },
+      body: JSON.stringify({ loginAddress: entry.loginAddress, password: "password" }),
+    }),
+  );
+  responses.push({
+    status: response.status,
+    retryAfter: response.headers.get("Retry-After"),
+    limit: response.headers.get("X-RateLimit-Limit"),
+    body: await response.json(),
+  });
+}
+
+console.log("MAILBOX_RATE_LIMIT_RESULT:" + JSON.stringify({ calls, responses }));
+process.exit(0);
+`;
+
+function runScenario(scenario: Scenario): ScenarioResult {
+	const result = spawnSync(process.execPath, ["-e", scenarioScript], {
+		cwd: process.cwd(),
+		encoding: "utf8",
+		env: {
+			...process.env,
+			UPSTASH_REDIS_REST_URL: scenario.missingRedis
+				? ""
+				: "https://example.upstash.io",
+			UPSTASH_REDIS_REST_TOKEN: scenario.missingRedis ? "" : "test-token",
+			ALLOW_REQUESTS_WITHOUT_RATE_LIMIT: "false",
+			MAILBOX_RATE_LIMIT_SCENARIO: JSON.stringify(scenario),
+		},
+		timeout: 10_000,
+	});
+
+	if (result.status !== 0) {
+		throw new Error(result.stderr || result.stdout || "Scenario execution failed");
+	}
+
+	const output = result.stdout
+		.split("\n")
+		.find((line) => line.startsWith("MAILBOX_RATE_LIMIT_RESULT:"));
+	if (!output) throw new Error("Scenario did not return rate limit results");
+
+	return JSON.parse(output.slice("MAILBOX_RATE_LIMIT_RESULT:".length));
+}
+
+describe("mailbox authentication rate limiting", () => {
+	it("isolates the same mailbox login across different trusted source IPs", () => {
+		const result = runScenario({
+			requests: [
+				{
+					endpoint: "mailbox",
+					loginAddress: "User@Example.com",
+					headers: { "x-real-ip": "203.0.113.10" },
+				},
+				{
+					endpoint: "mailbox",
+					loginAddress: "user@example.com",
+					headers: { "x-real-ip": "203.0.113.20" },
+				},
+			],
+		});
+
+		const loginKeys = result.calls
+			.filter(({ prefix }) => prefix === "e2:mailbox-auth:login")
+			.map(({ identifier }) => identifier);
+		expect(loginKeys).toEqual([
+			"203.0.113.10:user@example.com",
+			"203.0.113.20:user@example.com",
+		]);
+		expect(result.responses.map(({ status }) => status)).toEqual([429, 429]);
+	});
+
+	it("shares a source-plus-login budget across mailbox and SMTP authentication", () => {
+		const result = runScenario({
+			requests: [
+				{
+					endpoint: "mailbox",
+					loginAddress: " USER@Example.COM ",
+					headers: {
+						"x-real-ip": "203.0.113.30",
+						"x-forwarded-for": "198.51.100.10, 10.0.0.1",
+					},
+				},
+				{
+					endpoint: "smtp",
+					loginAddress: "user@example.com",
+					headers: {
+						"x-real-ip": "203.0.113.30",
+						"x-forwarded-for": "198.51.100.20, 10.0.0.1",
+					},
+				},
+			],
+		});
+
+		expect(result.calls).toEqual([
+			{
+				prefix: "e2:mailbox-auth:login",
+				identifier: "203.0.113.30:user@example.com",
+			},
+			{ prefix: "e2:mailbox-auth:ip", identifier: "203.0.113.30" },
+			{
+				prefix: "e2:mailbox-auth:login",
+				identifier: "203.0.113.30:user@example.com",
+			},
+			{ prefix: "e2:mailbox-auth:ip", identifier: "203.0.113.30" },
+		]);
+		for (const response of result.responses) {
+			expect(response.status).toBe(429);
+			expect(response.retryAfter).toBe("60");
+			expect(response.limit).toBe("60");
+			expect(response.body).toEqual({
+				error: "Too Many Requests",
+				message: "Too many authentication attempts. Please try again later.",
+				statusCode: 429,
+			});
+		}
+	});
+
+	it("ignores forged real IPs when Cloudflare supplies the client address", () => {
+		const result = runScenario({
+			requests: [
+				{
+					endpoint: "mailbox",
+					loginAddress: "user@example.com",
+					headers: {
+						"cf-connecting-ip": "203.0.113.50",
+						"x-real-ip": "198.51.100.30",
+						"x-forwarded-for": "198.51.100.31, 10.0.0.1",
+					},
+				},
+				{
+					endpoint: "smtp",
+					loginAddress: "user@example.com",
+					headers: {
+						"cf-connecting-ip": "203.0.113.50",
+						"x-real-ip": "198.51.100.40",
+						"x-forwarded-for": "198.51.100.41, 10.0.0.1",
+					},
+				},
+			],
+		});
+
+		expect(result.calls.map(({ identifier }) => identifier)).toEqual([
+			"203.0.113.50:user@example.com",
+			"203.0.113.50",
+			"203.0.113.50:user@example.com",
+			"203.0.113.50",
+		]);
+	});
+
+	it("ignores forged Cloudflare and real IP headers when Vercel supplies the client address", () => {
+		const result = runScenario({
+			requests: [
+				{
+					endpoint: "mailbox",
+					loginAddress: "user@example.com",
+					headers: {
+						"x-vercel-forwarded-for": "203.0.113.51, 10.0.0.1",
+						"cf-connecting-ip": "198.51.100.50",
+						"x-real-ip": "198.51.100.51",
+						"x-forwarded-for": "198.51.100.52, 10.0.0.2",
+					},
+				},
+				{
+					endpoint: "smtp",
+					loginAddress: "user@example.com",
+					headers: {
+						"x-vercel-forwarded-for": "203.0.113.51, 10.0.0.3",
+						"cf-connecting-ip": "198.51.100.60",
+						"x-real-ip": "198.51.100.61",
+						"x-forwarded-for": "198.51.100.62, 10.0.0.4",
+					},
+				},
+			],
+		});
+
+		expect(result.calls.map(({ identifier }) => identifier)).toEqual([
+			"203.0.113.51:user@example.com",
+			"203.0.113.51",
+			"203.0.113.51:user@example.com",
+			"203.0.113.51",
+		]);
+	});
+
+	it("retains forwarded client addresses when trusted platform headers are absent", () => {
+		const result = runScenario({
+			requests: [
+				{
+					endpoint: "smtp",
+					loginAddress: "user@example.com",
+					headers: { "x-forwarded-for": "203.0.113.55, 10.0.0.1" },
+				},
+			],
+		});
+
+		expect(result.calls[0].identifier).toBe(
+			"203.0.113.55:user@example.com",
+		);
+		expect(result.calls[1].identifier).toBe("203.0.113.55");
+	});
+
+	it("preserves the aggregate source budget across different logins and routes", () => {
+		const result = runScenario({
+			blockSource: true,
+			requests: [
+				{
+					endpoint: "mailbox",
+					loginAddress: "first@example.com",
+					headers: { "x-real-ip": "203.0.113.60" },
+				},
+				{
+					endpoint: "smtp",
+					loginAddress: "second@example.com",
+					headers: { "x-real-ip": "203.0.113.60" },
+				},
+			],
+		});
+
+		expect(
+			result.calls
+				.filter(({ prefix }) => prefix === "e2:mailbox-auth:ip")
+				.map(({ identifier }) => identifier),
+		).toEqual(["203.0.113.60", "203.0.113.60"]);
+		for (const response of result.responses) {
+			expect(response.status).toBe(429);
+			expect(response.limit).toBe("3000");
+			expect(response.retryAfter).toBe("60");
+		}
+	});
+
+	it("fails closed with Retry-After when the distributed limiter fails", () => {
+		const result = runScenario({
+			unavailable: true,
+			requests: [
+				{
+					endpoint: "mailbox",
+					loginAddress: "user@example.com",
+					headers: { "x-real-ip": "203.0.113.70" },
+				},
+			],
+		});
+
+		expect(result.responses).toEqual([
+			{
+				status: 503,
+				retryAfter: "60",
+				limit: null,
+				body: {
+					error: "Service Unavailable",
+					message:
+						"Rate limiting service is temporarily unavailable. Please try again later.",
+					statusCode: 503,
+				},
+			},
+		]);
+	});
+
+	it("fails closed when Redis is not configured", () => {
+		const result = runScenario({
+			missingRedis: true,
+			requests: [
+				{
+					endpoint: "smtp",
+					loginAddress: "user@example.com",
+					headers: { "x-real-ip": "203.0.113.80" },
+				},
+			],
+		});
+
+		expect(result.calls).toEqual([]);
+		expect(result.responses[0].status).toBe(503);
+		expect(result.responses[0].retryAfter).toBe("60");
+	});
+});

--- a/app/api/e2/lib/send-auth.ts
+++ b/app/api/e2/lib/send-auth.ts
@@ -1,4 +1,7 @@
-import { validateAndRateLimit } from "@/app/api/e2/lib/auth";
+import {
+	enforceAuthenticatedUserAndRateLimit,
+	validateAndRateLimit,
+} from "@/app/api/e2/lib/auth";
 import {
 	authenticateManagedMailCredential,
 	normalizeEmailAddress,
@@ -19,6 +22,7 @@ export async function authenticateEmailSend(
 	if (apiKey?.startsWith("mail_") || apiKey?.startsWith("imap_")) {
 		const credential = await authenticateManagedMailCredential(apiKey);
 		if (credential) {
+			await enforceAuthenticatedUserAndRateLimit(credential.userId, set);
 			return {
 				userId: credential.userId,
 				senderPolicy: {

--- a/app/api/e2/mailboxes/authenticate-smtp.ts
+++ b/app/api/e2/mailboxes/authenticate-smtp.ts
@@ -1,4 +1,5 @@
 import { Elysia, t } from "elysia";
+import { enforceMailboxAuthenticationRateLimit } from "@/app/api/e2/lib/auth";
 import {
 	authenticateManagedMailCredential,
 	MailboxErrorSchema,
@@ -8,7 +9,7 @@ import {
 
 const AuthenticateSmtpBody = t.Object({
 	loginAddress: t.String({ minLength: 3, maxLength: 255 }),
-	password: t.String({ minLength: 1 }),
+	password: t.String({ minLength: 1, maxLength: 1024 }),
 });
 
 const AuthenticateSmtpResponse = t.Object({
@@ -31,8 +32,13 @@ function unauthorized(set: { status?: number | string }) {
 
 export const authenticateSmtp = new Elysia().post(
 	"/mailboxes/authenticate-smtp",
-	async ({ body, set }) => {
+	async ({ request, body, set }) => {
 		const loginAddress = normalizeEmailAddress(body.loginAddress);
+		await enforceMailboxAuthenticationRateLimit(
+			request,
+			loginAddress ?? body.loginAddress.trim().toLowerCase(),
+			set,
+		);
 		if (!loginAddress) return unauthorized(set);
 
 		const credential = await authenticateManagedMailCredential(body.password, {
@@ -48,7 +54,9 @@ export const authenticateSmtp = new Elysia().post(
 			200: AuthenticateSmtpResponse,
 			400: MailboxErrorSchema,
 			401: MailboxErrorSchema,
+			429: MailboxErrorSchema,
 			500: MailboxErrorSchema,
+			503: MailboxErrorSchema,
 		},
 		detail: { tags: ["Mailboxes"], summary: "Authenticate for SMTP" },
 	},

--- a/app/api/e2/mailboxes/authenticate.ts
+++ b/app/api/e2/mailboxes/authenticate.ts
@@ -1,4 +1,5 @@
 import { Elysia, t } from "elysia";
+import { enforceMailboxAuthenticationRateLimit } from "@/app/api/e2/lib/auth";
 import {
 	authenticateManagedMailCredential,
 	MailboxErrorSchema,
@@ -8,7 +9,7 @@ import {
 
 const AuthenticateBody = t.Object({
 	loginAddress: t.String({ minLength: 3, maxLength: 255 }),
-	password: t.String({ minLength: 1 }),
+	password: t.String({ minLength: 1, maxLength: 1024 }),
 });
 
 const AuthenticateResponse = t.Object({
@@ -30,8 +31,13 @@ function unauthorized(set: { status?: number | string }) {
 
 export const authenticateMailbox = new Elysia().post(
 	"/mailboxes/authenticate",
-	async ({ body, set }) => {
+	async ({ request, body, set }) => {
 		const loginAddress = normalizeEmailAddress(body.loginAddress);
+		await enforceMailboxAuthenticationRateLimit(
+			request,
+			loginAddress ?? body.loginAddress.trim().toLowerCase(),
+			set,
+		);
 		if (!loginAddress) return unauthorized(set);
 
 		const credential = await authenticateManagedMailCredential(body.password, {
@@ -58,7 +64,9 @@ export const authenticateMailbox = new Elysia().post(
 			200: AuthenticateResponse,
 			400: MailboxErrorSchema,
 			401: MailboxErrorSchema,
+			429: MailboxErrorSchema,
 			500: MailboxErrorSchema,
+			503: MailboxErrorSchema,
 		},
 		detail: { tags: ["Mailboxes"], summary: "Authenticate a mailbox" },
 	},

--- a/app/api/e2/mailboxes/shared-verification.test.ts
+++ b/app/api/e2/mailboxes/shared-verification.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { authenticateManagedMailCredential } from "@/app/api/e2/mailboxes/shared";
+import { auth } from "@/lib/auth/auth";
+
+const invalidVerification = {
+	valid: false,
+	error: { message: "Invalid API key" },
+	key: null,
+} as Awaited<ReturnType<typeof auth.api.verifyApiKey>>;
+
+afterEach(() => {
+	spyOn(auth.api, "verifyApiKey").mockRestore();
+});
+
+describe("managed mail credential verification", () => {
+	it("rejects invalid credentials after both verifiers respond", async () => {
+		const verify = spyOn(auth.api, "verifyApiKey").mockResolvedValue(
+			invalidVerification,
+		);
+
+		expect(await authenticateManagedMailCredential("mail_invalid")).toBeNull();
+		expect(verify).toHaveBeenCalledTimes(2);
+	});
+
+	it("propagates an authentication backend outage", async () => {
+		spyOn(auth.api, "verifyApiKey").mockRejectedValue(
+			new Error("Authentication backend unavailable"),
+		);
+
+		await expect(
+			authenticateManagedMailCredential("mail_unavailable"),
+		).rejects.toThrow("Authentication backend unavailable");
+	});
+
+	it("does not classify a failed primary verifier as invalid credentials", async () => {
+		spyOn(auth.api, "verifyApiKey")
+			.mockRejectedValueOnce(new Error("Primary verifier unavailable"))
+			.mockResolvedValueOnce(invalidVerification);
+
+		await expect(
+			authenticateManagedMailCredential("mail_mixed"),
+		).rejects.toThrow("Primary verifier unavailable");
+	});
+
+	it("does not classify a failed fallback verifier as invalid credentials", async () => {
+		spyOn(auth.api, "verifyApiKey")
+			.mockResolvedValueOnce(invalidVerification)
+			.mockRejectedValueOnce(new Error("Fallback verifier unavailable"));
+
+		await expect(
+			authenticateManagedMailCredential("mail_mixed"),
+		).rejects.toThrow("Fallback verifier unavailable");
+	});
+});

--- a/app/api/e2/mailboxes/shared.ts
+++ b/app/api/e2/mailboxes/shared.ts
@@ -348,6 +348,8 @@ export async function authenticateManagedMailCredential(
 ): Promise<ManagedMailCredential | null> {
 	let verification: Awaited<ReturnType<typeof auth.api.verifyApiKey>> | null =
 		null;
+	let verificationFailed = false;
+	let verificationError: unknown;
 	const configIds = password.startsWith("imap_")
 		? (["imap", "mail"] as const)
 		: (["mail", "imap"] as const);
@@ -360,11 +362,15 @@ export async function authenticateManagedMailCredential(
 				verification = candidate;
 				break;
 			}
-		} catch {
-			continue;
+		} catch (error) {
+			verificationFailed = true;
+			verificationError = error;
 		}
 	}
-	if (!verification) return null;
+	if (!verification) {
+		if (verificationFailed) throw verificationError;
+		return null;
+	}
 
 	const apiKeyId = verification.valid ? verification.key?.id : null;
 	const apiKeyOwnerId = verification.valid

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,70 @@
-import { BookOpen, Workflow } from "lucide-react";
-import { headers } from "next/headers";
+import {
+	ArrowDownRight,
+	ArrowRight,
+	ArrowUpRight,
+	AtSign,
+	Check,
+	Code2,
+	GitBranch,
+	Inbox,
+	MessageSquareReply,
+	ShieldCheck,
+	Webhook,
+} from "lucide-react";
+import { cookies, headers } from "next/headers";
+import Image from "next/image";
 import Link from "next/link";
-import EnvelopeSparkle from "@/components/icons/envelope-sparkle";
-import { GetStartedTabs } from "@/components/marketing/get-started-tabs";
 import { DemoInbox } from "@/components/marketing/demo-inbox";
+import { GetStartedTabs } from "@/components/marketing/get-started-tabs";
 import { HeroSignupButton } from "@/components/marketing/hero-signup-button";
+import { HomepageControl } from "@/components/marketing/homepage-control";
+import { HomepageExperimentTracker } from "@/components/marketing/homepage-experiment-tracker";
 import { MarketingFooter, MarketingNav } from "@/components/marketing-nav";
 import { PricingTable } from "@/components/pricing-table";
 import { auth } from "@/lib/auth/auth";
+import {
+	HOMEPAGE_EXPERIMENT_COOKIE,
+	isHomepageVariant,
+} from "@/lib/homepage-experiment";
+
+const capabilities = [
+	{
+		icon: Inbox,
+		title: "Receive",
+		description: "Unlimited mailboxes on your domain.",
+	},
+	{
+		icon: Webhook,
+		title: "Route",
+		description: "Deliver messages to any webhook in under 100ms.",
+	},
+	{
+		icon: MessageSquareReply,
+		title: "Reply",
+		description: "Send from any address with automatic threading.",
+	},
+];
+
+const routes = [
+	{ address: "support@acme.com", endpoint: "/api/support-agent" },
+	{ address: "billing@acme.com", endpoint: "/api/billing" },
+	{ address: "*@acme.com", endpoint: "/api/catch-all" },
+];
+
+const questions = [
+	{
+		question: "Can I use my own domain?",
+		answer: "Yes. Point your MX records to Inbound.",
+	},
+	{
+		question: "How fast are webhooks delivered?",
+		answer: "Typically under 100ms, with automatic retries.",
+	},
+	{
+		question: "What about spam filtering?",
+		answer: "Reject, flag, or accept spam in your mailbox settings.",
+	},
+];
 
 export default async function Page() {
 	const session = await auth.api
@@ -17,200 +74,252 @@ export default async function Page() {
 		.catch(() => null);
 
 	const isLoggedIn = !!session?.user;
+	const assignedVariant = (await cookies()).get(
+		HOMEPAGE_EXPERIMENT_COOKIE,
+	)?.value;
+	const variant = isHomepageVariant(assignedVariant)
+		? assignedVariant
+		: "control";
+
+	if (variant === "control") {
+		return (
+			<>
+				<HomepageExperimentTracker variant={variant} />
+				<HomepageControl isLoggedIn={isLoggedIn} />
+			</>
+		);
+	}
 
 	return (
-		<div className="min-h-screen bg-[#fafaf9] text-[#1c1917] selection:bg-[#8161FF] selection:text-white">
-			{/* Top announcement banner */}
-			<div className="bg-[#8161FF] text-white text-center py-2 px-4">
-				<p className="text-sm">
-					<span className="font-medium">Extra domains now just $3.50/mo</span>
-					<span className="opacity-80 ml-1.5">— add as many as you need</span>
-				</p>
-			</div>
+		<div className="min-h-screen overflow-hidden bg-background text-[var(--text-primary)] selection:bg-[var(--button-primary-bg)] selection:text-white">
+			<HomepageExperimentTracker variant={variant} />
+			<div className="mx-auto min-h-screen max-w-6xl border-x border-border bg-card px-5 sm:px-8 [&>footer]:mt-0 [&>footer]:py-7">
+				<div className="-mx-5 border-b border-border px-5 sm:-mx-8 sm:px-8">
+					<MarketingNav isLoggedIn={isLoggedIn} />
+				</div>
 
-			<div className="max-w-2xl mx-auto px-6">
-				<MarketingNav isLoggedIn={isLoggedIn} />
+				<main>
+					<section className="grid gap-8 py-12 sm:py-14 lg:grid-cols-[1.05fr_0.95fr] lg:items-center lg:gap-12 lg:py-16">
+						<div>
+							<h1 className="max-w-xl font-outfit text-6xl font-medium leading-[0.98] tracking-tight sm:text-7xl xl:text-8xl">
+								The inbox
+								<br />
+								<span className="text-primary">is an API.</span>
+							</h1>
 
-				{/* Hero */}
-				<section className="pt-20 pb-16">
-					<h1 className="max-w-2xl font-heading text-[32px] leading-[1.2] tracking-tight text-[#1B1917]">
-						email infrastructure built for{" "}
-						<span className="whitespace-nowrap text-[#8161FF]">
-							<EnvelopeSparkle className="inline-block size-8 align-middle" />{" "}
-							agent inboxes,
-						</span>{" "}
-						webhooks, and{" "}
-						<span className="whitespace-nowrap text-[#8161FF]">
-							<Workflow className="inline-block size-7 align-middle" />{" "}
-							automated workflows.
-						</span>
-					</h1>
-					<p className="mt-3 max-w-xl text-base leading-relaxed text-[#52525b]">
-						send, receive, and reply in thread through one simple api & cli.
-					</p>
+							<p className="mt-7 max-w-md text-lg leading-relaxed tracking-normal text-[var(--text-secondary)] sm:text-xl">
+								Email for agents, apps, and workflows.
+							</p>
 
-					{!isLoggedIn && <HeroSignupButton />}
-
-					{/* Email Generator - Client Component */}
-					<DemoInbox />
-				</section>
-
-				{/* Get started */}
-				<section className="py-12 border-t border-[#e7e5e4]">
-					<GetStartedTabs />
-					<p className="mt-4 text-sm text-[#52525b] flex items-center gap-4">
-						<Link
-							href="/docs"
-							className="text-[#1c1917] hover:underline flex items-center gap-1.5"
-						>
-							<BookOpen className="w-4 h-4" />
-							Read the docs
-						</Link>
-						<span className="text-[#a8a29e]">or</span>
-						<a
-							href="https://github.com/inbound-org"
-							target="_blank"
-							rel="noopener noreferrer"
-							className="text-[#1c1917] hover:underline flex items-center gap-1.5"
-						>
-							<svg className="w-4 h-4" viewBox="0 0 24 24" fill="#000337">
-								<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-							</svg>
-							view on GitHub
-						</a>
-					</p>
-				</section>
-
-				<section className="py-10 border-t border-[#e7e5e4]">
-					<p className="text-xs text-[#78716c] uppercase tracking-wide mb-6">
-						Trusted by
-					</p>
-					<div className="flex items-center gap-10">
-						<img
-							src="/images/agentuity.png"
-							alt="Agentuity"
-							className="h-5 object-contain opacity-70 grayscale hover:opacity-100 hover:grayscale-0 transition-all"
-						/>
-						<img
-							src="/images/mandarin-3d.png"
-							alt="Mandarin 3D"
-							className="h-5 object-contain opacity-70 grayscale hover:opacity-100 hover:grayscale-0 transition-all"
-						/>
-						<img
-							src="/images/teslanav.png"
-							alt="TeslaNav"
-							className="h-5 object-contain opacity-70 grayscale hover:opacity-100 hover:grayscale-0 transition-all"
-						/>
-					</div>
-
-					<div className="mt-8 bg-[#fafaf9] rounded-lg">
-						<div className="flex items-start gap-3">
-							<div className="flex-shrink-0 w-10 h-10 bg-[#18181b] rounded-lg flex items-center justify-center">
-								<img
-									src="/images/linkdr.svg"
-									alt="LinkDR"
-									className="h-5 w-5"
-								/>
+							<div className="mt-9 flex flex-wrap items-center gap-3">
+								{isLoggedIn ? (
+									<Link
+										href="/logs"
+										className="inline-flex min-h-12 items-center gap-2 rounded-lg bg-[var(--button-primary-bg)] px-5 text-sm font-medium text-white transition-opacity hover:opacity-90"
+									>
+										Open dashboard <ArrowRight className="size-4" />
+									</Link>
+								) : (
+									<HeroSignupButton />
+								)}
+								<Link
+									href="/docs"
+									className="inline-flex min-h-12 items-center gap-2 rounded-lg border border-border bg-card px-5 text-sm font-medium text-[var(--text-primary)] transition-colors hover:bg-muted"
+								>
+									Read the docs <ArrowUpRight className="size-4" />
+								</Link>
 							</div>
-							<div>
+
+							<div className="mt-8 flex flex-wrap items-center gap-x-5 gap-y-2 text-xs tracking-normal text-[var(--text-muted)]">
+								<span className="inline-flex items-center gap-1.5">
+									<Check className="size-3.5 text-primary" /> Unlimited
+									mailboxes
+								</span>
+								<span className="inline-flex items-center gap-1.5">
+									<Check className="size-3.5 text-primary" /> Starts at $4/mo
+								</span>
+							</div>
+						</div>
+
+						<div className="border-t border-border pt-7 lg:border-l lg:border-t-0 lg:pl-10 lg:pt-0">
+							<div className="flex items-center justify-between border-b border-border pb-5">
+								<div className="flex items-center gap-2.5">
+									<Inbox className="size-4 text-primary" />
+									<span className="text-sm font-medium">Live inbox</span>
+								</div>
+								<span className="inline-flex items-center gap-1.5 font-mono text-xs tracking-normal text-[var(--text-muted)]">
+									<span className="size-1.5 rounded-full bg-emerald-500" /> live
+								</span>
+							</div>
+
+							<div className="border-b border-border py-7">
+								<div className="flex items-center justify-between font-mono text-xs tracking-normal text-[var(--text-muted)]">
+									<span>RECEIVED</span>
+									<ArrowDownRight className="size-4" />
+								</div>
+								<div className="mt-7 flex items-start gap-3">
+									<AtSign className="mt-0.5 size-5 shrink-0 text-primary" />
+									<div className="min-w-0">
+										<p className="truncate font-mono text-sm tracking-normal">
+											agent@yourcompany.com
+										</p>
+									</div>
+								</div>
+								<div className="mt-6 flex items-center gap-2 font-mono text-xs tracking-normal text-[var(--text-secondary)]">
+									<Webhook className="size-3.5 text-primary" />
+									POST /api/agent
+									<span className="ml-auto text-emerald-600">200 OK</span>
+								</div>
+							</div>
+
+							<div className="pt-7">
+								<DemoInbox />
+							</div>
+						</div>
+					</section>
+
+					<section className="-mx-5 grid gap-5 border-y border-border bg-background px-5 py-5 sm:-mx-8 sm:grid-cols-[auto_1fr] sm:items-center sm:gap-10 sm:px-8 sm:py-6">
+						<p className="font-mono text-xs tracking-normal text-[var(--text-muted)]">
+							TRUSTED BY
+						</p>
+						<div className="flex flex-wrap items-center gap-x-10 gap-y-6 sm:justify-end sm:gap-x-14">
+							<Image
+								src="/images/agentuity.png"
+								alt="Agentuity"
+								width={118}
+								height={28}
+								className="h-5 w-auto object-contain opacity-60 grayscale transition-opacity hover:opacity-100"
+							/>
+							<Image
+								src="/images/mandarin-3d.png"
+								alt="Mandarin 3D"
+								width={118}
+								height={28}
+								className="h-5 w-auto object-contain opacity-60 grayscale transition-opacity hover:opacity-100"
+							/>
+							<Image
+								src="/images/teslanav.png"
+								alt="TeslaNav"
+								width={118}
+								height={28}
+								className="h-5 w-auto object-contain opacity-60 grayscale transition-opacity hover:opacity-100"
+							/>
+						</div>
+					</section>
+
+					<section className="grid gap-7 py-9 sm:py-11 lg:grid-cols-[0.6fr_1fr] lg:items-center lg:gap-10">
+						<div>
+							<h2 className="max-w-md font-outfit text-3xl font-medium leading-tight tracking-tight sm:text-4xl">
+								Get started.
+							</h2>
+						</div>
+
+						<div className="border-t border-border pt-7 lg:border-l lg:border-t-0 lg:pl-10 lg:pt-0">
+							<GetStartedTabs />
+							<div className="mt-7 border-t border-border pt-5 text-sm">
 								<a
-									href="https://linkdr.com"
+									href="https://github.com/inbound-org"
 									target="_blank"
 									rel="noopener noreferrer"
-									className="font-medium text-[#18181b] hover:underline"
+									className="inline-flex items-center gap-1.5 text-[var(--text-secondary)] transition-colors hover:text-primary"
 								>
-									LinkDR
+									<Code2 className="size-4" /> GitHub
 								</a>
-								<p className="text-sm text-[#52525b] leading-relaxed">
-									LinkDR uses Inbound to power their internal order management
-									system for backlink management, processing thousands of
-									automated emails daily.
-								</p>
 							</div>
 						</div>
-					</div>
-				</section>
+					</section>
 
-				{/* What it does */}
-				<section className="py-12 border-t border-[#e7e5e4]">
-					<h2 className="font-heading text-xl font-semibold tracking-tight mb-6">
-						What is Inbound?
-					</h2>
-					<div className="space-y-4 text-[#3f3f46] leading-relaxed">
-						<p>
-							Inbound lets you send and receive emails programmatically. Add
-							your domain, configure your MX records, and you're ready to go.
-							Unlimited mailboxes on that domain, no setup required for each
-							address.
-						</p>
-						<p>
-							Send from any address on your domain. Receive at any address.
-							Route specific addresses to dedicated endpoints, or set up a
-							catch-all that forwards everything to a single webhook. Perfect
-							for support domains that route all incoming mail to an AI agent.
-						</p>
-						<p>
-							Every email preserves threading automatically. Reply
-							programmatically and we handle all the headers so your responses
-							show up in the right thread. It just works.
-						</p>
-					</div>
+					<section className="border-t border-border py-9 sm:py-11">
+						<div className="max-w-2xl">
+							<h2 className="font-outfit text-3xl font-medium leading-tight tracking-tight sm:text-4xl">
+								Send, receive, and reply.
+							</h2>
+						</div>
 
-					<div className="mt-8 space-y-2">
-						<p className="text-xs text-[#78716c] uppercase tracking-wide mb-3">
-							Example routes
-						</p>
-						<div className="font-mono text-sm space-y-1.5">
-							<div className="flex items-center gap-3">
-								<span className="text-[#52525b]">support@acme.com</span>
-								<span className="text-[#a8a29e]">&rarr;</span>
-								<span className="text-[#3f3f46]">/api/support-agent</span>
+						<div className="mt-8 grid gap-7 md:grid-cols-3 md:gap-0">
+							{capabilities.map(({ icon: Icon, title, description }) => (
+								<div
+									key={title}
+									className="border-t border-border pt-6 md:border-l md:border-t-0 md:px-8 md:pt-0 md:first:border-l-0 md:first:pl-0 md:last:pr-0"
+								>
+									<Icon className="size-5 text-primary" />
+									<h3 className="mt-5 font-outfit text-xl font-medium tracking-tight">
+										{title}
+									</h3>
+									<p className="mt-3 text-sm leading-relaxed tracking-normal text-[var(--text-secondary)]">
+										{description}
+									</p>
+								</div>
+							))}
+						</div>
+
+						<div className="mt-8 grid gap-7 border-t border-border pt-7 lg:grid-cols-[1.3fr_0.7fr] lg:gap-10">
+							<div>
+								<div className="flex items-center justify-between">
+									<div className="inline-flex items-center gap-2 text-sm text-[var(--text-secondary)]">
+										<GitBranch className="size-4 text-primary" /> Routes
+									</div>
+									<span className="font-mono text-xs tracking-normal text-[var(--text-muted)]">
+										acme.com
+									</span>
+								</div>
+								<div className="mt-7 space-y-4 font-mono text-xs tracking-normal sm:text-sm">
+									{routes.map(({ address, endpoint }) => (
+										<div
+											key={address}
+											className="flex flex-col gap-1.5 sm:flex-row sm:items-center sm:gap-4"
+										>
+											<span className="text-[var(--text-primary)] sm:min-w-44">
+												{address}
+											</span>
+											<ArrowRight className="hidden size-3.5 text-[var(--text-muted)] sm:block" />
+											<span className="text-primary">{endpoint}</span>
+										</div>
+									))}
+								</div>
 							</div>
-							<div className="flex items-center gap-3">
-								<span className="text-[#52525b]">billing@acme.com</span>
-								<span className="text-[#a8a29e]">&rarr;</span>
-								<span className="text-[#3f3f46]">/api/billing</span>
-							</div>
-							<div className="flex items-center gap-3">
-								<span className="text-[#52525b]">*@acme.com</span>
-								<span className="text-[#a8a29e]">&rarr;</span>
-								<span className="text-[#3f3f46]">/api/catch-all</span>
-							</div>
-						</div>
-					</div>
-				</section>
 
-				<PricingTable />
+							<div className="border-t border-border pt-7 lg:border-l lg:border-t-0 lg:pl-10 lg:pt-0">
+								<ShieldCheck className="size-5 text-primary" />
+								<div className="mt-6">
+									<p className="font-outfit text-xl font-medium tracking-tight">
+										Included
+									</p>
+									<p className="mt-2 text-sm leading-relaxed tracking-normal text-[var(--text-secondary)]">
+										Spam filtering, retries, and threading.
+									</p>
+								</div>
+							</div>
+						</div>
+					</section>
 
-				{/* FAQ */}
-				<section className="py-12 border-t border-[#e7e5e4]">
-					<h2 className="font-heading text-xl font-semibold tracking-tight mb-6">
-						FAQ
-					</h2>
-					<div className="space-y-6">
-						<div>
-							<p className="text-[#1c1917]">Can I use my own domain?</p>
-							<p className="text-sm text-[#52525b] mt-1">
-								Yes. Configure your MX records to point to our servers and you
-								can receive email at any address on your domain.
-							</p>
+					<section className="grid gap-9 border-t border-border py-9 sm:py-11 lg:grid-cols-2 lg:gap-0">
+						<div className="lg:pr-9">
+							<h2 className="font-outfit text-3xl font-medium leading-tight tracking-tight sm:text-4xl">
+								Pricing
+							</h2>
+							<div className="mt-7 [&>section]:border-t-0 [&>section]:py-0">
+								<PricingTable showHeader={false} />
+							</div>
 						</div>
-						<div>
-							<p className="text-[#1c1917]">How fast are webhooks delivered?</p>
-							<p className="text-sm text-[#52525b] mt-1">
-								Typically under 100ms from when we receive the email. We retry
-								failed webhooks with exponential backoff.
-							</p>
+
+						<div className="border-t border-border pt-8 lg:border-l lg:border-t-0 lg:pl-9 lg:pt-0">
+							<h2 className="font-outfit text-3xl font-medium leading-tight tracking-tight sm:text-4xl">
+								FAQ
+							</h2>
+							<div className="mt-7 divide-y divide-border">
+								{questions.map(({ question, answer }) => (
+									<div key={question} className="py-5 first:pt-0 last:pb-0">
+										<h3 className="font-medium">{question}</h3>
+										<p className="mt-2 text-sm leading-relaxed tracking-normal text-[var(--text-secondary)]">
+											{answer}
+										</p>
+									</div>
+								))}
+							</div>
 						</div>
-						<div>
-							<p className="text-[#1c1917]">What about spam filtering?</p>
-							<p className="text-sm text-[#52525b] mt-1">
-								We run incoming email through spam detection. You can choose to
-								reject, flag, or accept spam in your mailbox settings.
-							</p>
-						</div>
-					</div>
-				</section>
+					</section>
+				</main>
 
 				<MarketingFooter />
 			</div>

--- a/components/marketing/control/demo-inbox.tsx
+++ b/components/marketing/control/demo-inbox.tsx
@@ -75,26 +75,29 @@ export function DemoInbox() {
 	};
 
 	return (
-		<div>
-			<div className="flex min-h-11 min-w-0 items-center gap-3 border-b border-border">
-				<span className="truncate font-mono text-xs tracking-normal text-[var(--text-primary)] sm:text-sm">
-					{email || "Generating your address..."}
-				</span>
-				<button
-					type="button"
-					onClick={copyToClipboard}
-					aria-label={copied ? "Email address copied" : "Copy email address"}
-					className="ml-auto shrink-0 text-[var(--text-muted)] transition-colors hover:text-primary"
-				>
-					{copied ? (
-						<Check className="size-4 text-primary" />
-					) : (
-						<Copy className="size-4" />
-					)}
-				</button>
+		<div className="mt-12">
+			<div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
+				<div className="flex-1 bg-white border border-[#e7e5e4] rounded-lg px-3 py-2 flex items-center gap-3 min-w-0">
+					<span className="font-mono text-sm text-[#3f3f46] truncate">
+						{email}
+					</span>
+					<button
+						type="button"
+						onClick={copyToClipboard}
+						aria-label={copied ? "Email address copied" : "Copy email address"}
+						className="ml-auto text-[#52525b] hover:text-[#1c1917] transition-colors flex-shrink-0"
+					>
+						{copied ? (
+							<Check className="w-4 h-4 text-[#8161FF]" />
+						) : (
+							<Copy className="w-4 h-4" />
+						)}
+					</button>
+				</div>
 			</div>
-			<p className="mt-3 text-xs leading-relaxed tracking-normal text-[var(--text-secondary)]">
-				Send an email to see it here.
+			<p className="mt-3 text-sm text-[#52525b]">
+				This is a real inbox. Send an email to this address and watch it appear
+				in real-time.
 			</p>
 
 			{emails.length > 0 && (
@@ -105,28 +108,24 @@ export function DemoInbox() {
 								mail.emailId ||
 								`${mail.from}-${mail.timestamp.getTime()}-${mail.subject}`
 							}
-							className="group relative animate-in border-t border-border py-4 duration-300 fade-in slide-in-from-top-2 motion-reduce:animate-none"
+							className="bg-white border border-[#e7e5e4] rounded-xl p-4 animate-in slide-in-from-top-2 fade-in duration-300 relative group"
 						>
 							<button
 								type="button"
 								onClick={() => dismissEmail(i)}
 								aria-label="Dismiss email"
-								className="absolute right-3 top-3 text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)] focus-visible:opacity-100 sm:opacity-0 sm:group-hover:opacity-100"
+								className="absolute top-3 right-3 text-[#a8a29e] hover:text-[#1c1917] transition-colors opacity-0 group-hover:opacity-100"
 							>
 								<X className="w-4 h-4" />
 							</button>
 							<div className="flex items-center gap-2 mb-1">
-								<span className="text-sm font-medium text-[var(--text-primary)]">
+								<span className="text-sm font-medium text-[#1c1917]">
 									{mail.from}
 								</span>
-								<span className="text-xs text-[var(--text-muted)]">
-									just now
-								</span>
+								<span className="text-xs text-[#a8a29e]">just now</span>
 							</div>
-							<p className="text-sm text-[var(--text-secondary)]">
-								{mail.subject}
-							</p>
-							<p className="mt-1 line-clamp-1 text-xs text-[var(--text-muted)]">
+							<p className="text-sm text-[#3f3f46]">{mail.subject}</p>
+							<p className="text-xs text-[#78716c] mt-1 line-clamp-1">
 								{mail.preview}
 							</p>
 						</div>

--- a/components/marketing/control/get-started-tabs.tsx
+++ b/components/marketing/control/get-started-tabs.tsx
@@ -29,9 +29,12 @@ export function GetStartedTabs() {
 
 	return (
 		<div>
-			<div className="flex items-center">
+			<div className="flex items-center justify-between gap-4">
+				<h2 className="font-heading text-lg font-semibold tracking-tight text-[#1c1917]">
+					get started
+				</h2>
 				<div
-					className="flex rounded-lg bg-background p-1"
+					className="flex rounded-lg bg-[#f0efee] p-0.5"
 					role="tablist"
 					aria-label="setup path"
 				>
@@ -40,10 +43,10 @@ export function GetStartedTabs() {
 						role="tab"
 						aria-selected={mode === "agent"}
 						onClick={() => selectMode("agent")}
-						className={`rounded-md px-3.5 py-2 text-sm transition-[background-color,color,box-shadow] ${
+						className={`rounded-[6px] px-3.5 py-2 text-sm transition-[background-color,color,box-shadow] ${
 							mode === "agent"
-								? "bg-card text-[var(--text-primary)] shadow-sm"
-								: "text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+								? "bg-white text-[#1c1917] shadow-sm"
+								: "text-[#78716c] hover:text-[#1c1917]"
 						}`}
 					>
 						agent led
@@ -53,10 +56,10 @@ export function GetStartedTabs() {
 						role="tab"
 						aria-selected={mode === "human"}
 						onClick={() => selectMode("human")}
-						className={`rounded-md px-3.5 py-2 text-sm transition-[background-color,color,box-shadow] ${
+						className={`rounded-[6px] px-3.5 py-2 text-sm transition-[background-color,color,box-shadow] ${
 							mode === "human"
-								? "bg-card text-[var(--text-primary)] shadow-sm"
-								: "text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+								? "bg-white text-[#1c1917] shadow-sm"
+								: "text-[#78716c] hover:text-[#1c1917]"
 						}`}
 					>
 						human led
@@ -69,7 +72,7 @@ export function GetStartedTabs() {
 					<button
 						type="button"
 						onClick={copyContent}
-						className="group mt-5 flex min-h-14 w-full items-center justify-between gap-4 rounded-xl bg-[var(--button-primary-bg)] px-5 text-left text-white transition-[opacity,transform] duration-200 hover:opacity-90 active:scale-[0.99] motion-reduce:transform-none"
+						className="group mt-4 flex min-h-14 w-full items-center justify-between gap-4 rounded-xl bg-[#8161FF] px-5 text-left text-white transition-[background-color,transform] duration-200 ease-[cubic-bezier(0.2,0,0,1)] will-change-transform hover:bg-[#6b4fd9] active:scale-[0.99]"
 					>
 						<span className="flex items-center gap-2.5 font-medium">
 							<Sparkles className="size-4" />
@@ -84,8 +87,8 @@ export function GetStartedTabs() {
 							)}
 						</span>
 					</button>
-					<p className="mt-3 text-sm tracking-normal text-[var(--text-muted)]">
-						Paste into your coding agent.
+					<p className="mt-3 text-sm text-[#78716c]">
+						paste it into opencode, claude code, cursor, or any coding agent.
 					</p>
 				</>
 			) : (
@@ -93,7 +96,7 @@ export function GetStartedTabs() {
 					<button
 						type="button"
 						onClick={copyContent}
-						className="group mt-5 flex min-h-14 w-full items-center justify-between gap-4 rounded-xl bg-sidebar px-5 text-left font-mono text-sm tracking-normal text-white transition-[opacity,transform] duration-200 hover:opacity-90 active:scale-[0.99] motion-reduce:transform-none"
+						className="group mt-4 flex min-h-14 w-full items-center justify-between gap-4 rounded-xl bg-[#1c1917] px-5 text-left font-mono text-sm text-[#fafaf9] transition-[background-color,transform] duration-200 ease-[cubic-bezier(0.2,0,0,1)] will-change-transform hover:bg-[#292524] active:scale-[0.99]"
 					>
 						<span>
 							<span className="text-[#a8a29e]">$ </span>
@@ -108,6 +111,9 @@ export function GetStartedTabs() {
 							)}
 						</span>
 					</button>
+					<p className="mt-3 text-sm text-[#78716c]">
+						install the sdk, then send your first email in five lines of code.
+					</p>
 				</>
 			)}
 		</div>

--- a/components/marketing/control/hero-signup-button.tsx
+++ b/components/marketing/control/hero-signup-button.tsx
@@ -4,7 +4,7 @@ import { authClient } from "@/lib/auth/auth-client";
 
 export function HeroSignupButton() {
 	return (
-		<div>
+		<div className="mt-6">
 			<button
 				type="button"
 				onClick={() =>
@@ -13,12 +13,13 @@ export function HeroSignupButton() {
 						callbackURL: "/logs",
 					})
 				}
-				className="inline-flex min-h-12 items-center gap-2.5 rounded-lg bg-[var(--button-primary-bg)] px-5 text-sm font-medium text-white transition-opacity hover:opacity-90"
+				className="inline-flex items-center gap-1.5 rounded-md border border-[#e5e5e5] bg-white px-3 py-1.5 text-xs font-medium text-[#52525b] transition-colors hover:bg-[#f5f5f5] hover:text-[#1c1917]"
 			>
 				<svg
+					aria-hidden="true"
 					xmlns="http://www.w3.org/2000/svg"
 					viewBox="0 0 24 24"
-					className="size-4 rounded-sm bg-white p-0.5"
+					className="w-3.5 h-3.5"
 				>
 					<path
 						d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
@@ -37,7 +38,7 @@ export function HeroSignupButton() {
 						fill="#EA4335"
 					/>
 				</svg>
-				Start with Google
+				Get started with Google
 			</button>
 		</div>
 	);

--- a/components/marketing/homepage-control.tsx
+++ b/components/marketing/homepage-control.tsx
@@ -1,0 +1,217 @@
+import { BookOpen, Workflow } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import EnvelopeSparkle from "@/components/icons/envelope-sparkle";
+import { DemoInbox } from "@/components/marketing/control/demo-inbox";
+import { GetStartedTabs } from "@/components/marketing/control/get-started-tabs";
+import { HeroSignupButton } from "@/components/marketing/control/hero-signup-button";
+import { MarketingFooter, MarketingNav } from "@/components/marketing-nav";
+import { PricingTable } from "@/components/pricing-table";
+
+export function HomepageControl({ isLoggedIn }: { isLoggedIn: boolean }) {
+	return (
+		<div className="min-h-screen bg-[#fafaf9] text-[#1c1917] selection:bg-[#8161FF] selection:text-white">
+			<div className="bg-[#8161FF] text-white text-center py-2 px-4">
+				<p className="text-sm">
+					<span className="font-medium">Extra domains now just $3.50/mo</span>
+					<span className="opacity-80 ml-1.5">— add as many as you need</span>
+				</p>
+			</div>
+
+			<div className="max-w-2xl mx-auto px-6">
+				<MarketingNav isLoggedIn={isLoggedIn} />
+
+				<section className="pt-20 pb-16">
+					<h1 className="max-w-2xl font-heading text-[32px] leading-[1.2] tracking-tight text-[#1B1917]">
+						email infrastructure built for{" "}
+						<span className="whitespace-nowrap text-[#8161FF]">
+							<EnvelopeSparkle className="inline-block size-8 align-middle" />{" "}
+							agent inboxes,
+						</span>{" "}
+						webhooks, and{" "}
+						<span className="whitespace-nowrap text-[#8161FF]">
+							<Workflow className="inline-block size-7 align-middle" />{" "}
+							automated workflows.
+						</span>
+					</h1>
+					<p className="mt-3 max-w-xl text-base leading-relaxed text-[#52525b]">
+						send, receive, and reply in thread through one simple api & cli.
+					</p>
+
+					{!isLoggedIn && <HeroSignupButton />}
+
+					<DemoInbox />
+				</section>
+
+				<section className="py-12 border-t border-[#e7e5e4]">
+					<GetStartedTabs />
+					<p className="mt-4 text-sm text-[#52525b] flex items-center gap-4">
+						<Link
+							href="/docs"
+							className="text-[#1c1917] hover:underline flex items-center gap-1.5"
+						>
+							<BookOpen className="w-4 h-4" />
+							Read the docs
+						</Link>
+						<span className="text-[#a8a29e]">or</span>
+						<a
+							href="https://github.com/inbound-org"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="text-[#1c1917] hover:underline flex items-center gap-1.5"
+						>
+							<svg
+								aria-hidden="true"
+								className="w-4 h-4"
+								viewBox="0 0 24 24"
+								fill="#000337"
+							>
+								<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+							</svg>
+							view on GitHub
+						</a>
+					</p>
+				</section>
+
+				<section className="py-10 border-t border-[#e7e5e4]">
+					<p className="text-xs text-[#78716c] uppercase tracking-wide mb-6">
+						Trusted by
+					</p>
+					<div className="flex items-center gap-10">
+						<Image
+							src="/images/agentuity.png"
+							alt="Agentuity"
+							width={1040}
+							height={200}
+							className="h-5 w-auto object-contain opacity-70 grayscale hover:opacity-100 hover:grayscale-0 transition-all"
+						/>
+						<Image
+							src="/images/mandarin-3d.png"
+							alt="Mandarin 3D"
+							width={628}
+							height={141}
+							className="h-5 w-auto object-contain opacity-70 grayscale hover:opacity-100 hover:grayscale-0 transition-all"
+						/>
+						<Image
+							src="/images/teslanav.png"
+							alt="TeslaNav"
+							width={487}
+							height={120}
+							className="h-5 w-auto object-contain opacity-70 grayscale hover:opacity-100 hover:grayscale-0 transition-all"
+						/>
+					</div>
+
+					<div className="mt-8 bg-[#fafaf9] rounded-lg">
+						<div className="flex items-start gap-3">
+							<div className="flex-shrink-0 w-10 h-10 bg-[#18181b] rounded-lg flex items-center justify-center">
+								<Image
+									src="/images/linkdr.svg"
+									alt="LinkDR"
+									width={64}
+									height={64}
+									className="h-5 w-5"
+								/>
+							</div>
+							<div>
+								<a
+									href="https://linkdr.com"
+									target="_blank"
+									rel="noopener noreferrer"
+									className="font-medium text-[#18181b] hover:underline"
+								>
+									LinkDR
+								</a>
+								<p className="text-sm text-[#52525b] leading-relaxed">
+									LinkDR uses Inbound to power their internal order management
+									system for backlink management, processing thousands of
+									automated emails daily.
+								</p>
+							</div>
+						</div>
+					</div>
+				</section>
+
+				<section className="py-12 border-t border-[#e7e5e4]">
+					<h2 className="font-heading text-xl font-semibold tracking-tight mb-6">
+						What is Inbound?
+					</h2>
+					<div className="space-y-4 text-[#3f3f46] leading-relaxed">
+						<p>
+							Inbound lets you send and receive emails programmatically. Add
+							your domain, configure your MX records, and you're ready to go.
+							Unlimited mailboxes on that domain, no setup required for each
+							address.
+						</p>
+						<p>
+							Send from any address on your domain. Receive at any address.
+							Route specific addresses to dedicated endpoints, or set up a
+							catch-all that forwards everything to a single webhook. Perfect
+							for support domains that route all incoming mail to an AI agent.
+						</p>
+						<p>
+							Every email preserves threading automatically. Reply
+							programmatically and we handle all the headers so your responses
+							show up in the right thread. It just works.
+						</p>
+					</div>
+
+					<div className="mt-8 space-y-2">
+						<p className="text-xs text-[#78716c] uppercase tracking-wide mb-3">
+							Example routes
+						</p>
+						<div className="font-mono text-sm space-y-1.5">
+							<div className="flex items-center gap-3">
+								<span className="text-[#52525b]">support@acme.com</span>
+								<span className="text-[#a8a29e]">&rarr;</span>
+								<span className="text-[#3f3f46]">/api/support-agent</span>
+							</div>
+							<div className="flex items-center gap-3">
+								<span className="text-[#52525b]">billing@acme.com</span>
+								<span className="text-[#a8a29e]">&rarr;</span>
+								<span className="text-[#3f3f46]">/api/billing</span>
+							</div>
+							<div className="flex items-center gap-3">
+								<span className="text-[#52525b]">*@acme.com</span>
+								<span className="text-[#a8a29e]">&rarr;</span>
+								<span className="text-[#3f3f46]">/api/catch-all</span>
+							</div>
+						</div>
+					</div>
+				</section>
+
+				<PricingTable />
+
+				<section className="py-12 border-t border-[#e7e5e4]">
+					<h2 className="font-heading text-xl font-semibold tracking-tight mb-6">
+						FAQ
+					</h2>
+					<div className="space-y-6">
+						<div>
+							<p className="text-[#1c1917]">Can I use my own domain?</p>
+							<p className="text-sm text-[#52525b] mt-1">
+								Yes. Configure your MX records to point to our servers and you
+								can receive email at any address on your domain.
+							</p>
+						</div>
+						<div>
+							<p className="text-[#1c1917]">How fast are webhooks delivered?</p>
+							<p className="text-sm text-[#52525b] mt-1">
+								Typically under 100ms from when we receive the email. We retry
+								failed webhooks with exponential backoff.
+							</p>
+						</div>
+						<div>
+							<p className="text-[#1c1917]">What about spam filtering?</p>
+							<p className="text-sm text-[#52525b] mt-1">
+								We run incoming email through spam detection. You can choose to
+								reject, flag, or accept spam in your mailbox settings.
+							</p>
+						</div>
+					</div>
+				</section>
+
+				<MarketingFooter />
+			</div>
+		</div>
+	);
+}

--- a/components/marketing/homepage-experiment-tracker.tsx
+++ b/components/marketing/homepage-experiment-tracker.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+	HOMEPAGE_EXPERIMENT_NAME,
+	type HomepageVariant,
+} from "@/lib/homepage-experiment";
+import { trackEvent } from "@/lib/utils/visitors";
+
+export function HomepageExperimentTracker({
+	variant,
+}: {
+	variant: HomepageVariant;
+}) {
+	useEffect(() => {
+		const storageKey = `homepage-experiment-viewed:${HOMEPAGE_EXPERIMENT_NAME}:${variant}`;
+
+		const trackView = () => {
+			if (window.sessionStorage.getItem(storageKey)) {
+				return true;
+			}
+
+			if (!window.visitors) {
+				return false;
+			}
+
+			trackEvent("Homepage Experiment Viewed", {
+				experiment: HOMEPAGE_EXPERIMENT_NAME,
+				homepage_variant: variant,
+			});
+			window.sessionStorage.setItem(storageKey, "1");
+			return true;
+		};
+
+		if (trackView()) {
+			return;
+		}
+
+		let attempts = 0;
+		const interval = window.setInterval(() => {
+			if (trackView() || ++attempts >= 40) {
+				window.clearInterval(interval);
+			}
+		}, 250);
+
+		return () => window.clearInterval(interval);
+	}, [variant]);
+
+	return null;
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -610,6 +610,9 @@ export const sentEmails = pgTable(
 			table.userId,
 			table.firstOpenedAt,
 		),
+		uniqueUserIdempotencyKey: unique(
+			"sent_emails_user_idempotency_key_unique",
+		).on(table.userId, table.idempotencyKey),
 	}),
 );
 

--- a/lib/homepage-experiment.ts
+++ b/lib/homepage-experiment.ts
@@ -1,0 +1,10 @@
+export const HOMEPAGE_EXPERIMENT_COOKIE = "inbound_homepage_variant";
+export const HOMEPAGE_EXPERIMENT_NAME = "homepage-redesign";
+
+export type HomepageVariant = "control" | "redesign";
+
+export function isHomepageVariant(
+	value: string | null | undefined,
+): value is HomepageVariant {
+	return value === "control" || value === "redesign";
+}

--- a/lib/utils/visitors.ts
+++ b/lib/utils/visitors.ts
@@ -1,3 +1,8 @@
+import {
+	HOMEPAGE_EXPERIMENT_COOKIE,
+	isHomepageVariant,
+} from "@/lib/homepage-experiment";
+
 declare global {
 	interface Window {
 		visitors?: {
@@ -20,7 +25,18 @@ export function trackEvent(
 	properties?: Record<string, string | number | boolean | null>,
 ) {
 	if (typeof window !== "undefined" && window.visitors) {
-		window.visitors.track(event, properties);
+		const homepageVariant = document.cookie
+			.split(";")
+			.map((cookie) => cookie.trim())
+			.find((cookie) => cookie.startsWith(`${HOMEPAGE_EXPERIMENT_COOKIE}=`))
+			?.slice(HOMEPAGE_EXPERIMENT_COOKIE.length + 1);
+
+		window.visitors.track(
+			event,
+			isHomepageVariant(homepageVariant)
+				? { homepage_variant: homepageVariant, ...properties }
+				: properties,
+		);
 	}
 }
 

--- a/packages/imap-gateway/bun.lock
+++ b/packages/imap-gateway/bun.lock
@@ -12,7 +12,7 @@
         "libbase64": "^1.3.0",
         "libmime": "^5.3.6",
         "libqp": "^2.1.1",
-        "nodemailer": "^7.0.3",
+        "nodemailer": "^9.0.1",
         "postgres": "^3.4.5",
         "punycode.js": "^2.3.1",
       },
@@ -63,7 +63,7 @@
 
     "libqp": ["libqp@2.1.1", "", {}, "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow=="],
 
-    "nodemailer": ["nodemailer@7.0.13", "", {}, "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw=="],
+    "nodemailer": ["nodemailer@9.0.5", "", {}, "sha512-wvjiKvjczmsN7U/8006JOdXubgBk2XFAbioDMbT+sM7cPs0QrhJTa6KBRX7P5REGGkDcLUz/EarWidb8G8C1jQ=="],
 
     "parseley": ["parseley@0.12.1", "", { "dependencies": { "leac": "^0.6.0", "peberminta": "^0.9.0" } }, "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw=="],
 

--- a/packages/imap-gateway/package.json
+++ b/packages/imap-gateway/package.json
@@ -18,7 +18,7 @@
 		"libbase64": "^1.3.0",
 		"libmime": "^5.3.6",
 		"libqp": "^2.1.1",
-		"nodemailer": "^7.0.3",
+		"nodemailer": "^9.0.1",
 		"postgres": "^3.4.5",
 		"punycode.js": "^2.3.1"
 	},

--- a/packages/imap-gateway/src/auth.test.ts
+++ b/packages/imap-gateway/src/auth.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { ApiAuth } from "./auth.ts";
+import type { ImapConfig } from "./config.ts";
+
+const originalFetch = globalThis.fetch;
+
+const config: ImapConfig = {
+	hostname: "imap.example.com",
+	port: 143,
+	securePort: 993,
+	tlsKeyPath: null,
+	tlsCertPath: null,
+	allowPlaintext: true,
+	databaseUrl: "postgres://localhost/inbound",
+	apiBaseUrl: "https://example.com/api/e2",
+	maxConnections: 200,
+	maxConnectionsPerIp: 20,
+	authFailureLimit: 10,
+	authFailureWindowMs: 900_000,
+	apiTimeoutMs: 20,
+	maxMessageBytes: 1024 * 1024,
+	appendMaxBytesPerUser: 250 * 1024 * 1024,
+	appendMaxMessagesPerUser: 5000,
+};
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+describe("ApiAuth", () => {
+	it("passes an expiring abort signal to the authentication backend", async () => {
+		let signal: AbortSignal | null | undefined;
+		globalThis.fetch = mock(
+			async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+				signal = init?.signal;
+				return new Response(null, { status: 401 });
+			},
+		) as unknown as typeof fetch;
+
+		const result = await new ApiAuth(config).authenticate(
+			"user@example.com",
+			"password",
+		);
+
+		expect(result).toBeNull();
+		expect(signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it("aborts an authentication request that exceeds its configured timeout", async () => {
+		globalThis.fetch = mock(
+			(_input: Parameters<typeof fetch>[0], init?: RequestInit) =>
+				new Promise<Response>((_resolve, reject) => {
+					init?.signal?.addEventListener("abort", () => {
+						reject(init.signal?.reason);
+					});
+				}),
+		) as unknown as typeof fetch;
+
+		await expect(
+			new ApiAuth(config).authenticate("user@example.com", "password"),
+		).rejects.toThrow();
+	});
+});

--- a/packages/imap-gateway/src/auth.ts
+++ b/packages/imap-gateway/src/auth.ts
@@ -33,6 +33,7 @@ export class ApiAuth {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ loginAddress: address, password }),
+				signal: AbortSignal.timeout(this.config.apiTimeoutMs),
 			},
 		);
 		if (response.status === 401 || response.status === 403) return null;

--- a/packages/imap-gateway/src/auth.ts
+++ b/packages/imap-gateway/src/auth.ts
@@ -35,7 +35,10 @@ export class ApiAuth {
 				body: JSON.stringify({ loginAddress: address, password }),
 			},
 		);
-		if (!response.ok) return null;
+		if (response.status === 401 || response.status === 403) return null;
+		if (!response.ok) {
+			throw new Error(`Authentication backend returned ${response.status}`);
+		}
 		return (await response.json()) as AuthenticatedMailbox;
 	}
 }

--- a/packages/imap-gateway/src/config.test.ts
+++ b/packages/imap-gateway/src/config.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { loadConfig } from "./config.ts";
+
+const originalEnvironment = { ...process.env };
+
+afterEach(() => {
+	for (const key of Object.keys(process.env)) {
+		if (!(key in originalEnvironment)) delete process.env[key];
+	}
+	Object.assign(process.env, originalEnvironment);
+});
+
+describe("loadConfig", () => {
+	it("uses safe defaults and accepts valid paired TLS settings", () => {
+		process.env.DATABASE_URL = "postgres://localhost/inbound";
+		process.env.IMAP_TLS_KEY_PATH = "/certs/key.pem";
+		process.env.IMAP_TLS_CERT_PATH = "/certs/cert.pem";
+		process.env.IMAP_API_TIMEOUT_MS = "2500";
+		process.env.IMAP_MAX_MESSAGE_BYTES = "524288";
+		process.env.IMAP_PORT = "1143";
+
+		const config = loadConfig();
+		expect(config.port).toBe(1143);
+		expect(config.apiTimeoutMs).toBe(2500);
+		expect(config.maxMessageBytes).toBe(524288);
+		expect(config.tlsKeyPath).toBe("/certs/key.pem");
+		expect(config.tlsCertPath).toBe("/certs/cert.pem");
+	});
+
+	it.each([
+		"0",
+		"-1",
+		"1.5",
+		"NaN",
+	])("rejects invalid positive integer settings: %s", (value) => {
+		process.env.DATABASE_URL = "postgres://localhost/inbound";
+		delete process.env.IMAP_TLS_KEY_PATH;
+		delete process.env.IMAP_TLS_CERT_PATH;
+		process.env.IMAP_API_TIMEOUT_MS = value;
+		expect(loadConfig).toThrow(
+			"IMAP_API_TIMEOUT_MS must be a positive integer",
+		);
+	});
+
+	it("defaults APPEND messages to 1 MiB", () => {
+		process.env.DATABASE_URL = "postgres://localhost/inbound";
+		delete process.env.IMAP_TLS_KEY_PATH;
+		delete process.env.IMAP_TLS_CERT_PATH;
+		delete process.env.IMAP_MAX_MESSAGE_BYTES;
+		expect(loadConfig().maxMessageBytes).toBe(1024 * 1024);
+	});
+
+	it("accepts the maximum supported authentication timeout", () => {
+		process.env.DATABASE_URL = "postgres://localhost/inbound";
+		delete process.env.IMAP_TLS_KEY_PATH;
+		delete process.env.IMAP_TLS_CERT_PATH;
+		process.env.IMAP_API_TIMEOUT_MS = "2147483647";
+		expect(loadConfig().apiTimeoutMs).toBe(2_147_483_647);
+	});
+
+	it("rejects authentication timeouts outside AbortSignal's supported range", () => {
+		process.env.DATABASE_URL = "postgres://localhost/inbound";
+		delete process.env.IMAP_TLS_KEY_PATH;
+		delete process.env.IMAP_TLS_CERT_PATH;
+		process.env.IMAP_API_TIMEOUT_MS = "2147483648";
+		expect(loadConfig).toThrow(
+			"IMAP_API_TIMEOUT_MS must be a positive integer",
+		);
+	});
+
+	it("rejects invalid APPEND message limits", () => {
+		process.env.DATABASE_URL = "postgres://localhost/inbound";
+		delete process.env.IMAP_TLS_KEY_PATH;
+		delete process.env.IMAP_TLS_CERT_PATH;
+		process.env.IMAP_MAX_MESSAGE_BYTES = "0";
+		expect(loadConfig).toThrow(
+			"IMAP_MAX_MESSAGE_BYTES must be a positive integer",
+		);
+	});
+
+	it("rejects out-of-range ports", () => {
+		process.env.DATABASE_URL = "postgres://localhost/inbound";
+		delete process.env.IMAP_TLS_KEY_PATH;
+		delete process.env.IMAP_TLS_CERT_PATH;
+		process.env.IMAP_PORT = "65536";
+		expect(loadConfig).toThrow("IMAP_PORT must be a positive integer");
+	});
+
+	it("requires both TLS certificate and key paths", () => {
+		process.env.DATABASE_URL = "postgres://localhost/inbound";
+		process.env.IMAP_TLS_KEY_PATH = "/certs/key.pem";
+		delete process.env.IMAP_TLS_CERT_PATH;
+		expect(loadConfig).toThrow(
+			"IMAP_TLS_KEY_PATH and IMAP_TLS_CERT_PATH must both be set",
+		);
+	});
+});

--- a/packages/imap-gateway/src/config.ts
+++ b/packages/imap-gateway/src/config.ts
@@ -11,27 +11,46 @@ export interface ImapConfig {
 	maxConnectionsPerIp: number;
 	authFailureLimit: number;
 	authFailureWindowMs: number;
+	apiTimeoutMs: number;
+	maxMessageBytes: number;
 	appendMaxBytesPerUser: number;
 	appendMaxMessagesPerUser: number;
 }
 
-function envNumber(name: string, fallback: number): number {
+function envNumber(name: string, fallback: number, maximum?: number): number {
 	const value = process.env[name];
 	if (!value) return fallback;
 	const parsed = Number(value);
-	return Number.isFinite(parsed) ? parsed : fallback;
+	if (
+		!Number.isSafeInteger(parsed) ||
+		parsed <= 0 ||
+		(maximum !== undefined && parsed > maximum)
+	) {
+		throw new Error(
+			`${name} must be a positive integer${maximum ? ` no greater than ${maximum}` : ""}`,
+		);
+	}
+	return parsed;
 }
 
 export function loadConfig(): ImapConfig {
 	const databaseUrl = process.env.DATABASE_URL;
 	if (!databaseUrl) throw new Error("DATABASE_URL is required");
 
+	const tlsKeyPath = process.env.IMAP_TLS_KEY_PATH ?? null;
+	const tlsCertPath = process.env.IMAP_TLS_CERT_PATH ?? null;
+	if (Boolean(tlsKeyPath) !== Boolean(tlsCertPath)) {
+		throw new Error(
+			"IMAP_TLS_KEY_PATH and IMAP_TLS_CERT_PATH must both be set",
+		);
+	}
+
 	return {
 		hostname: process.env.IMAP_HOSTNAME ?? "imap.inboundemail.com",
-		port: envNumber("IMAP_PORT", 143),
-		securePort: envNumber("IMAP_SECURE_PORT", 993),
-		tlsKeyPath: process.env.IMAP_TLS_KEY_PATH ?? null,
-		tlsCertPath: process.env.IMAP_TLS_CERT_PATH ?? null,
+		port: envNumber("IMAP_PORT", 143, 65_535),
+		securePort: envNumber("IMAP_SECURE_PORT", 993, 65_535),
+		tlsKeyPath,
+		tlsCertPath,
 		allowPlaintext: process.env.IMAP_ALLOW_PLAINTEXT === "true",
 		databaseUrl,
 		apiBaseUrl: (
@@ -41,6 +60,8 @@ export function loadConfig(): ImapConfig {
 		maxConnectionsPerIp: envNumber("IMAP_MAX_CONNECTIONS_PER_IP", 20),
 		authFailureLimit: envNumber("IMAP_AUTH_FAILURE_LIMIT", 10),
 		authFailureWindowMs: envNumber("IMAP_AUTH_FAILURE_WINDOW_MS", 15 * 60_000),
+		apiTimeoutMs: envNumber("IMAP_API_TIMEOUT_MS", 10_000, 2_147_483_647),
+		maxMessageBytes: envNumber("IMAP_MAX_MESSAGE_BYTES", 1024 * 1024),
 		appendMaxBytesPerUser: envNumber(
 			"IMAP_APPEND_MAX_BYTES_PER_USER",
 			250 * 1024 * 1024,

--- a/packages/imap-gateway/src/db.test.ts
+++ b/packages/imap-gateway/src/db.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "bun:test";
+import type { AuthenticatedMailbox } from "./auth.ts";
+import { type MailboxRow, MailStore } from "./db.ts";
+
+interface SqlRequest {
+	statement: string;
+	values: unknown[];
+}
+
+interface SqlStub {
+	<T extends readonly object[]>(
+		strings: TemplateStringsArray,
+		...values: unknown[]
+	): Promise<T>;
+	begin: <T>(callback: (transaction: SqlStub) => Promise<T>) => Promise<T>;
+}
+
+const principal: AuthenticatedMailbox = {
+	userId: "user",
+	credentialId: "credential",
+	loginAddress: "user@example.com",
+	accessMode: "read_write",
+	scopes: [
+		{
+			id: "address-scope",
+			type: "address",
+			domainId: "domain",
+			domain: "example.com",
+			address: "User@Example.com",
+		},
+		{
+			id: "domain-scope",
+			type: "domain",
+			domainId: "domain",
+			domain: "Example.com",
+			address: null,
+		},
+	],
+};
+
+const mailbox: MailboxRow = {
+	id: "inbox",
+	address: "user@example.com",
+	path: "INBOX",
+	uidValidity: 1,
+	uidNext: 1,
+	modseq: 0,
+	credentialId: "credential",
+	scopeId: null,
+};
+
+function createStore(): { store: MailStore; requests: SqlRequest[] } {
+	const requests: SqlRequest[] = [];
+	async function execute<T extends readonly object[]>(
+		strings: TemplateStringsArray,
+		...values: unknown[]
+	): Promise<T> {
+		const statement = strings.join("?");
+		requests.push({ statement, values });
+		if (statement.includes("SELECT uid_next, modseq")) {
+			return [{ uid_next: 1, modseq: 0 }] as unknown as T;
+		}
+		if (statement.includes("SELECT raw_content")) {
+			return [{ raw_content: "message" }] as unknown as T;
+		}
+		return [] as unknown as T;
+	}
+	const sql: SqlStub = Object.assign(execute, {
+		begin: <T>(callback: (transaction: SqlStub) => Promise<T>) => callback(sql),
+	});
+	const store = new MailStore("postgres://localhost/inbound", {
+		appendMaxBytesPerUser: 1024,
+		appendMaxMessagesPerUser: 10,
+	});
+	Object.assign(store, { sql });
+	return { store, requests };
+}
+
+describe("MailStore Guard and scope enforcement", () => {
+	it.each([
+		"credential",
+		"",
+	])("excludes Guard-blocked messages from sync for credential mode %s", async (credentialId) => {
+		const { store, requests } = createStore();
+		await store.syncMailbox(mailbox, { ...principal, credentialId });
+		const sync = requests.find((request) =>
+			request.statement.includes("WITH new_msgs AS"),
+		);
+		expect(sync?.statement).toContain("se.guard_blocked IS NOT TRUE");
+	});
+
+	it("restricts structured raw content to unblocked, currently authorized scopes", async () => {
+		const { store, requests } = createStore();
+		expect(await store.getRawContent("message", "structured", principal)).toBe(
+			"message",
+		);
+		const request = requests[0];
+		expect(request?.statement).toContain("guard_blocked IS NOT TRUE");
+		expect(request?.statement).toContain("lower(recipient) = ANY");
+		expect(request?.values).toContainEqual(["user@example.com"]);
+		expect(request?.values).toContainEqual(["example.com"]);
+	});
+
+	it("preserves appended-message ownership checks without applying structured scopes", async () => {
+		const { store, requests } = createStore();
+		expect(await store.getRawContent("message", "appended", principal)).toBe(
+			"message",
+		);
+		expect(requests[0]?.statement).toContain("FROM imap_appended_messages");
+		expect(requests[0]?.statement).not.toContain("guard_blocked");
+		expect(requests[0]?.values).toContain("user");
+	});
+
+	it("reconciles structured mappings in every credential-owned folder when scopes are revoked", async () => {
+		const { store, requests } = createStore();
+		await store.ensureScopeMailboxes({ ...principal, scopes: [] });
+		const reconciliation = requests.find((request) =>
+			request.statement.includes("DELETE FROM imap_mailbox_messages mm"),
+		);
+		expect(reconciliation?.statement).not.toContain("mb.path = 'INBOX'");
+		expect(reconciliation?.statement).toContain("mb.credential_id = ?");
+		expect(reconciliation?.statement).toContain("mb.user_id = ?");
+		expect(reconciliation?.statement).toContain("mm.raw_source = 'structured'");
+		expect(reconciliation?.statement).not.toContain(
+			"mm.raw_source = 'appended'",
+		);
+		expect(reconciliation?.statement).toContain("se.guard_blocked IS TRUE");
+		expect(reconciliation?.values).toContain("credential");
+		expect(reconciliation?.values).toContain("user");
+		expect(
+			requests.some((request) =>
+				request.statement.includes("DELETE FROM structured_emails"),
+			),
+		).toBe(false);
+	});
+});

--- a/packages/imap-gateway/src/db.ts
+++ b/packages/imap-gateway/src/db.ts
@@ -141,6 +141,12 @@ export class MailStore {
 		principal: AuthenticatedMailbox,
 	): Promise<MailboxRow[]> {
 		const scopeIds = principal.scopes.map((scope) => scope.id);
+		const addresses = principal.scopes
+			.filter((scope) => scope.type === "address" && scope.address)
+			.map((scope) => scope.address?.toLowerCase() ?? "");
+		const domains = principal.scopes
+			.filter((scope) => scope.type === "domain")
+			.map((scope) => scope.domain.toLowerCase());
 		await this.sql.begin(async (sql) => {
 			const stale = await sql<{ id: string }[]>`
 				SELECT id FROM imap_mailboxes
@@ -149,13 +155,32 @@ export class MailStore {
 				  AND NOT (scope_id = ANY(${scopeIds}))
 				FOR UPDATE`;
 			const staleIds = stale.map((row) => row.id);
-			if (staleIds.length === 0) return;
+			if (staleIds.length > 0) {
+				await sql`
+					DELETE FROM imap_mailbox_messages
+					WHERE mailbox_id = ANY(${staleIds})`;
+				await sql`
+					DELETE FROM imap_mailboxes
+					WHERE id = ANY(${staleIds})`;
+			}
 			await sql`
-				DELETE FROM imap_mailbox_messages
-				WHERE mailbox_id = ANY(${staleIds})`;
-			await sql`
-				DELETE FROM imap_mailboxes
-				WHERE id = ANY(${staleIds})`;
+				DELETE FROM imap_mailbox_messages mm
+				USING imap_mailboxes mb, structured_emails se
+				WHERE mm.mailbox_id = mb.id
+				  AND mb.credential_id = ${principal.credentialId}
+				  AND mb.user_id = ${principal.userId}
+				  AND mm.raw_source = 'structured'
+				  AND se.id = mm.structured_email_id
+				  AND (
+					se.guard_blocked IS TRUE
+					OR NOT (
+						lower(se.recipient) = ANY(${addresses})
+						OR (
+							split_part(lower(se.recipient), '@', 2) = ANY(${domains})
+							AND split_part(lower(se.recipient), '@', 1) <> 'dmarc'
+						)
+					)
+				  )`;
 		});
 		const result: MailboxRow[] = [];
 		for (const scope of principal.scopes) {
@@ -438,10 +463,10 @@ export class MailStore {
 		const scopes = scope ? [scope] : principal.scopes;
 		const addresses = scopes
 			.filter((item) => item.type === "address" && item.address)
-			.map((item) => item.address as string);
+			.map((item) => item.address?.toLowerCase() ?? "");
 		const domains = scopes
 			.filter((item) => item.type === "domain")
-			.map((item) => item.domain);
+			.map((item) => item.domain.toLowerCase());
 		if (addresses.length === 0 && domains.length === 0) return 0;
 
 		return this.sql.begin(async (sql) => {
@@ -457,6 +482,7 @@ export class MailStore {
 						       row_number() OVER (ORDER BY se.created_at ASC, se.id ASC) AS rn
 						FROM structured_emails se
 						WHERE se.user_id = ${principal.userId}
+						  AND se.guard_blocked IS NOT TRUE
 						  AND se.raw_content IS NOT NULL
 						  AND (
 							lower(se.recipient) = ANY(${addresses})
@@ -484,6 +510,7 @@ export class MailStore {
 					       row_number() OVER (ORDER BY se.created_at ASC, se.id ASC) AS rn
 					FROM structured_emails se
 					WHERE se.user_id = ${principal.userId}
+					  AND se.guard_blocked IS NOT TRUE
 					  AND lower(se.recipient) = ${principal.loginAddress.toLowerCase()}
 					  AND se.raw_content IS NOT NULL
 					  AND NOT EXISTS (
@@ -624,16 +651,42 @@ export class MailStore {
 	async getRawContent(
 		messageId: string,
 		rawSource: string,
-		userId: string,
+		principal: AuthenticatedMailbox,
 	): Promise<string | null> {
-		const rows =
-			rawSource === "appended"
-				? await this.sql<{ raw_content: string | null }[]>`
-					SELECT raw_content FROM imap_appended_messages
-					WHERE id = ${messageId} AND user_id = ${userId} LIMIT 1`
-				: await this.sql<{ raw_content: string | null }[]>`
-					SELECT raw_content FROM structured_emails
-					WHERE id = ${messageId} AND user_id = ${userId} LIMIT 1`;
+		if (rawSource === "appended") {
+			const rows = await this.sql<{ raw_content: string | null }[]>`
+				SELECT raw_content FROM imap_appended_messages
+				WHERE id = ${messageId} AND user_id = ${principal.userId} LIMIT 1`;
+			return rows[0]?.raw_content ?? null;
+		}
+
+		const addresses = principal.scopes
+			.filter((scope) => scope.type === "address" && scope.address)
+			.map((scope) => scope.address?.toLowerCase() ?? "");
+		const domains = principal.scopes
+			.filter((scope) => scope.type === "domain")
+			.map((scope) => scope.domain.toLowerCase());
+		const rows = principal.credentialId
+			? await this.sql<{ raw_content: string | null }[]>`
+				SELECT raw_content FROM structured_emails
+				WHERE id = ${messageId}
+				  AND user_id = ${principal.userId}
+				  AND guard_blocked IS NOT TRUE
+				  AND (
+					lower(recipient) = ANY(${addresses})
+					OR (
+						split_part(lower(recipient), '@', 2) = ANY(${domains})
+						AND split_part(lower(recipient), '@', 1) <> 'dmarc'
+					)
+				  )
+				LIMIT 1`
+			: await this.sql<{ raw_content: string | null }[]>`
+				SELECT raw_content FROM structured_emails
+				WHERE id = ${messageId}
+				  AND user_id = ${principal.userId}
+				  AND guard_blocked IS NOT TRUE
+				  AND lower(recipient) = ${principal.loginAddress.toLowerCase()}
+				LIMIT 1`;
 		return rows[0]?.raw_content ?? null;
 	}
 

--- a/packages/imap-gateway/src/db.ts
+++ b/packages/imap-gateway/src/db.ts
@@ -460,7 +460,10 @@ export class MailStore {
 						  AND se.raw_content IS NOT NULL
 						  AND (
 							lower(se.recipient) = ANY(${addresses})
-							OR split_part(lower(se.recipient), '@', 2) = ANY(${domains})
+							OR (
+								split_part(lower(se.recipient), '@', 2) = ANY(${domains})
+								AND split_part(lower(se.recipient), '@', 1) <> 'dmarc'
+							)
 						  )
 						  AND NOT EXISTS (
 							SELECT 1 FROM imap_mailbox_messages mm

--- a/packages/imap-gateway/src/handlers.test.ts
+++ b/packages/imap-gateway/src/handlers.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { ApiAuth, AuthenticatedMailbox } from "./auth.ts";
+import type { MailboxRow, MailStore } from "./db.ts";
+import { buildHandlers } from "./handlers.ts";
+import type { ConnectionLimits } from "./limits.ts";
+
+type Handlers = ReturnType<typeof buildHandlers>;
+type Session = Parameters<Handlers["onOpen"]>[1];
+
+function createHarness(
+	accessMode: AuthenticatedMailbox["accessMode"],
+	scopeId: string | null = null,
+) {
+	const mailbox: MailboxRow = {
+		id: scopeId ? "scope-mailbox" : "inbox",
+		address: "user@example.com",
+		path: scopeId ? "Scopes/user@example.com" : "INBOX",
+		uidValidity: 1,
+		uidNext: 2,
+		modseq: 1,
+		credentialId: "credential",
+		scopeId,
+	};
+	const destination: MailboxRow = {
+		...mailbox,
+		id: "destination",
+		path: "Archive",
+		scopeId: null,
+	};
+	const store = {
+		ensureDefaultMailboxes: mock(async () => [mailbox]),
+		ensureScopeMailboxes: mock(async () => []),
+		getMailboxByPath: mock(
+			async (_principal: AuthenticatedMailbox, path: string) =>
+				path === "Archive" ? destination : mailbox,
+		),
+		syncMailbox: mock(async () => 0),
+		listUids: mock(async () => [1]),
+		listMessages: mock(async () => [
+			{
+				uid: 1,
+				structuredEmailId: "message",
+				rawSource: "structured",
+				flags: [],
+				internalDate: new Date(),
+				size: 10,
+			},
+		]),
+		addFlag: mock(async () => undefined),
+		updateFlags: mock(async () => []),
+		expunge: mock(async () => []),
+		copyMessages: mock(async () => ({
+			uidValidity: 1,
+			sourceUid: [1],
+			destinationUid: [1],
+		})),
+		deleteMessages: mock(async () => undefined),
+		appendMessage: mock(async () => ({ uidValidity: 1, uid: 1 })),
+	};
+	const handlers = buildHandlers(
+		{} as ApiAuth,
+		store as unknown as MailStore,
+		{} as ConnectionLimits,
+	);
+	const session: Session = {
+		user: {
+			id: "user",
+			userId: "user",
+			credentialId: "credential",
+			loginAddress: "user@example.com",
+			username: "user@example.com",
+			address: "user@example.com",
+			accessMode,
+			scopes: scopeId
+				? [
+						{
+							id: scopeId,
+							type: "address",
+							domainId: "domain",
+							domain: "example.com",
+							address: "user@example.com",
+						},
+					]
+				: [],
+		},
+		selected: {
+			mailbox: mailbox.id,
+			path: mailbox.path,
+			readOnly: Boolean(scopeId),
+		},
+		formatResponse: () => ({ tag: "*", command: "FETCH", attributes: [] }),
+		getQueryResponse: () => [],
+		isUTF8Enabled: () => false,
+		writeStream: {
+			write: (_chunk, done) => done?.(),
+		},
+	};
+	return { handlers, mailbox, session, store };
+}
+
+function callbackResult(
+	invoke: (
+		callback: (error: Error | null, ...result: unknown[]) => void,
+	) => void,
+): Promise<unknown[]> {
+	return new Promise((resolve, reject) => {
+		invoke((error, ...result) => {
+			if (error) reject(error);
+			else resolve(result);
+		});
+	});
+}
+
+describe("IMAP backend authorization", () => {
+	it.each([
+		["read", null],
+		["read_write", "scope"],
+	] as const)("opens %s credentials and scope folders read-only", async (mode, scopeId) => {
+		const { handlers, mailbox, session } = createHarness(mode, scopeId);
+		const [selected] = await callbackResult((callback) => {
+			handlers.onOpen(mailbox.path, session, callback);
+		});
+		expect(selected).toMatchObject({ readOnly: true });
+	});
+
+	it("rejects STORE, EXPUNGE, and MOVE from read-only scope folders", async () => {
+		const { handlers, mailbox, session, store } = createHarness(
+			"read_write",
+			"scope",
+		);
+		const [stored] = await callbackResult((callback) => {
+			handlers.onStore(
+				mailbox.id,
+				{
+					value: ["\\Seen"],
+					action: "add",
+					silent: false,
+					messages: [1],
+					unchangedSince: 0,
+				},
+				session,
+				callback,
+			);
+		});
+		const [expunged] = await callbackResult((callback) => {
+			handlers.onExpunge(mailbox.id, { isUid: false }, session, callback);
+		});
+		const [moved] = await callbackResult((callback) => {
+			handlers.onMove(
+				mailbox.id,
+				{ destination: "Archive", messages: [1] },
+				session,
+				callback,
+			);
+		});
+
+		expect([stored, expunged, moved]).toEqual([
+			"READ-ONLY",
+			"READ-ONLY",
+			"READ-ONLY",
+		]);
+		expect(store.updateFlags).not.toHaveBeenCalled();
+		expect(store.expunge).not.toHaveBeenCalled();
+		expect(store.copyMessages).not.toHaveBeenCalled();
+	});
+
+	it("fails closed when selected mailbox does not match the mutation source", async () => {
+		const { handlers, mailbox, session, store } = createHarness("read_write");
+		session.selected = {
+			mailbox: "different-mailbox",
+			path: "Archive",
+			readOnly: false,
+		};
+		const [stored] = await callbackResult((callback) => {
+			handlers.onStore(
+				mailbox.id,
+				{
+					value: ["\\Seen"],
+					action: "add",
+					silent: false,
+					messages: [1],
+					unchangedSince: 0,
+				},
+				session,
+				callback,
+			);
+		});
+		const [expunged] = await callbackResult((callback) => {
+			handlers.onExpunge(mailbox.id, { isUid: false }, session, callback);
+		});
+		const [moved] = await callbackResult((callback) => {
+			handlers.onMove(
+				mailbox.id,
+				{ destination: "Archive", messages: [1] },
+				session,
+				callback,
+			);
+		});
+
+		expect([stored, expunged, moved]).toEqual([
+			"READ-ONLY",
+			"READ-ONLY",
+			"READ-ONLY",
+		]);
+		expect(store.updateFlags).not.toHaveBeenCalled();
+		expect(store.expunge).not.toHaveBeenCalled();
+		expect(store.copyMessages).not.toHaveBeenCalled();
+	});
+
+	it("does not mark messages seen for a mismatched selected mailbox", async () => {
+		const { handlers, mailbox, session, store } = createHarness("read_write");
+		session.selected = {
+			mailbox: "different-mailbox",
+			path: "Archive",
+			readOnly: false,
+		};
+		const [success] = await callbackResult((callback) => {
+			handlers.onFetch(
+				mailbox.id,
+				{
+					messages: [1],
+					query: [{ item: "flags" }],
+					metadataOnly: true,
+					markAsSeen: true,
+					isUid: true,
+				},
+				session,
+				callback,
+			);
+		});
+
+		expect(success).toBe(true);
+		expect(store.addFlag).not.toHaveBeenCalled();
+	});
+
+	it("rejects mutations without a selected mailbox", async () => {
+		const { handlers, mailbox, session, store } = createHarness("read_write");
+		session.selected = false;
+		const [result] = await callbackResult((callback) => {
+			handlers.onExpunge(mailbox.id, { isUid: false }, session, callback);
+		});
+
+		expect(result).toBe("READ-ONLY");
+		expect(store.expunge).not.toHaveBeenCalled();
+	});
+
+	it("allows CLOSE to expunge an independently verified writable mailbox", async () => {
+		const { handlers, mailbox, session, store } = createHarness("read_write");
+		session.selected = false;
+		const [result] = await callbackResult((callback) => {
+			handlers.onExpunge(
+				mailbox.id,
+				{ isUid: false, silent: true, path: mailbox.path },
+				session,
+				callback,
+			);
+		});
+
+		expect(result).toBe(true);
+		expect(store.getMailboxByPath).toHaveBeenCalledTimes(1);
+		expect(store.expunge).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects CLOSE-style expunges of scoped or mismatched mailboxes", async () => {
+		const scoped = createHarness("read_write", "scope");
+		scoped.session.selected = false;
+		const [scopeResult] = await callbackResult((callback) => {
+			scoped.handlers.onExpunge(
+				scoped.mailbox.id,
+				{ isUid: false, silent: true, path: scoped.mailbox.path },
+				scoped.session,
+				callback,
+			);
+		});
+		const writable = createHarness("read_write");
+		writable.session.selected = false;
+		const [mismatchResult] = await callbackResult((callback) => {
+			writable.handlers.onExpunge(
+				writable.mailbox.id,
+				{ isUid: false, silent: true, path: "Archive" },
+				writable.session,
+				callback,
+			);
+		});
+
+		expect(scopeResult).toBe("READ-ONLY");
+		expect(mismatchResult).toBe("READ-ONLY");
+		expect(scoped.store.expunge).not.toHaveBeenCalled();
+		expect(writable.store.expunge).not.toHaveBeenCalled();
+	});
+
+	it("preserves COPY from a read-only source into a writable destination", async () => {
+		const { handlers, mailbox, session, store } = createHarness(
+			"read_write",
+			"scope",
+		);
+		const [success] = await callbackResult((callback) => {
+			handlers.onCopy(
+				null,
+				mailbox.id,
+				{ destination: "Archive", messages: [1] },
+				session,
+				callback,
+			);
+		});
+
+		expect(success).toBe(true);
+		expect(store.copyMessages).toHaveBeenCalledTimes(1);
+	});
+
+	it("preserves APPEND to a writable destination while a read-only folder is selected", async () => {
+		const { handlers, session, store } = createHarness("read_write", "scope");
+		const [success] = await callbackResult((callback) => {
+			handlers.onAppend(
+				"Archive",
+				[],
+				undefined,
+				Buffer.from("Subject: test\r\n\r\nbody"),
+				session,
+				callback,
+			);
+		});
+
+		expect(success).toBe(true);
+		expect(store.appendMessage).toHaveBeenCalledTimes(1);
+	});
+
+	it.each([
+		["read", null],
+		["read_write", "scope"],
+	] as const)("never marks messages seen for %s read-only selections", async (mode, scopeId) => {
+		const { handlers, mailbox, session, store } = createHarness(mode, scopeId);
+		const [success] = await callbackResult((callback) => {
+			handlers.onFetch(
+				mailbox.id,
+				{
+					messages: [1],
+					query: [{ item: "flags" }],
+					metadataOnly: true,
+					markAsSeen: true,
+					isUid: true,
+				},
+				session,
+				callback,
+			);
+		});
+
+		expect(success).toBe(true);
+		expect(store.addFlag).not.toHaveBeenCalled();
+	});
+});

--- a/packages/imap-gateway/src/handlers.ts
+++ b/packages/imap-gateway/src/handlers.ts
@@ -101,21 +101,21 @@ export function buildHandlers(
 
 		onAuth(authData: AuthData, _session: ImapSession, callback: Callback) {
 			const ip = _session.remoteAddress ?? "unknown";
-			const limited = limits.assertAuthAllowed(ip);
-			if (limited) return callback(limited);
 			const address = authData.username.trim().toLowerCase();
+			const limited = limits.assertAuthAllowed(ip, address);
+			if (limited) return callback(null);
 			if (!address.includes("@") || !authData.password) {
-				limits.recordAuthFailure(ip);
-				return callback(new Error("Invalid credentials"));
+				limits.recordAuthFailure(ip, address);
+				return callback(null);
 			}
 			auth
 				.authenticate(address, authData.password)
 				.then((result) => {
 					if (!result) {
-						limits.recordAuthFailure(ip);
-						return callback(new Error("Invalid credentials"));
+						limits.recordAuthFailure(ip, address);
+						return callback(null);
 					}
-					limits.recordAuthSuccess(ip);
+					limits.recordAuthSuccess(ip, address);
 					callback(null, {
 						user: {
 							...result,

--- a/packages/imap-gateway/src/handlers.ts
+++ b/packages/imap-gateway/src/handlers.ts
@@ -35,6 +35,13 @@ interface ImapSession {
 		address: string;
 	};
 	remoteAddress?: string;
+	selected?:
+		| {
+				mailbox?: string;
+				path?: string;
+				readOnly?: boolean;
+		  }
+		| false;
 	formatResponse: (command: string, uid: number, data: unknown) => unknown;
 	getQueryResponse: (
 		query: unknown,
@@ -94,6 +101,16 @@ export function buildHandlers(
 		const user = session.user;
 		if (!user?.address) throw new Error("Not authenticated");
 		return user;
+	}
+
+	function sourceIsReadOnly(session: ImapSession, mailboxId: string): boolean {
+		const selected = session.selected;
+		return (
+			!selected ||
+			selected.mailbox !== mailboxId ||
+			Boolean(selected.readOnly) ||
+			Boolean(selected.path?.startsWith("Scopes/"))
+		);
 	}
 
 	return {
@@ -199,7 +216,9 @@ export function buildHandlers(
 						modifyIndex: fresh?.modseq ?? mailbox.modseq,
 						uidList,
 						flags: [],
-						readOnly: Boolean(mailbox.scopeId),
+						readOnly:
+							Boolean(mailbox.scopeId) ||
+							requireUser(session).accessMode !== "read_write",
 					});
 				})
 				.catch((err: Error) => callback(err));
@@ -293,6 +312,9 @@ export function buildHandlers(
 				await store.ensureDefaultMailboxes(user);
 				const mailbox = await store.getMailboxByPath(user, path);
 				if (!mailbox) return { success: "TRYCREATE" as const, info: null };
+				if (mailbox.scopeId) {
+					return { success: "READ-ONLY" as const, info: null };
+				}
 				const date = internaldate ? new Date(internaldate) : new Date();
 				const info = await store.appendMessage(
 					mailbox,
@@ -331,6 +353,9 @@ export function buildHandlers(
 					update.destination,
 				);
 				if (!destination) return { success: "TRYCREATE" as const, info: null };
+				if (destination.scopeId) {
+					return { success: "READ-ONLY" as const, info: null };
+				}
 				const info = await store.copyMessages(
 					mailboxId,
 					destination,
@@ -352,6 +377,7 @@ export function buildHandlers(
 				const user = requireUser(session);
 				if (
 					user.accessMode !== "read_write" ||
+					sourceIsReadOnly(session, mailboxId) ||
 					update.destination.startsWith("Scopes/")
 				)
 					return { success: "READ-ONLY" as const, info: null };
@@ -360,6 +386,9 @@ export function buildHandlers(
 					update.destination,
 				);
 				if (!destination) return { success: "TRYCREATE" as const, info: null };
+				if (destination.scopeId) {
+					return { success: "READ-ONLY" as const, info: null };
+				}
 				const info = await store.copyMessages(
 					mailboxId,
 					destination,
@@ -389,13 +418,17 @@ export function buildHandlers(
 						raw = await store.getRawContent(
 							row.structuredEmailId,
 							row.rawSource,
-							requireUser(session).userId,
+							requireUser(session),
 						);
 						if (!raw) continue;
 					}
 
 					const flags = [...row.flags];
-					const markAsSeen = options.markAsSeen && !flags.includes("\\Seen");
+					const markAsSeen =
+						options.markAsSeen &&
+						requireUser(session).accessMode === "read_write" &&
+						!sourceIsReadOnly(session, mailboxId) &&
+						!flags.includes("\\Seen");
 					if (markAsSeen) flags.unshift("\\Seen");
 
 					const messageData = {
@@ -456,7 +489,10 @@ export function buildHandlers(
 			_session: ImapSession,
 			callback: Callback,
 		) {
-			if (requireUser(_session).accessMode !== "read_write") {
+			if (
+				requireUser(_session).accessMode !== "read_write" ||
+				sourceIsReadOnly(_session, mailboxId)
+			) {
 				return callback(null, "READ-ONLY", []);
 			}
 			store
@@ -467,16 +503,34 @@ export function buildHandlers(
 
 		onExpunge(
 			mailboxId: string,
-			update: { isUid: boolean; messages?: number[] },
+			update: {
+				isUid: boolean;
+				messages?: number[];
+				silent?: boolean;
+				path?: string;
+			},
 			_session: ImapSession,
 			callback: Callback,
 		) {
-			if (requireUser(_session).accessMode !== "read_write") {
-				return callback(null, "READ-ONLY");
-			}
-			store
-				.expunge(mailboxId, update.isUid ? (update.messages ?? []) : undefined)
-				.then(() => callback(null, true))
+			(async () => {
+				const user = requireUser(_session);
+				if (user.accessMode !== "read_write") return "READ-ONLY";
+				if (sourceIsReadOnly(_session, mailboxId)) {
+					if (_session.selected || update.silent !== true || !update.path) {
+						return "READ-ONLY";
+					}
+					const mailbox = await store.getMailboxByPath(user, update.path);
+					if (!mailbox || mailbox.id !== mailboxId || mailbox.scopeId) {
+						return "READ-ONLY";
+					}
+				}
+				await store.expunge(
+					mailboxId,
+					update.isUid ? (update.messages ?? []) : undefined,
+				);
+				return true;
+			})()
+				.then((result) => callback(null, result))
 				.catch((err: Error) => callback(err));
 		},
 	};

--- a/packages/imap-gateway/src/index.ts
+++ b/packages/imap-gateway/src/index.ts
@@ -41,6 +41,7 @@ const tls =
 		? {
 				key: readFileSync(config.tlsKeyPath),
 				cert: readFileSync(config.tlsCertPath),
+				minVersion: "TLSv1.2" as const,
 			}
 		: null;
 
@@ -59,6 +60,7 @@ function startServer(secure: boolean, port: number) {
 		ignoreSTARTTLS: !tls,
 		useProxy: false,
 		maxConnections: config.maxConnections,
+		maxMessage: config.maxMessageBytes,
 		...(tls ?? {}),
 		...(tls
 			? {
@@ -105,8 +107,8 @@ function startServer(secure: boolean, port: number) {
 		console.error("[imap-gateway] server error", err);
 	});
 
+	server.server.maxConnections = config.maxConnections;
 	server.listen(port, () => {
-		server.server.maxConnections = config.maxConnections;
 		console.log(
 			`[imap-gateway] ${config.hostname} listening on :${port} (${secure ? "TLS" : "plaintext dev"})`,
 		);
@@ -114,8 +116,37 @@ function startServer(secure: boolean, port: number) {
 	return server;
 }
 
-if (tls) startServer(true, config.securePort);
-if (config.allowPlaintext) startServer(false, config.port);
+const servers: Array<{ close: (callback: () => void) => void }> = [];
+if (tls) servers.push(startServer(true, config.securePort));
+if (config.allowPlaintext) servers.push(startServer(false, config.port));
 
-process.on("SIGTERM", () => process.exit(0));
-process.on("SIGINT", () => process.exit(0));
+let shuttingDown = false;
+function shutdown(): void {
+	if (shuttingDown) return;
+	shuttingDown = true;
+	clearInterval(orphanCleanup);
+	const shutdownTimeout = setTimeout(() => {
+		console.error("[imap-gateway] graceful shutdown timed out");
+		process.exit(1);
+	}, 10_000);
+	shutdownTimeout.unref();
+	Promise.all([
+		...servers.map(
+			(server) => new Promise<void>((resolve) => server.close(resolve)),
+		),
+		notifier.stop(),
+	])
+		.then(() => store.end())
+		.then(() => {
+			clearTimeout(shutdownTimeout);
+			process.exit(0);
+		})
+		.catch((err: Error) => {
+			clearTimeout(shutdownTimeout);
+			console.error("[imap-gateway] graceful shutdown failed", err.message);
+			process.exit(1);
+		});
+}
+
+process.once("SIGTERM", shutdown);
+process.once("SIGINT", shutdown);

--- a/packages/imap-gateway/src/limits.test.ts
+++ b/packages/imap-gateway/src/limits.test.ts
@@ -15,13 +15,26 @@ describe("ConnectionLimits", () => {
 		expect(limits.onConnect(third)).toBeNull();
 	});
 
-	it("blocks repeated authentication failures and clears on success", () => {
+	it("isolates authentication failures by IP and username", () => {
 		const limits = new ConnectionLimits(2, 2, 60_000);
-		limits.recordAuthFailure("192.0.2.2");
-		expect(limits.assertAuthAllowed("192.0.2.2")).toBeNull();
-		limits.recordAuthFailure("192.0.2.2");
-		expect(limits.assertAuthAllowed("192.0.2.2")).toBeInstanceOf(Error);
-		limits.recordAuthSuccess("192.0.2.2");
-		expect(limits.assertAuthAllowed("192.0.2.2")).toBeNull();
+		limits.recordAuthFailure("192.0.2.2", "first@example.com");
+		expect(
+			limits.assertAuthAllowed("192.0.2.2", "first@example.com"),
+		).toBeNull();
+		limits.recordAuthFailure("192.0.2.2", "first@example.com");
+		expect(
+			limits.assertAuthAllowed("192.0.2.2", "first@example.com"),
+		).toBeInstanceOf(Error);
+		expect(
+			limits.assertAuthAllowed("192.0.2.2", "second@example.com"),
+		).toBeNull();
+		limits.recordAuthSuccess("192.0.2.2", "second@example.com");
+		expect(
+			limits.assertAuthAllowed("192.0.2.2", "first@example.com"),
+		).toBeInstanceOf(Error);
+		limits.recordAuthSuccess("192.0.2.2", "first@example.com");
+		expect(
+			limits.assertAuthAllowed("192.0.2.2", "first@example.com"),
+		).toBeNull();
 	});
 });

--- a/packages/imap-gateway/src/limits.test.ts
+++ b/packages/imap-gateway/src/limits.test.ts
@@ -15,6 +15,116 @@ describe("ConnectionLimits", () => {
 		expect(limits.onConnect(third)).toBeNull();
 	});
 
+	it("blocks username spraying after the higher aggregate IP threshold", () => {
+		const limits = new ConnectionLimits(2, 2, 60_000);
+		for (let index = 0; index < 9; index++) {
+			limits.recordAuthFailure("192.0.2.3", `user-${index}@example.com`);
+		}
+		expect(
+			limits.assertAuthAllowed("192.0.2.3", "fresh@example.com"),
+		).toBeNull();
+		limits.recordAuthFailure("192.0.2.3", "last@example.com");
+		expect(
+			limits.assertAuthAllowed("192.0.2.3", "fresh@example.com"),
+		).toBeInstanceOf(Error);
+		limits.recordAuthSuccess("192.0.2.3", "last@example.com");
+		expect(
+			limits.assertAuthAllowed("192.0.2.3", "fresh@example.com"),
+		).toBeInstanceOf(Error);
+		expect(
+			limits.assertAuthAllowed("192.0.2.4", "fresh@example.com"),
+		).toBeNull();
+	});
+
+	it("expires account and aggregate failure windows", async () => {
+		const limits = new ConnectionLimits(2, 1, 1);
+		for (let index = 0; index < 5; index++) {
+			limits.recordAuthFailure("192.0.2.5", `user-${index}@example.com`);
+		}
+		expect(
+			limits.assertAuthAllowed("192.0.2.5", "fresh@example.com"),
+		).toBeInstanceOf(Error);
+		await Bun.sleep(5);
+		expect(
+			limits.assertAuthAllowed("192.0.2.5", "fresh@example.com"),
+		).toBeNull();
+		expect(
+			limits.assertAuthAllowed("192.0.2.5", "user-0@example.com"),
+		).toBeNull();
+	});
+
+	it("preserves blocked account records and fails closed at capacity", () => {
+		const limits = new ConnectionLimits(2, 2, 60_000, 3);
+		limits.recordAuthFailure("192.0.2.10", "blocked@example.com");
+		limits.recordAuthFailure("192.0.2.10", "blocked@example.com");
+		limits.recordAuthFailure("192.0.2.11", "first@example.com");
+		limits.recordAuthFailure("192.0.2.12", "second@example.com");
+		limits.recordAuthFailure("192.0.2.13", "attacker@example.com");
+
+		expect(
+			limits.assertAuthAllowed("192.0.2.10", "blocked@example.com"),
+		).toBeInstanceOf(Error);
+		expect(
+			limits.assertAuthAllowed("192.0.2.13", "attacker@example.com"),
+		).toBeInstanceOf(Error);
+		const records = limits as unknown as {
+			failures: Map<string, unknown>;
+			ipFailures: Map<string, unknown>;
+		};
+		expect(records.failures.has("192.0.2.10\0blocked@example.com")).toBe(true);
+		expect(records.failures.size).toBe(3);
+		expect(records.ipFailures.size).toBe(3);
+	});
+
+	it("preserves blocked aggregate IP records when the IP map is full", () => {
+		const limits = new ConnectionLimits(2, 1, 60_000, 3);
+		for (let index = 0; index < 5; index++) {
+			limits.recordAuthFailure("192.0.2.20", "blocked@example.com");
+		}
+		limits.recordAuthFailure("192.0.2.21", "first@example.com");
+		limits.recordAuthFailure("192.0.2.22", "second@example.com");
+		limits.recordAuthFailure("192.0.2.23", "attacker@example.com");
+
+		expect(
+			limits.assertAuthAllowed("192.0.2.20", "fresh@example.com"),
+		).toBeInstanceOf(Error);
+		expect(
+			limits.assertAuthAllowed("192.0.2.23", "attacker@example.com"),
+		).toBeInstanceOf(Error);
+	});
+
+	it("reuses expired failure slots without evicting active records", async () => {
+		const limits = new ConnectionLimits(2, 2, 1, 1);
+		limits.recordAuthFailure("192.0.2.30", "expired@example.com");
+		expect(
+			limits.assertAuthAllowed("192.0.2.31", "fresh@example.com"),
+		).toBeInstanceOf(Error);
+		await Bun.sleep(5);
+		expect(
+			limits.assertAuthAllowed("192.0.2.31", "fresh@example.com"),
+		).toBeNull();
+		limits.recordAuthFailure("192.0.2.31", "fresh@example.com");
+		const records = limits as unknown as { failures: Map<string, unknown> };
+		expect(records.failures.has("192.0.2.31\0fresh@example.com")).toBe(true);
+	});
+
+	it("rejects failure-map capacities above the hard maximum", () => {
+		expect(() => new ConnectionLimits(2, 2, 60_000, 10_001)).toThrow();
+	});
+
+	it("bounds account and IP failure maps to 10,000 entries", () => {
+		const limits = new ConnectionLimits(2, 2, 60_000);
+		for (let index = 0; index < 10_005; index++) {
+			limits.recordAuthFailure(`192.0.2.${index}`, `user-${index}@example.com`);
+		}
+		const records = limits as unknown as {
+			failures: Map<string, unknown>;
+			ipFailures: Map<string, unknown>;
+		};
+		expect(records.failures.size).toBe(10_000);
+		expect(records.ipFailures.size).toBe(10_000);
+	});
+
 	it("isolates authentication failures by IP and username", () => {
 		const limits = new ConnectionLimits(2, 2, 60_000);
 		limits.recordAuthFailure("192.0.2.2", "first@example.com");

--- a/packages/imap-gateway/src/limits.ts
+++ b/packages/imap-gateway/src/limits.ts
@@ -11,14 +11,31 @@ export class ConnectionLimits {
 	private perIp = new Map<string, number>();
 	private accepted = new WeakSet<object>();
 	private failures = new Map<string, FailureRecord>();
+	private ipFailures = new Map<string, FailureRecord>();
 	private maxPerIp: number;
 	private failureLimit: number;
 	private failureWindowMs: number;
+	private maxFailureRecords: number;
 
-	constructor(maxPerIp: number, failureLimit: number, failureWindowMs: number) {
+	constructor(
+		maxPerIp: number,
+		failureLimit: number,
+		failureWindowMs: number,
+		maxFailureRecords = 10_000,
+	) {
+		if (
+			!Number.isSafeInteger(maxFailureRecords) ||
+			maxFailureRecords <= 0 ||
+			maxFailureRecords > 10_000
+		) {
+			throw new Error(
+				"Authentication failure record cap must be between 1 and 10,000",
+			);
+		}
 		this.maxPerIp = maxPerIp;
 		this.failureLimit = failureLimit;
 		this.failureWindowMs = failureWindowMs;
+		this.maxFailureRecords = maxFailureRecords;
 	}
 
 	onConnect(session: ConnectionSession): Error | null {
@@ -42,30 +59,32 @@ export class ConnectionLimits {
 	}
 
 	assertAuthAllowed(ip: string, username: string): Error | null {
-		const key = this.authKey(ip, username);
-		const record = this.failures.get(key);
-		if (!record) return null;
-		if (Date.now() - record.windowStart > this.failureWindowMs) {
-			this.failures.delete(key);
-			return null;
-		}
-		if (record.count >= this.failureLimit) {
+		const now = Date.now();
+		const account = this.getActiveFailure(
+			this.failures,
+			this.authKey(ip, username),
+			now,
+		);
+		const aggregate = this.getActiveFailure(this.ipFailures, ip, now);
+		if (
+			(account && account.count >= this.failureLimit) ||
+			(aggregate && aggregate.count >= this.failureLimit * 5)
+		) {
 			return new Error("Too many failed authentication attempts");
+		}
+		if (
+			(!account && !this.hasFailureCapacity(this.failures, now)) ||
+			(!aggregate && !this.hasFailureCapacity(this.ipFailures, now))
+		) {
+			return new Error("Authentication failure tracking is at capacity");
 		}
 		return null;
 	}
 
 	recordAuthFailure(ip: string, username: string): void {
 		const now = Date.now();
-		const key = this.authKey(ip, username);
-		const record = this.failures.get(key);
-		if (!record || now - record.windowStart > this.failureWindowMs) {
-			this.failures.set(key, { count: 1, windowStart: now });
-		} else {
-			record.count++;
-		}
-
-		if (this.failures.size > 10_000) this.sweepFailures(now);
+		this.incrementFailure(this.failures, this.authKey(ip, username), now);
+		this.incrementFailure(this.ipFailures, ip, now);
 	}
 
 	recordAuthSuccess(ip: string, username: string): void {
@@ -76,11 +95,45 @@ export class ConnectionLimits {
 		return `${ip}\0${username}`;
 	}
 
-	private sweepFailures(now: number): void {
-		for (const [ip, record] of this.failures) {
-			if (now - record.windowStart > this.failureWindowMs) {
-				this.failures.delete(ip);
-			}
+	private getActiveFailure(
+		records: Map<string, FailureRecord>,
+		key: string,
+		now: number,
+	): FailureRecord | undefined {
+		const record = records.get(key);
+		if (record && now - record.windowStart > this.failureWindowMs) {
+			records.delete(key);
+			return undefined;
 		}
+		return record;
+	}
+
+	private hasFailureCapacity(
+		records: Map<string, FailureRecord>,
+		now: number,
+	): boolean {
+		if (records.size < this.maxFailureRecords) return true;
+		while (records.size >= this.maxFailureRecords) {
+			const oldest = records.entries().next().value;
+			if (!oldest || now - oldest[1].windowStart <= this.failureWindowMs) {
+				return false;
+			}
+			records.delete(oldest[0]);
+		}
+		return true;
+	}
+
+	private incrementFailure(
+		records: Map<string, FailureRecord>,
+		key: string,
+		now: number,
+	): void {
+		const record = this.getActiveFailure(records, key, now);
+		if (record) {
+			record.count++;
+			return;
+		}
+		if (!this.hasFailureCapacity(records, now)) return;
+		records.set(key, { count: 1, windowStart: now });
 	}
 }

--- a/packages/imap-gateway/src/limits.ts
+++ b/packages/imap-gateway/src/limits.ts
@@ -41,11 +41,12 @@ export class ConnectionLimits {
 		else this.perIp.set(ip, current - 1);
 	}
 
-	assertAuthAllowed(ip: string): Error | null {
-		const record = this.failures.get(ip);
+	assertAuthAllowed(ip: string, username: string): Error | null {
+		const key = this.authKey(ip, username);
+		const record = this.failures.get(key);
 		if (!record) return null;
 		if (Date.now() - record.windowStart > this.failureWindowMs) {
-			this.failures.delete(ip);
+			this.failures.delete(key);
 			return null;
 		}
 		if (record.count >= this.failureLimit) {
@@ -54,11 +55,12 @@ export class ConnectionLimits {
 		return null;
 	}
 
-	recordAuthFailure(ip: string): void {
+	recordAuthFailure(ip: string, username: string): void {
 		const now = Date.now();
-		const record = this.failures.get(ip);
+		const key = this.authKey(ip, username);
+		const record = this.failures.get(key);
 		if (!record || now - record.windowStart > this.failureWindowMs) {
-			this.failures.set(ip, { count: 1, windowStart: now });
+			this.failures.set(key, { count: 1, windowStart: now });
 		} else {
 			record.count++;
 		}
@@ -66,8 +68,12 @@ export class ConnectionLimits {
 		if (this.failures.size > 10_000) this.sweepFailures(now);
 	}
 
-	recordAuthSuccess(ip: string): void {
-		this.failures.delete(ip);
+	recordAuthSuccess(ip: string, username: string): void {
+		this.failures.delete(this.authKey(ip, username));
+	}
+
+	private authKey(ip: string, username: string): string {
+		return `${ip}\0${username}`;
 	}
 
 	private sweepFailures(now: number): void {

--- a/packages/imap-gateway/src/protocol.test.ts
+++ b/packages/imap-gateway/src/protocol.test.ts
@@ -1,0 +1,502 @@
+import { describe, expect, it } from "bun:test";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+interface ProtocolResponse {
+	response: string;
+	code?: string;
+	message?: string;
+}
+
+interface CommandModule {
+	handler: (
+		this: object,
+		command: {
+			command: string;
+			attributes: Array<
+				| { value: string; type?: string }
+				| Array<{ value: string; type?: string }>
+			>;
+		},
+		callback: (error: Error | null, response: ProtocolResponse) => void,
+	) => void;
+}
+
+const tlsOptions = require("../vendor/imap-core/lib/tls-options.js") as (
+	options?: object,
+) => { minVersion: string };
+const imapTools = require("../vendor/imap-core/lib/imap-tools.js") as {
+	sendCapabilityResponse: (connection: object) => void;
+	generateFolderListing: (
+		folders: Array<{ path: string; flags: string[] }>,
+	) => Array<{ path: string; flags: string[] }>;
+};
+
+function runCommand(name: string, commandName = name): ProtocolResponse {
+	const command = require(
+		`../vendor/imap-core/lib/commands/${name}.js`,
+	) as CommandModule;
+	let response: ProtocolResponse | undefined;
+	command.handler.call(
+		{
+			_server: {
+				options: {},
+				onStore: () => undefined,
+				onMove: () => undefined,
+				onExpunge: () => undefined,
+			},
+			selected: { readOnly: true },
+		},
+		{ command: commandName, attributes: [{ value: "DEFLATE" }] },
+		(_error, result) => {
+			response = result;
+		},
+	);
+	if (!response) throw new Error("Command did not produce a response");
+	return response;
+}
+
+describe("IMAP protocol hardening", () => {
+	it("requires TLS 1.2 by default", () => {
+		expect(tlsOptions().minVersion).toBe("TLSv1.2");
+	});
+
+	it.each([
+		["store", "STORE"],
+		["uid-store", "UID STORE"],
+		["move", "MOVE"],
+		["move", "UID MOVE"],
+		["expunge", "EXPUNGE"],
+		["uid-expunge", "UID EXPUNGE"],
+	])("rejects %s on read-only mailboxes", (module, command) => {
+		expect(runCommand(module, command)).toMatchObject({
+			response: "NO",
+			code: "READ-ONLY",
+		});
+	});
+
+	it("rejects compression unless explicitly enabled", () => {
+		expect(runCommand("compress", "COMPRESS")).toMatchObject({
+			response: "NO",
+			code: "CANNOT",
+		});
+	});
+
+	it.each([
+		"Not Authenticated",
+		"Authenticated",
+	])("advertises supported capabilities and the APPEND limit in %s state", (state) => {
+		let response = "";
+		imapTools.sendCapabilityResponse({
+			secure: true,
+			state,
+			_server: { options: { maxMessage: 1024 * 1024 } },
+			send: (value: string) => {
+				response = value;
+			},
+		});
+		expect(response).toContain("APPENDLIMIT=1048576");
+		expect(response).not.toContain("CONDSTORE");
+		expect(response).not.toContain("AUTH=PLAIN-CLIENTTOKEN");
+		if (state === "Not Authenticated") {
+			expect(response).toContain("AUTH=PLAIN");
+		}
+		expect(response).not.toContain("QUOTA");
+		expect(response).not.toContain("COMPRESS=DEFLATE");
+	});
+
+	it("rejects direct PLAIN-CLIENTTOKEN handler invocation without logging secrets", () => {
+		const authenticate =
+			require("../vendor/imap-core/lib/commands/authenticate-plain.js") as CommandModule;
+		const clientToken = "private-client-token";
+		const encoded = Buffer.from(
+			`\0user@example.com\0private-password\0${clientToken}`,
+		).toString("base64");
+		const logs: unknown[][] = [];
+		let authCalled = false;
+		let response: ProtocolResponse | undefined;
+		authenticate.handler.call(
+			{
+				secure: true,
+				_server: {
+					options: {},
+					onAuth: () => {
+						authCalled = true;
+					},
+					logger: { info: (...values: unknown[]) => logs.push(values) },
+				},
+			},
+			{
+				command: "AUTHENTICATE PLAIN-CLIENTTOKEN",
+				attributes: [{ value: encoded }],
+			},
+			(_error, result) => {
+				response = result;
+			},
+		);
+
+		expect(response).toMatchObject({ response: "BAD" });
+		expect(authCalled).toBe(false);
+		expect(JSON.stringify(logs)).not.toContain(clientToken);
+		expect(JSON.stringify(logs)).not.toContain(encoded);
+	});
+
+	it("preserves AUTH PLAIN and useful logging without exposing credentials", () => {
+		const authenticate =
+			require("../vendor/imap-core/lib/commands/authenticate-plain.js") as CommandModule;
+		const password = "private-password";
+		const encoded = Buffer.from(`\0user@example.com\0${password}`).toString(
+			"base64",
+		);
+		const logs: unknown[][] = [];
+		const session: { user?: { id: string }; clientId?: object } = {};
+		let credentials: Record<string, unknown> | undefined;
+		let response: ProtocolResponse | undefined;
+		authenticate.handler.call(
+			{
+				id: "connection",
+				secure: true,
+				state: "Not Authenticated",
+				session,
+				_server: {
+					options: {},
+					logger: { info: (...values: unknown[]) => logs.push(values) },
+					onAuth: (
+						input: Record<string, unknown>,
+						_session: object,
+						callback: (error: null, result: { user: { id: string } }) => void,
+					) => {
+						credentials = input;
+						callback(null, { user: { id: "user" } });
+					},
+				},
+				setUser: (user: { id: string }) => {
+					session.user = user;
+				},
+				setupNotificationListener: () => undefined,
+				send: () => undefined,
+			},
+			{ command: "AUTHENTICATE PLAIN", attributes: [{ value: encoded }] },
+			(_error, result) => {
+				response = result;
+			},
+		);
+
+		expect(response).toMatchObject({ response: "OK" });
+		expect(credentials).toMatchObject({
+			method: "PLAIN",
+			username: "user@example.com",
+			password,
+		});
+		expect(credentials).not.toHaveProperty("clientToken");
+		expect(logs[0]?.[0]).toMatchObject({
+			username: "user@example.com",
+			method: "PLAIN",
+			action: "success",
+		});
+		expect(JSON.stringify(logs)).not.toContain(password);
+		expect(JSON.stringify(logs)).not.toContain(encoded);
+	});
+
+	it("rejects unregistered CLIENTTOKEN commands without logging their payload", () => {
+		const { IMAPCommand } =
+			require("../vendor/imap-core/lib/imap-command.js") as {
+				IMAPCommand: new (
+					connection: object,
+				) => {
+					append: (
+						command: { value: string; literal: boolean; expecting: number },
+						callback: (error?: Error) => void,
+					) => void;
+				};
+			};
+		const clientToken = "private-client-token";
+		const encoded = Buffer.from(
+			`\0user@example.com\0private-password\0${clientToken}`,
+		).toString("base64");
+		const logs: Array<Record<string, unknown>> = [];
+		const responses: string[] = [];
+		const parser = new IMAPCommand({
+			loggelf: (entry: Record<string, unknown>) => logs.push(entry),
+			send: (value: string) => responses.push(value),
+		});
+		let error: Error | undefined;
+		parser.append(
+			{
+				value: `A1 AUTHENTICATE PLAIN-CLIENTTOKEN ${encoded}`,
+				literal: false,
+				expecting: 0,
+			},
+			(result) => {
+				error = result;
+			},
+		);
+
+		expect(error).toBeInstanceOf(Error);
+		expect(responses[0]).toContain("BAD Unknown command");
+		expect(logs[0]).toMatchObject({
+			_command: "AUTHENTICATE PLAIN-CLIENTTOKEN",
+			_payload: false,
+		});
+		expect(JSON.stringify(logs)).not.toContain(clientToken);
+		expect(JSON.stringify(logs)).not.toContain(encoded);
+	});
+
+	it("advertises the configured APPEND limit rather than a fixed default", () => {
+		let response = "";
+		imapTools.sendCapabilityResponse({
+			secure: true,
+			state: "Authenticated",
+			_server: { options: { maxMessage: 512 } },
+			send: (value: string) => {
+				response = value;
+			},
+		});
+		expect(response).toContain("APPENDLIMIT=512");
+	});
+
+	it("ignores ENABLE CONDSTORE while preserving ENABLE UTF8=ACCEPT", () => {
+		const enable =
+			require("../vendor/imap-core/lib/commands/enable.js") as CommandModule;
+		const sent: string[] = [];
+		const connection: {
+			condstoreEnabled?: boolean;
+			acceptUTF8Enabled?: boolean;
+			send: (value: string) => void;
+		} = {
+			send: (value) => sent.push(value),
+		};
+		enable.handler.call(
+			connection,
+			{
+				command: "ENABLE",
+				attributes: [{ value: "CONDSTORE" }, { value: "UTF8=ACCEPT" }],
+			},
+			() => undefined,
+		);
+
+		expect(connection.condstoreEnabled).not.toBe(true);
+		expect(connection.acceptUTF8Enabled).toBe(true);
+		expect(sent).toEqual(["* ENABLED UTF8=ACCEPT"]);
+	});
+
+	it("preserves the selected mailbox path when CLOSE deselects before expunging", () => {
+		const close =
+			require("../vendor/imap-core/lib/commands/close.js") as CommandModule;
+		const selected = { mailbox: "inbox", path: "INBOX", readOnly: false };
+		const session: { selected: typeof selected | false } = { selected };
+		let expunge: { mailbox?: string; path?: string; silent?: boolean } = {};
+		close.handler.call(
+			{
+				selected,
+				session,
+				_server: {
+					onExpunge: (
+						mailbox: string,
+						update: { path: string; silent: boolean },
+						_session: object,
+						callback: () => void,
+					) => {
+						expunge = { mailbox, ...update };
+						callback();
+					},
+				},
+			},
+			{ command: "CLOSE", attributes: [] },
+			() => undefined,
+		);
+
+		expect(session.selected).toBe(false);
+		expect(expunge).toMatchObject({
+			mailbox: "inbox",
+			path: "INBOX",
+			silent: true,
+		});
+	});
+
+	it("rejects CONDSTORE selection and HIGHESTMODSEQ status requests", () => {
+		const select =
+			require("../vendor/imap-core/lib/commands/select.js") as CommandModule;
+		let selectResponse: ProtocolResponse | undefined;
+		select.handler.call(
+			{},
+			{
+				command: "SELECT",
+				attributes: [{ value: "INBOX" }, [{ value: "CONDSTORE" }]],
+			},
+			(_error, response) => {
+				selectResponse = response;
+			},
+		);
+
+		const status =
+			require("../vendor/imap-core/lib/commands/status.js") as CommandModule;
+		let statusResponse: ProtocolResponse | undefined;
+		status.handler.call(
+			{ _server: { onStatus: () => undefined } },
+			{
+				command: "STATUS",
+				attributes: [{ value: "INBOX" }, [{ value: "HIGHESTMODSEQ" }]],
+			},
+			(_error, response) => {
+				statusResponse = response;
+			},
+		);
+
+		expect(selectResponse).toMatchObject({ response: "BAD" });
+		expect(statusResponse).toMatchObject({ response: "BAD" });
+	});
+
+	it("rejects implicit CONDSTORE activation through STORE, FETCH, and SEARCH", () => {
+		for (const [module, commandName] of [
+			["store", "STORE"],
+			["uid-store", "UID STORE"],
+		] as const) {
+			const command = require(
+				`../vendor/imap-core/lib/commands/${module}.js`,
+			) as CommandModule;
+			let response: ProtocolResponse | undefined;
+			command.handler.call(
+				{
+					_server: { onStore: () => undefined },
+					selected: { readOnly: false, uidList: [1] },
+				},
+				{
+					command: commandName,
+					attributes: [
+						{ value: "1" },
+						[{ value: "UNCHANGEDSINCE" }, { value: "1" }],
+						{ value: "+FLAGS" },
+						[{ value: "\\Seen" }],
+					],
+				},
+				(_error, result) => {
+					response = result;
+				},
+			);
+			expect(response).toMatchObject({ response: "BAD" });
+		}
+
+		const fetch =
+			require("../vendor/imap-core/lib/commands/fetch.js") as CommandModule;
+		for (const attributes of [
+			[
+				{ value: "1" },
+				[{ value: "FLAGS", type: "ATOM" }],
+				[{ value: "CHANGEDSINCE" }, { value: "1" }],
+			],
+			[{ value: "1" }, [{ value: "MODSEQ", type: "ATOM" }]],
+		]) {
+			let response: ProtocolResponse | undefined;
+			fetch.handler.call(
+				{
+					_server: { onFetch: () => undefined },
+					selected: { readOnly: false, uidList: [1] },
+				},
+				{ command: "FETCH", attributes },
+				(_error, result) => {
+					response = result;
+				},
+			);
+			expect(response).toMatchObject({ response: "BAD" });
+		}
+
+		const search =
+			require("../vendor/imap-core/lib/commands/search.js") as CommandModule;
+		let searchResponse: ProtocolResponse | undefined;
+		search.handler.call(
+			{
+				_server: { onSearch: () => undefined },
+				selected: { uidList: [1] },
+			},
+			{
+				command: "SEARCH",
+				attributes: [{ value: "MODSEQ" }, { value: "1" }],
+			},
+			(_error, response) => {
+				searchResponse = response;
+			},
+		);
+		expect(searchResponse).toMatchObject({ response: "BAD" });
+	});
+
+	it("enforces configured APPEND limits smaller than the historical default", () => {
+		const { IMAPCommand } =
+			require("../vendor/imap-core/lib/imap-command.js") as {
+				IMAPCommand: new (
+					connection: object,
+				) => {
+					append: (
+						command: { value: string; literal: boolean; expecting: number },
+						callback: (error?: Error) => void,
+					) => void;
+				};
+			};
+		const responses: string[] = [];
+		const parser = new IMAPCommand({
+			_server: { options: { maxMessage: 512 } },
+			logger: { debug: () => undefined },
+			loggelf: () => undefined,
+			send: (value: string) => responses.push(value),
+		});
+		let error: Error | undefined;
+		parser.append(
+			{ value: "A1 APPEND INBOX {513}", literal: true, expecting: 513 },
+			(result) => {
+				error = result;
+			},
+		);
+
+		expect(error).toBeInstanceOf(Error);
+		expect(responses[0]).toContain("maximum allowed is 512 bytes");
+	});
+
+	it("does not emit unsupported HIGHESTMODSEQ data during SELECT", () => {
+		const select =
+			require("../vendor/imap-core/lib/commands/select.js") as CommandModule;
+		const responses: string[] = [];
+		select.handler.call(
+			{
+				_server: {
+					onOpen: (
+						_path: string,
+						_session: object,
+						callback: (error: null, mailbox: object) => void,
+					) => {
+						callback(null, {
+							_id: "inbox",
+							uidList: [1],
+							uidValidity: 1,
+							uidNext: 2,
+							modifyIndex: 1,
+							flags: [],
+							readOnly: false,
+						});
+					},
+				},
+				session: { user: { id: "user" }, commandCounters: { SELECT: 0 } },
+				send: (response: string | Buffer) => {
+					responses.push(response.toString());
+				},
+			},
+			{ command: "SELECT", attributes: [{ value: "INBOX" }] },
+			() => undefined,
+		);
+		expect(responses.join("\n")).not.toContain("HIGHESTMODSEQ");
+	});
+
+	it("preserves folder flags provided by backend handlers", () => {
+		const folders = imapTools.generateFolderListing([
+			{ path: "Scopes", flags: ["\\Noselect", "\\HasChildren"] },
+			{ path: "Scopes/user@example.com", flags: ["\\NoInferiors"] },
+		]);
+		expect(folders.find((folder) => folder.path === "Scopes")?.flags).toContain(
+			"\\Noselect",
+		);
+		expect(
+			folders.find((folder) => folder.path === "Scopes/user@example.com")
+				?.flags,
+		).toContain("\\NoInferiors");
+	});
+});

--- a/packages/imap-gateway/vendor/imap-core/lib/commands/authenticate-plain.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/commands/authenticate-plain.js
@@ -16,7 +16,12 @@ module.exports = {
     handler(command, callback, next) {
         let token = ((command.attributes && command.attributes[0] && command.attributes[0].value) || '').toString().trim();
 
-        let requireClientToken = (command.command || '').toString().toUpperCase() === 'AUTHENTICATE PLAIN-CLIENTTOKEN' ? true : false;
+        if ((command.command || '').toString().toUpperCase() !== 'AUTHENTICATE PLAIN') {
+            return callback(null, {
+                response: 'BAD',
+                message: 'Unsupported authentication mechanism'
+            });
+        }
 
         if (!this.secure && !this._server.options.disableSTARTTLS && !this._server.options.ignoreSTARTTLS) {
             // Only allow authentication using TLS
@@ -38,20 +43,20 @@ module.exports = {
             this._nextHandler = (token, next) => {
                 this._nextHandler = false;
                 next(); // keep the parser flowing
-                authenticate(this, token, requireClientToken, callback);
+                authenticate(this, token, callback);
             };
             this.send('+');
             return next(); // resume input parser. Normally this is done by callback() but we need the next input sooner
         }
 
-        authenticate(this, token, requireClientToken, callback);
+        authenticate(this, token, callback);
     }
 };
 
-function authenticate(connection, token, requireClientToken, callback) {
+function authenticate(connection, token, callback) {
     let data = Buffer.from(token, 'base64').toString().split('\x00');
 
-    if ((!requireClientToken && data.length !== 3) || (requireClientToken && data.length !== 4)) {
+    if (data.length !== 3) {
         return callback(null, {
             response: 'BAD',
             message: 'Invalid SASL argument'
@@ -60,7 +65,6 @@ function authenticate(connection, token, requireClientToken, callback) {
 
     let username = (data[1] || '').toString().trim();
     let password = (data[2] || '').toString().trim();
-    let clientToken = (data[3] || '').toString().trim() || false;
 
     // Do auth
     connection._server.onAuth(
@@ -68,7 +72,6 @@ function authenticate(connection, token, requireClientToken, callback) {
             method: 'PLAIN',
             username,
             password,
-            clientToken,
             connection
         },
         connection.session,
@@ -119,14 +122,12 @@ function authenticate(connection, token, requireClientToken, callback) {
                     username,
                     method: 'PLAIN',
                     action: 'success',
-                    cid: connection.id,
-                    clientToken
+                    cid: connection.id
                 },
-                '[%s] %s authenticated using %s%s',
+                '[%s] %s authenticated using %s',
                 connection.id,
                 username,
-                'PLAIN' + (requireClientToken ? '-CLIENTTOKEN' : ''),
-                clientToken ? ' with token "' + clientToken + '"' : ''
+                'PLAIN'
             );
 
             connection.setUser(response.user);

--- a/packages/imap-gateway/vendor/imap-core/lib/commands/close.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/commands/close.js
@@ -22,6 +22,7 @@ module.exports = {
         }
 
         let mailbox = this.selected.mailbox;
+        let mailboxPath = this.selected.path;
 
         this.session.selected = this.selected = false;
         this.state = 'Authenticated';
@@ -30,7 +31,8 @@ module.exports = {
             mailbox,
             {
                 isUid: false,
-                silent: true
+                silent: true,
+                path: mailboxPath
             },
             this.session,
             () => {

--- a/packages/imap-gateway/vendor/imap-core/lib/commands/compress.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/commands/compress.js
@@ -26,6 +26,14 @@ module.exports = {
     ],
 
     handler(command, callback) {
+        if (this._server.options.enableCompression !== true) {
+            return callback(null, {
+                response: 'NO',
+                code: 'CANNOT',
+                message: 'Compression is not enabled'
+            });
+        }
+
         let mechanism = ((command.attributes[0] && command.attributes[0].value) || '').toString().toUpperCase().trim();
 
         if (!mechanism) {

--- a/packages/imap-gateway/vendor/imap-core/lib/commands/enable.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/commands/enable.js
@@ -8,11 +8,6 @@ module.exports = {
         let enabled = [];
 
         command.attributes.map(attr => {
-            if (((attr && attr.value) || '').toString().toUpperCase() === 'CONDSTORE') {
-                this.condstoreEnabled = true;
-                enabled.push('CONDSTORE');
-            }
-
             if (((attr && attr.value) || '').toString().toUpperCase() === 'UTF8=ACCEPT') {
                 this.acceptUTF8Enabled = true;
                 enabled.push('UTF8=ACCEPT');

--- a/packages/imap-gateway/vendor/imap-core/lib/commands/expunge.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/commands/expunge.js
@@ -15,7 +15,9 @@ module.exports = {
         // Do nothing if in read only mode
         if (this.selected.readOnly) {
             return callback(null, {
-                response: 'OK'
+                response: 'NO',
+                code: 'READ-ONLY',
+                message: 'Mailbox is read-only'
             });
         }
 

--- a/packages/imap-gateway/vendor/imap-core/lib/commands/fetch.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/commands/fetch.js
@@ -64,14 +64,10 @@ module.exports = {
         let extensions = [].concat(command.attributes[2] || []).map(val => val && val.value);
 
         if (extensions.length) {
-            if (extensions.length !== 2 || (extensions[0] || '').toString().toUpperCase() !== 'CHANGEDSINCE' || isNaN(extensions[1])) {
-                return callback(new Error('Invalid modifier for ' + command.command));
-            }
-            changedSince = Number(extensions[1]);
-            changedSinceSpecified = true;
-            if (!this.selected.condstoreEnabled) {
-                this.condstoreEnabled = this.selected.condstoreEnabled = true;
-            }
+            return callback(null, {
+                response: 'BAD',
+                message: 'CONDSTORE is not supported'
+            });
         }
 
         let macros = new Map(
@@ -118,10 +114,10 @@ module.exports = {
             }
 
             if (param.value.toUpperCase() === 'MODSEQ') {
-                modseqExist = true;
-                if (!this.selected.condstoreEnabled) {
-                    this.condstoreEnabled = this.selected.condstoreEnabled = true;
-                }
+                return callback(null, {
+                    response: 'BAD',
+                    message: 'CONDSTORE is not supported'
+                });
             }
 
             if (param.value.toUpperCase() === 'BODYSTRUCTURE') {

--- a/packages/imap-gateway/vendor/imap-core/lib/commands/move.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/commands/move.js
@@ -27,6 +27,14 @@ module.exports = {
             });
         }
 
+        if (this.selected.readOnly) {
+            return callback(null, {
+                response: 'NO',
+                code: 'READ-ONLY',
+                message: 'Mailbox is read-only'
+            });
+        }
+
         let range = (command.attributes[0] && command.attributes[0].value) || '';
         let path = Buffer.from((command.attributes[1] && command.attributes[1].value) || '', 'binary').toString();
         path = imapTools.normalizeMailbox(path, !this.acceptUTF8Enabled);

--- a/packages/imap-gateway/vendor/imap-core/lib/commands/search.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/commands/search.js
@@ -41,9 +41,11 @@ module.exports = {
             return callback(E);
         }
 
-        // mark CONDSTORE as enabled
-        if (parsed.terms.indexOf('modseq') >= 0 && !this.selected.condstoreEnabled) {
-            this.condstoreEnabled = this.selected.condstoreEnabled = true;
+        if (parsed.terms.indexOf('modseq') >= 0) {
+            return callback(null, {
+                response: 'BAD',
+                message: 'CONDSTORE is not supported'
+            });
         }
 
         let logdata = {

--- a/packages/imap-gateway/vendor/imap-core/lib/commands/select.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/commands/select.js
@@ -27,9 +27,11 @@ module.exports = {
 
         let extensions = [].concat(command.attributes[1] || []).map(attr => ((attr && attr.value) || '').toString().toUpperCase());
 
-        // Is CONDSTORE found from the optional arguments list?
         if (extensions.indexOf('CONDSTORE') >= 0) {
-            this.condstoreEnabled = true;
+            return callback(null, {
+                response: 'BAD',
+                message: 'CONDSTORE is not supported'
+            });
         }
 
         if (typeof this._server.onOpen !== 'function') {
@@ -181,33 +183,6 @@ module.exports = {
 
             // * 0 RECENT
             this.send('* 0 RECENT');
-
-            // * OK [HIGHESTMODSEQ 123]
-            this.send(
-                imapHandler.compiler({
-                    tag: '*',
-                    command: 'OK',
-                    attributes: [
-                        {
-                            type: 'section',
-                            section: [
-                                {
-                                    type: 'atom',
-                                    value: 'HIGHESTMODSEQ'
-                                },
-                                {
-                                    type: 'atom',
-                                    value: String(Number(mailboxData.modifyIndex) || 1)
-                                }
-                            ]
-                        },
-                        {
-                            type: 'text',
-                            value: 'Highest'
-                        }
-                    ]
-                })
-            );
 
             // * OK [UIDNEXT 1] Predicted next UID
             this.send(

--- a/packages/imap-gateway/vendor/imap-core/lib/commands/starttls.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/commands/starttls.js
@@ -69,7 +69,7 @@ function upgrade(connection) {
     };
 
     // Apply additional socket options if these are set in the server options
-    ['requestCert', 'rejectUnauthorized', 'NPNProtocols', 'SNICallback', 'session', 'requestOCSP'].forEach(key => {
+    ['minVersion', 'requestCert', 'rejectUnauthorized', 'NPNProtocols', 'SNICallback', 'session', 'requestOCSP'].forEach(key => {
         if (key in connection._server.options) {
             socketOptions[key] = connection._server.options[key];
         }

--- a/packages/imap-gateway/vendor/imap-core/lib/commands/status.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/commands/status.js
@@ -23,7 +23,7 @@ module.exports = {
         let path = Buffer.from((command.attributes[0] && command.attributes[0].value) || '', 'binary').toString();
         let query = command.attributes[1] && command.attributes[1];
 
-        let statusElements = ['MESSAGES', 'RECENT', 'UIDNEXT', 'UIDVALIDITY', 'UNSEEN', 'HIGHESTMODSEQ'];
+        let statusElements = ['MESSAGES', 'RECENT', 'UIDNEXT', 'UIDVALIDITY', 'UNSEEN'];
         let statusItem;
         let statusQuery = [];
 
@@ -74,14 +74,6 @@ module.exports = {
         }
 
         path = imapTools.normalizeMailbox(path, !this.acceptUTF8Enabled);
-
-        // mark CONDSTORE as enabled
-        if (statusQuery.indexOf('HIGHESTMODSEQ') >= 0 && !this.condstoreEnabled) {
-            this.condstoreEnabled = true;
-            if (this.selected) {
-                this.selected.condstoreEnabled = true;
-            }
-        }
 
         let logdata = {
             short_message: '[STATUS]',

--- a/packages/imap-gateway/vendor/imap-core/lib/commands/store.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/commands/store.js
@@ -39,8 +39,9 @@ module.exports = {
         // Do nothing if in read only mode
         if (this.selected.readOnly) {
             return callback(null, {
-                response: 'OK',
-                message: 'STORE ignored with read-only mailbox'
+                response: 'NO',
+                code: 'READ-ONLY',
+                message: 'Mailbox is read-only'
             });
         }
 
@@ -61,13 +62,10 @@ module.exports = {
         let extensions = !pos ? [] : [].concat(command.attributes[pos] || []).map(val => val && val.value);
 
         if (extensions.length) {
-            if (extensions.length !== 2 || (extensions[0] || '').toString().toUpperCase() !== 'UNCHANGEDSINCE' || isNaN(extensions[1])) {
-                return callback(new Error('Invalid modifier for STORE'));
-            }
-            unchangedSince = Number(extensions[1]);
-            if (unchangedSince && !this.selected.condstoreEnabled) {
-                this.condstoreEnabled = this.selected.condstoreEnabled = true;
-            }
+            return callback(null, {
+                response: 'BAD',
+                message: 'CONDSTORE is not supported'
+            });
         }
 
         if (action.substr(-7) === '.SILENT') {

--- a/packages/imap-gateway/vendor/imap-core/lib/commands/uid-expunge.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/commands/uid-expunge.js
@@ -24,7 +24,9 @@ module.exports = {
         // Do nothing if in read only mode
         if (this.selected.readOnly) {
             return callback(null, {
-                response: 'OK'
+                response: 'NO',
+                code: 'READ-ONLY',
+                message: 'Mailbox is read-only'
             });
         }
 

--- a/packages/imap-gateway/vendor/imap-core/lib/commands/uid-store.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/commands/uid-store.js
@@ -34,6 +34,14 @@ module.exports = {
             });
         }
 
+        if (this.selected.readOnly) {
+            return callback(null, {
+                response: 'NO',
+                code: 'READ-ONLY',
+                message: 'Mailbox is read-only'
+            });
+        }
+
         let type = 'flags'; // currently hard coded, in the future might support other values as well, eg. X-GM-LABELS
         let range = (command.attributes[0] && command.attributes[0].value) || '';
 
@@ -51,13 +59,10 @@ module.exports = {
         let extensions = !pos ? [] : [].concat(command.attributes[pos] || []).map(val => val && val.value);
 
         if (extensions.length) {
-            if (extensions.length !== 2 || (extensions[0] || '').toString().toUpperCase() !== 'UNCHANGEDSINCE' || isNaN(extensions[1])) {
-                return callback(new Error('Invalid modifier for STORE'));
-            }
-            unchangedSince = Number(extensions[1]);
-            if (unchangedSince && !this.selected.condstoreEnabled) {
-                this.condstoreEnabled = this.selected.condstoreEnabled = true;
-            }
+            return callback(null, {
+                response: 'BAD',
+                message: 'CONDSTORE is not supported'
+            });
         }
 
         if (action.substr(-7) === '.SILENT') {

--- a/packages/imap-gateway/vendor/imap-core/lib/imap-command.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/imap-command.js
@@ -16,7 +16,6 @@ const commands = new Map([
     ['STARTTLS', require('./commands/starttls')],
     ['LOGIN', require('./commands/login')],
     ['AUTHENTICATE PLAIN', require('./commands/authenticate-plain')],
-    ['AUTHENTICATE PLAIN-CLIENTTOKEN', require('./commands/authenticate-plain')],
     ['NAMESPACE', require('./commands/namespace')],
     ['LIST', require('./commands/list')],
     ['XLIST', require('./commands/list')],
@@ -123,7 +122,13 @@ class IMAPCommand {
                         // Log tagged IMAP input that names a command this server does not implement.
                         let logEntry = createCommandFailureLogEntry(this.connection, err, {
                             _command: this.command,
-                            _payload: this.payload ? (this.payload.length < 256 ? this.payload : this.payload.toString().substr(0, 150) + '...') : false
+                            _payload: this.command.startsWith('AUTHENTICATE ')
+                                ? false
+                                : this.payload
+                                  ? this.payload.length < 256
+                                      ? this.payload
+                                      : this.payload.toString().substr(0, 150) + '...'
+                                  : false
                         });
                         this.connection.loggelf(logEntry);
                     }
@@ -154,7 +159,7 @@ class IMAPCommand {
                 return callback(err);
             }
 
-            let maxAllowed = Math.max(Number(this.connection._server.options.maxMessage) || 0, MAX_MESSAGE_SIZE);
+            let maxAllowed = Number(this.connection._server.options.maxMessage) || MAX_MESSAGE_SIZE;
             if (
                 // Allow large literals for selected commands only
                 (!['APPEND'].includes(this.command) && command.expecting > 1024) ||

--- a/packages/imap-gateway/vendor/imap-core/lib/imap-server.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/imap-server.js
@@ -400,8 +400,15 @@ class IMAPServer extends EventEmitter {
 
         // upgrade connection
         tlsSocket = new tls.TLSSocket(socket, socketOptions);
+        errorTimer = setTimeout(() => {
+            let err = new Error('TLS handshake timed out');
+            err.code = 'TLSHandshakeTimeout';
+            tlsSocket.destroy(err);
+        }, this.options.tlsHandshakeTimeout || 10 * 1000);
+        errorTimer.unref();
 
         let onCloseError = hadError => {
+            clearTimeout(errorTimer);
             if (hadError) {
                 return onError();
             }
@@ -414,6 +421,7 @@ class IMAPServer extends EventEmitter {
         tlsSocket.once('tlsClientError', onError);
 
         tlsSocket.on('secure', () => {
+            clearTimeout(errorTimer);
             socket.removeListener('error', onError);
             tlsSocket.removeListener('close', onCloseError);
             tlsSocket.removeListener('error', onError);

--- a/packages/imap-gateway/vendor/imap-core/lib/imap-tools.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/imap-tools.js
@@ -264,10 +264,7 @@ module.exports.generateFolderListing = function (folders, skipHierarchy) {
         }
 
         item = {
-            // flags array is used to store permanentflags
-            //flags: [].concat(folder.flags || []),
-
-            flags: [],
+            flags: [].concat(folder.flags || []),
             path
         };
 
@@ -780,7 +777,6 @@ module.exports.sendCapabilityResponse = connection => {
 
     if (connection.state === 'Not Authenticated') {
         capabilities.push('AUTH=PLAIN');
-        capabilities.push('AUTH=PLAIN-CLIENTTOKEN');
         capabilities.push('SASL-IR');
         capabilities.push('ENABLE');
 
@@ -788,14 +784,12 @@ module.exports.sendCapabilityResponse = connection => {
         capabilities.push('UNSELECT');
         capabilities.push('IDLE');
         capabilities.push('NAMESPACE');
-        capabilities.push('QUOTA');
         capabilities.push('XLIST');
         capabilities.push('CHILDREN');
 
         // Advertise extended capabilities pre-auth (matches Gmail/Yahoo/Outlook behavior)
         capabilities.push('SPECIAL-USE');
         capabilities.push('UIDPLUS');
-        capabilities.push('CONDSTORE');
         capabilities.push('UTF8=ACCEPT');
         capabilities.push('WITHIN');
 
@@ -809,20 +803,18 @@ module.exports.sendCapabilityResponse = connection => {
         capabilities.push('UNSELECT');
         capabilities.push('IDLE');
         capabilities.push('NAMESPACE');
-        capabilities.push('QUOTA');
         capabilities.push('XLIST');
         capabilities.push('CHILDREN');
 
         capabilities.push('SPECIAL-USE');
         capabilities.push('UIDPLUS');
         capabilities.push('ENABLE');
-        capabilities.push('CONDSTORE');
         capabilities.push('UTF8=ACCEPT');
         capabilities.push('WITHIN');
 
         capabilities.push('MOVE');
 
-        if (connection._server.options.enableCompression) {
+        if (connection._server.options.enableCompression === true) {
             capabilities.push('COMPRESS=DEFLATE');
         }
 

--- a/packages/imap-gateway/vendor/imap-core/lib/tls-options.js
+++ b/packages/imap-gateway/vendor/imap-core/lib/tls-options.js
@@ -9,7 +9,7 @@ const tlsDefaults = {
     honorCipherOrder: true,
     requestOCSP: false,
     sessionIdContext: crypto.createHash('sha1').update(process.argv.join(' ')).digest('hex').slice(0, 32),
-    minVersion: 'TLSv1'
+    minVersion: 'TLSv1.2'
 };
 
 /**

--- a/packages/smtp-gateway/README.md
+++ b/packages/smtp-gateway/README.md
@@ -1,14 +1,14 @@
 # @inboundemail/smtp-gateway
 
-Standalone SMTP submission gateway for `smtp.inboundemail.com`. Accepts mail from any SMTP client, authenticates with an Inbound API key, and relays through the existing `POST /api/e2/emails` pipeline (all guards, quotas, and billing apply unchanged). No database or app dependencies — it only talks to the HTTP API, so it deploys anywhere.
+Standalone SMTP submission gateway for `smtp.inboundemail.com`. Accepts mail from any SMTP client, authenticates managed mailbox or SMTP credentials, and relays through the existing `POST /api/e2/emails` pipeline (all guards, quotas, and billing apply unchanged). No database or app dependencies — it only talks to the HTTP API, so it deploys anywhere.
 
 ## Client usage
 
 ```
 Host:     smtp.inboundemail.com
 Port:     587 (STARTTLS) or 465 (implicit TLS)
-Username: inbound
-Password: <your Inbound API key>
+Username: <managed mailbox or SMTP login address>
+Password: <managed mailbox or SMTP credential password>
 ```
 
 Nodemailer example:
@@ -18,32 +18,40 @@ const transporter = nodemailer.createTransport({
   host: "smtp.inboundemail.com",
   port: 465,
   secure: true,
-  auth: { user: "inbound", pass: process.env.INBOUND_API_KEY },
+  auth: { user: process.env.INBOUND_SMTP_LOGIN, pass: process.env.INBOUND_SMTP_PASSWORD },
 });
 ```
 
 ## How it works
 
-1. AUTH PLAIN/LOGIN (TLS required) — username must be `inbound`, password is the API key. Verified with a lightweight authenticated GET against the API; successful keys are cached in memory for 5 minutes.
-2. DATA — raw MIME is parsed (mailparser), mapped to the send-API JSON shape (from/to/cc/bcc from envelope + headers, html/text, reply-to, In-Reply-To/References/X-* headers, attachments as base64), and POSTed with the API key as the Bearer token and a content-derived `Idempotency-Key`.
-3. API errors map to SMTP responses: 429 → 451 (retry), 413 → 552, other 4xx → 550, 5xx → 451. Domain-ownership, blocklist, ban, and billing enforcement all happen in the API.
+1. AUTH PLAIN/LOGIN (TLS required) — the username is the managed login address and the password is its managed credential. Both are verified through `POST /mailboxes/authenticate-smtp`; successful credentials retain their authorized sending identity or scoped domains.
+2. MAIL FROM / RCPT TO — sender authorization and the per-message recipient limit are enforced before DATA. Accepted envelope recipients are the sole delivery authority; MIME To/Cc addresses outside that envelope are discarded and remaining envelope recipients stay Bcc.
+3. DATA — raw MIME is parsed (mailparser), mapped to the send-API JSON shape, and POSTed with the credential as the Bearer token and an idempotency key derived from its stable credential ID, message, normalized sender, and normalized recipient set.
+4. API errors map to SMTP responses: 429 → 451 (retry), 413 → 552, other 4xx → 550, 5xx/network timeouts → 451. Domain-ownership, blocklist, ban, and billing enforcement all happen in the API.
 
-Per-IP AUTH-failure throttling (default 10 failures / 15 min → 421) is built in.
+AUTH failures are throttled per login/IP pair and at a higher aggregate per-IP threshold; recently successful users remain exempt from the aggregate threshold.
 
 ## Configuration (env)
 
 | Variable | Default | Notes |
 |---|---|---|
-| `INBOUND_API_BASE_URL` | `https://inbound.new/api/e2` | |
-| `INBOUND_AUTH_CHECK_PATH` | `/domains?limit=1` | Cheap authenticated GET used to validate keys at AUTH time |
-| `INBOUND_SEND_PATH` | `/emails` | |
+| `INBOUND_API_BASE_URL` | `https://inbound.new/api/e2` | Base URL for managed-credential authentication and sending |
+| `INBOUND_SEND_PATH` | `/emails` | Send endpoint relative to the API base URL |
 | `SMTP_HOSTNAME` | `smtp.inboundemail.com` | EHLO/banner name |
 | `SMTP_STARTTLS_PORT` | `587` | `0` disables |
-| `SMTP_IMPLICIT_TLS_PORT` | `465` | `0` disables; requires TLS paths |
-| `SMTP_TLS_KEY_PATH` / `SMTP_TLS_CERT_PATH` | — | Let's Encrypt fullchain + privkey |
-| `SMTP_MAX_MESSAGE_BYTES` | `26214400` (25 MB) | |
-| `SMTP_ALLOW_INSECURE_AUTH` | `false` | Local dev only |
-| `SMTP_AUTH_FAILURE_LIMIT` / `SMTP_AUTH_FAILURE_WINDOW_MS` | `10` / `900000` | Per-IP throttle |
+| `SMTP_IMPLICIT_TLS_PORT` | `465` | `0` disables; always requires both TLS paths |
+| `SMTP_TLS_KEY_PATH` / `SMTP_TLS_CERT_PATH` | — | Both paths are required unless insecure development mode is explicitly enabled; minimum TLS 1.2 |
+| `SMTP_TLS_HANDSHAKE_TIMEOUT_MS` | `10000` | Handshake timeout for implicit TLS and accepted STARTTLS upgrades |
+| `SMTP_MAX_MESSAGE_BYTES` | `26214400` (25 MB) | Maximum accepted DATA size |
+| `SMTP_MAX_RECIPIENTS` | `50` | Maximum distinct accepted envelope recipients; cannot exceed the SES limit of 50 |
+| `SMTP_ALLOW_INSECURE_AUTH` | `false` | Explicit plaintext local-development override only |
+| `SMTP_AUTH_FAILURE_LIMIT` / `SMTP_AUTH_FAILURE_WINDOW_MS` | `10` / `900000` | Per-login/IP failure threshold and window |
+| `SMTP_AUTH_FAILURE_IP_LIMIT` | `50` | Higher aggregate failure threshold per IP |
+| `SMTP_MAX_AUTH_FAILURE_RECORDS` | `10000` | Maximum retained failure records and successful-login exemptions |
+| `SMTP_AUTH_REQUEST_TIMEOUT_MS` / `SMTP_SEND_REQUEST_TIMEOUT_MS` | `10000` / `30000` | Independent upstream authentication and send timeouts |
+| `SMTP_SOCKET_TIMEOUT_MS` | `60000` | SMTP socket inactivity timeout |
+| `SMTP_MAX_CONNECTIONS` | `50` | Maximum simultaneous TCP and SMTP connections per listener |
+| `SMTP_MAX_CONCURRENT_DATA` / `SMTP_MAX_DATA_QUEUE` | `2` / `20` | Concurrent message-processing slots and pending queue limit |
 
 ## Local dev
 

--- a/packages/smtp-gateway/bun.lock
+++ b/packages/smtp-gateway/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@inboundemail/smtp-gateway",
       "dependencies": {
-        "mailparser": "^3.7.1",
+        "mailparser": "^3.9.16",
         "smtp-server": "^3.13.6",
       },
       "devDependencies": {
@@ -25,9 +25,9 @@
 
     "@types/smtp-server": ["@types/smtp-server@3.5.13", "", { "dependencies": { "@types/node": "*", "@types/nodemailer": "*" } }, "sha512-S3rGl2KbViH+98/CgHipPIWgtAFnjxLsppxIRbgJHNuZL7Y+py+7kZjT7xS+wOmCxYTn4O7IqLqkvekg99MDVQ=="],
 
-    "@zone-eu/mailsplit": ["@zone-eu/mailsplit@5.4.14", "", { "dependencies": { "libbase64": "1.3.0", "libmime": "5.4.1", "libqp": "2.1.1" } }, "sha512-rz0FQOhN3Vq1XrSeSSa9+dPcaFbBxmQPjiZm6zS9oxdVHV7rOWIAYX3yP2YAUf0qBncY8CI+NogzPCmMVrMXcw=="],
+    "@zone-eu/mailsplit": ["@zone-eu/mailsplit@5.4.15", "", { "dependencies": { "libbase64": "1.3.0", "libmime": "5.4.2", "libqp": "2.1.1" } }, "sha512-c7ZpxauvF4AEkDJlKDYO7iMUtMuqJMBnDWNff1cyx+d7zaBVR3iFEmXhNHOVoMmVyVF3pTZLsLIJsEFKDldOAA=="],
 
-    "deepmerge-ts": ["deepmerge-ts@7.1.5", "", {}, "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw=="],
+    "deepmerge-ts": ["deepmerge-ts@8.0.2", "", {}, "sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -43,7 +43,7 @@
 
     "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
 
-    "html-to-text": ["html-to-text@10.0.0", "", { "dependencies": { "@selderee/plugin-htmlparser2": "~0.12.0", "deepmerge-ts": "^7.1.5", "dom-serializer": "^2.0.0", "htmlparser2": "^10.1.0", "selderee": "~0.12.0" } }, "sha512-2OH59Gtprdczel+7Rxgpz9hGVJREaf8Lt1H4kZwWHpEn70VQKRuMNGsb2eDbwaTzrYzb0hheiOG1P7Dim0B4dQ=="],
+    "html-to-text": ["html-to-text@10.0.1", "", { "dependencies": { "@selderee/plugin-htmlparser2": "~0.12.0", "deepmerge-ts": "^8.0.1", "dom-serializer": "^2.0.0", "htmlparser2": "^10.1.0", "selderee": "~0.12.0" } }, "sha512-GiVhRI1BatGARSCmlXWNCjDT0cWrwBWoeduLoV0WSKAgaV/wa+hUWy5LiQLUs4UwiUrE52ZCMfBGiKD87TDPrg=="],
 
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
@@ -55,15 +55,15 @@
 
     "libbase64": ["libbase64@1.3.0", "", {}, "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg=="],
 
-    "libmime": ["libmime@5.4.1", "", { "dependencies": { "encoding-japanese": "2.2.0", "iconv-lite": "0.7.3", "libbase64": "1.3.0", "libqp": "2.1.1" } }, "sha512-0wHGhsofo9IdQPenr3BBHXuxcwMq4atFUTsZ9Ogc1OvI5h4rUdDIrBQEN9JHjCXfDMrE59LUMJWsTD82wTYk8A=="],
+    "libmime": ["libmime@5.4.2", "", { "dependencies": { "encoding-japanese": "2.2.0", "iconv-lite": "0.7.3", "libbase64": "1.3.0", "libqp": "2.1.1" } }, "sha512-+IQnCOdPiufGBkOii+Ze8F7iniyBzOwvWDbn1DyExBpc9pT2B3IEMQi7GUc/PpqhNUh/sr1SG9UXDITQoR0VIA=="],
 
     "libqp": ["libqp@2.1.1", "", {}, "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow=="],
 
     "linkify-it": ["linkify-it@5.0.2", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q=="],
 
-    "mailparser": ["mailparser@3.9.14", "", { "dependencies": { "@zone-eu/mailsplit": "5.4.14", "encoding-japanese": "2.2.0", "he": "1.2.0", "html-to-text": "10.0.0", "iconv-lite": "0.7.3", "libmime": "5.4.1", "linkify-it": "5.0.2", "nodemailer": "9.0.3", "punycode.js": "2.3.1", "tlds": "1.261.0" } }, "sha512-3QD6TRXcyXtq2NCuyA2AEjqmallQkyxYmZI9GMCIvQDCaB9Uc034WUI1x8RUBYFnk5+p7h14JEz4O/lrxQmttw=="],
+    "mailparser": ["mailparser@3.9.16", "", { "dependencies": { "@zone-eu/mailsplit": "5.4.15", "encoding-japanese": "2.2.0", "he": "1.2.0", "html-to-text": "10.0.1", "iconv-lite": "0.7.3", "libmime": "5.4.2", "linkify-it": "5.0.2", "nodemailer": "9.0.5", "punycode.js": "2.3.1", "tlds": "1.261.0" } }, "sha512-TvbU4YMEDLPkDIft/oUTjjV5PvoR/mj9gw+zzNP6SHJHxBd9FsRWP+rDt80a1wOJ4dKyNesRrYATZ+n0RKyDtw=="],
 
-    "nodemailer": ["nodemailer@9.0.3", "", {}, "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw=="],
+    "nodemailer": ["nodemailer@9.0.5", "", {}, "sha512-wvjiKvjczmsN7U/8006JOdXubgBk2XFAbioDMbT+sM7cPs0QrhJTa6KBRX7P5REGGkDcLUz/EarWidb8G8C1jQ=="],
 
     "parseley": ["parseley@0.13.1", "", { "dependencies": { "leac": "^0.7.0", "peberminta": "^0.10.0" } }, "sha512-uNBJZzmb60l6p6VWLTmevizNAGnE0xoSf1n0B4q3ntegDNzcS68NRCcBDZTcyXHxt2XhBChsCuqj4M+nChvE/A=="],
 
@@ -88,5 +88,7 @@
     "libmime/iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 
     "mailparser/iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
+    "smtp-server/nodemailer": ["nodemailer@9.0.3", "", {}, "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw=="],
   }
 }

--- a/packages/smtp-gateway/package.json
+++ b/packages/smtp-gateway/package.json
@@ -2,7 +2,7 @@
 	"name": "@inboundemail/smtp-gateway",
 	"version": "0.1.0",
 	"private": true,
-	"description": "Standalone SMTP submission gateway for smtp.inboundemail.com. Authenticates with Inbound API keys and relays messages through the Inbound send API.",
+	"description": "Standalone SMTP submission gateway for smtp.inboundemail.com. Authenticates managed mail credentials and relays messages through the Inbound send API.",
 	"type": "module",
 	"main": "src/index.ts",
 	"scripts": {
@@ -12,7 +12,7 @@
 		"typecheck": "bunx tsc --noEmit"
 	},
 	"dependencies": {
-		"mailparser": "^3.7.1",
+		"mailparser": "^3.9.16",
 		"smtp-server": "^3.13.6"
 	},
 	"devDependencies": {

--- a/packages/smtp-gateway/src/api-client.test.ts
+++ b/packages/smtp-gateway/src/api-client.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import {
+	InboundApiClient,
+	SmtpRelayError,
+	smtpFailureForApiStatus,
+} from "./api-client.ts";
+import { loadConfig } from "./config.ts";
+
+const identity = {
+	credentialId: "credential-id",
+	userId: "user-id",
+	loginAddress: "sender@example.com",
+	type: "smtp" as const,
+	accessMode: "read_write" as const,
+	sendingMode: "identity" as const,
+	sendingName: null,
+	sendingAddress: "sender@example.com",
+	allowedDomains: [],
+};
+
+function client(overrides: Partial<ReturnType<typeof loadConfig>> = {}) {
+	return new InboundApiClient({
+		...loadConfig(),
+		apiBaseUrl: "https://example.com/api/e2",
+		...overrides,
+	});
+}
+
+const timedOutFetch = Object.assign(
+	(
+		_input: Parameters<typeof fetch>[0],
+		options?: Parameters<typeof fetch>[1],
+	) => {
+		return new Promise<Response>((_resolve, reject) => {
+			options?.signal?.addEventListener("abort", () => {
+				reject(options.signal?.reason);
+			});
+		});
+	},
+	{ preconnect: globalThis.fetch.preconnect },
+);
+
+afterEach(() => mock.restore());
+
+describe("smtpFailureForApiStatus", () => {
+	it("maps authorization, size, rate-limit, validation, and upstream errors", () => {
+		expect(smtpFailureForApiStatus(401, null).responseCode).toBe(550);
+		expect(smtpFailureForApiStatus(403, "denied").message).toContain("denied");
+		expect(smtpFailureForApiStatus(413, null).responseCode).toBe(552);
+		expect(smtpFailureForApiStatus(429, null).responseCode).toBe(451);
+		expect(smtpFailureForApiStatus(422, "invalid").message).toContain(
+			"invalid",
+		);
+		expect(smtpFailureForApiStatus(500, null).responseCode).toBe(451);
+	});
+});
+
+describe("InboundApiClient.authenticateSmtp", () => {
+	it("posts managed credentials with an independent timeout signal", async () => {
+		const fetchMock = spyOn(globalThis, "fetch").mockResolvedValue(
+			Response.json(identity),
+		);
+
+		expect(
+			await client().authenticateSmtp("sender@example.com", "secret"),
+		).toEqual(identity);
+		const [url, options] = fetchMock.mock.calls[0] ?? [];
+		expect(url).toBe("https://example.com/api/e2/mailboxes/authenticate-smtp");
+		expect(options?.method).toBe("POST");
+		expect(options?.body).toBe(
+			JSON.stringify({
+				loginAddress: "sender@example.com",
+				password: "secret",
+			}),
+		);
+		expect(options?.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it("treats unauthorized managed credentials as invalid", async () => {
+		spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(null, { status: 401 }),
+		);
+		expect(
+			await client().authenticateSmtp("sender@example.com", "bad"),
+		).toBeNull();
+	});
+
+	it("maps authentication backend failures to temporary SMTP failures", async () => {
+		spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(null, { status: 503 }),
+		);
+
+		await expect(
+			client().authenticateSmtp("sender@example.com", "secret"),
+		).rejects.toMatchObject({ responseCode: 451 });
+	});
+
+	it("aborts authentication requests at their configured timeout", async () => {
+		spyOn(globalThis, "fetch").mockImplementation(timedOutFetch);
+
+		await expect(
+			client({ authRequestTimeoutMs: 5 }).authenticateSmtp(
+				"sender@example.com",
+				"secret",
+			),
+		).rejects.toMatchObject({ responseCode: 451 });
+	});
+});
+
+describe("InboundApiClient.sendEmail", () => {
+	const payload = {
+		from: "sender@example.com",
+		to: [] as string[],
+		bcc: ["hidden@example.com"],
+		subject: "Private delivery",
+	};
+
+	it("sends BCC-only payloads unchanged with authorization and idempotency", async () => {
+		const fetchMock = spyOn(globalThis, "fetch").mockResolvedValue(
+			Response.json({ id: "message-id" }),
+		);
+
+		expect(await client().sendEmail("secret", payload, "smtp-key")).toEqual({
+			id: "message-id",
+		});
+		const [url, options] = fetchMock.mock.calls[0] ?? [];
+		expect(url).toBe("https://example.com/api/e2/emails");
+		expect(options?.headers).toEqual({
+			Authorization: "Bearer secret",
+			"Content-Type": "application/json",
+			"Idempotency-Key": "smtp-key",
+		});
+		expect(options?.body).toBe(JSON.stringify(payload));
+		expect(options?.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it("includes upstream rejection details in SMTP failures", async () => {
+		spyOn(globalThis, "fetch").mockResolvedValue(
+			Response.json({ error: "Recipient blocked" }, { status: 422 }),
+		);
+
+		await expect(
+			client().sendEmail("secret", payload, "key"),
+		).rejects.toMatchObject({
+			responseCode: 550,
+			message: "5.6.0 Message rejected: Recipient blocked",
+		});
+	});
+
+	it("maps network failures to temporary SMTP failures", async () => {
+		spyOn(globalThis, "fetch").mockRejectedValue(
+			new Error("network unavailable"),
+		);
+
+		const result = client().sendEmail("secret", payload, "key");
+		await expect(result).rejects.toBeInstanceOf(SmtpRelayError);
+		await expect(result).rejects.toMatchObject({ responseCode: 451 });
+	});
+
+	it("aborts send requests independently of authentication requests", async () => {
+		spyOn(globalThis, "fetch").mockImplementation(timedOutFetch);
+
+		await expect(
+			client({
+				authRequestTimeoutMs: 60_000,
+				sendRequestTimeoutMs: 5,
+			}).sendEmail("secret", payload, "key"),
+		).rejects.toMatchObject({ responseCode: 451 });
+	});
+});

--- a/packages/smtp-gateway/src/api-client.ts
+++ b/packages/smtp-gateway/src/api-client.ts
@@ -107,20 +107,20 @@ export class InboundApiClient {
 		loginAddress: string,
 		password: string,
 	): Promise<SmtpIdentity | null> {
-		const response = await fetch(
+		const failure = "4.3.0 Authentication backend unavailable, try again later";
+		const response = await this.request(
 			`${this.config.apiBaseUrl}/mailboxes/authenticate-smtp`,
 			{
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ loginAddress, password }),
 			},
+			this.config.authRequestTimeoutMs,
+			failure,
 		);
 		if (response.ok) return (await response.json()) as SmtpIdentity;
 		if (response.status === 401 || response.status === 403) return null;
-		throw new SmtpRelayError({
-			responseCode: 451,
-			message: "4.3.0 Authentication backend unavailable, try again later",
-		});
+		throw new SmtpRelayError({ responseCode: 451, message: failure });
 	}
 
 	async sendEmail(
@@ -128,7 +128,7 @@ export class InboundApiClient {
 		payload: SendEmailPayload,
 		idempotencyKey: string,
 	): Promise<SendEmailResult> {
-		const response = await fetch(
+		const response = await this.request(
 			`${this.config.apiBaseUrl}${this.config.sendPath}`,
 			{
 				method: "POST",
@@ -139,6 +139,8 @@ export class InboundApiClient {
 				},
 				body: JSON.stringify(payload),
 			},
+			this.config.sendRequestTimeoutMs,
+			"4.3.0 Temporary upstream failure, try again later",
 		);
 		if (!response.ok) {
 			const apiMessage = await readErrorMessage(response);
@@ -147,5 +149,21 @@ export class InboundApiClient {
 			);
 		}
 		return (await response.json()) as SendEmailResult;
+	}
+
+	private async request(
+		url: string,
+		options: RequestInit,
+		timeoutMs: number,
+		failure: string,
+	): Promise<Response> {
+		try {
+			return await fetch(url, {
+				...options,
+				signal: AbortSignal.timeout(timeoutMs),
+			});
+		} catch {
+			throw new SmtpRelayError({ responseCode: 451, message: failure });
+		}
 	}
 }

--- a/packages/smtp-gateway/src/config.test.ts
+++ b/packages/smtp-gateway/src/config.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { loadConfig } from "./config.ts";
+
+const names = [
+	"INBOUND_API_BASE_URL",
+	"SMTP_STARTTLS_PORT",
+	"SMTP_IMPLICIT_TLS_PORT",
+	"SMTP_MAX_MESSAGE_BYTES",
+	"SMTP_MAX_RECIPIENTS",
+	"SMTP_TLS_HANDSHAKE_TIMEOUT_MS",
+	"SMTP_AUTH_FAILURE_WINDOW_MS",
+	"SMTP_AUTH_FAILURE_LIMIT",
+	"SMTP_AUTH_FAILURE_IP_LIMIT",
+	"SMTP_MAX_AUTH_FAILURE_RECORDS",
+	"SMTP_AUTH_REQUEST_TIMEOUT_MS",
+	"SMTP_SEND_REQUEST_TIMEOUT_MS",
+	"SMTP_SOCKET_TIMEOUT_MS",
+	"SMTP_MAX_CONNECTIONS",
+	"SMTP_MAX_CONCURRENT_DATA",
+	"SMTP_MAX_DATA_QUEUE",
+] as const;
+const original = new Map(names.map((name) => [name, process.env[name]]));
+
+afterEach(() => {
+	for (const [name, value] of original) {
+		if (value === undefined) delete process.env[name];
+		else process.env[name] = value;
+	}
+});
+
+describe("loadConfig", () => {
+	it("loads conservative production defaults", () => {
+		for (const name of names) delete process.env[name];
+		const config = loadConfig();
+
+		expect(config.starttlsPort).toBe(587);
+		expect(config.implicitTlsPort).toBe(465);
+		expect(config.maxRecipients).toBe(50);
+		expect(config.authFailureIpLimit).toBe(50);
+		expect(config.maxAuthFailureRecords).toBe(10_000);
+		expect(config.authRequestTimeoutMs).toBe(10_000);
+		expect(config.sendRequestTimeoutMs).toBe(30_000);
+		expect(config.tlsHandshakeTimeoutMs).toBe(10_000);
+	});
+
+	it("allows disabling listeners and disabling the DATA queue with zero", () => {
+		process.env.SMTP_STARTTLS_PORT = "0";
+		process.env.SMTP_IMPLICIT_TLS_PORT = "0";
+		process.env.SMTP_MAX_DATA_QUEUE = "0";
+
+		const config = loadConfig();
+		expect(config.starttlsPort).toBe(0);
+		expect(config.implicitTlsPort).toBe(0);
+		expect(config.maxDataQueue).toBe(0);
+	});
+
+	it("rejects invalid, fractional, negative, and out-of-range ports", () => {
+		for (const value of ["invalid", "1.5", "-1", "65536", "Infinity"]) {
+			process.env.SMTP_STARTTLS_PORT = value;
+			expect(() => loadConfig()).toThrow("SMTP_STARTTLS_PORT");
+		}
+	});
+
+	it("rejects nonpositive limits and timeouts", () => {
+		const positiveNames = [
+			"SMTP_MAX_MESSAGE_BYTES",
+			"SMTP_MAX_RECIPIENTS",
+			"SMTP_TLS_HANDSHAKE_TIMEOUT_MS",
+			"SMTP_AUTH_FAILURE_WINDOW_MS",
+			"SMTP_AUTH_FAILURE_LIMIT",
+			"SMTP_AUTH_FAILURE_IP_LIMIT",
+			"SMTP_MAX_AUTH_FAILURE_RECORDS",
+			"SMTP_AUTH_REQUEST_TIMEOUT_MS",
+			"SMTP_SEND_REQUEST_TIMEOUT_MS",
+			"SMTP_SOCKET_TIMEOUT_MS",
+			"SMTP_MAX_CONNECTIONS",
+			"SMTP_MAX_CONCURRENT_DATA",
+		] as const;
+
+		for (const name of positiveNames) {
+			process.env[name] = "0";
+			expect(() => loadConfig()).toThrow(name);
+			delete process.env[name];
+		}
+	});
+
+	it("rejects recipient limits above the SES maximum", () => {
+		process.env.SMTP_MAX_RECIPIENTS = "50";
+		expect(loadConfig().maxRecipients).toBe(50);
+		process.env.SMTP_MAX_RECIPIENTS = "51";
+		expect(() => loadConfig()).toThrow("SMTP_MAX_RECIPIENTS");
+	});
+
+	it("rejects a negative or fractional DATA queue size", () => {
+		process.env.SMTP_MAX_DATA_QUEUE = "-1";
+		expect(() => loadConfig()).toThrow("SMTP_MAX_DATA_QUEUE");
+		process.env.SMTP_MAX_DATA_QUEUE = "1.5";
+		expect(() => loadConfig()).toThrow("SMTP_MAX_DATA_QUEUE");
+	});
+
+	it("normalizes a trailing slash on the upstream base URL", () => {
+		process.env.INBOUND_API_BASE_URL = "https://example.com/api/";
+		expect(loadConfig().apiBaseUrl).toBe("https://example.com/api");
+	});
+});

--- a/packages/smtp-gateway/src/config.ts
+++ b/packages/smtp-gateway/src/config.ts
@@ -5,11 +5,17 @@ export interface GatewayConfig {
 	starttlsPort: number;
 	implicitTlsPort: number;
 	maxMessageBytes: number;
+	maxRecipients: number;
 	tlsKeyPath: string | null;
 	tlsCertPath: string | null;
+	tlsHandshakeTimeoutMs: number;
 	allowInsecureAuth: boolean;
 	authFailureWindowMs: number;
 	authFailureLimit: number;
+	authFailureIpLimit: number;
+	maxAuthFailureRecords: number;
+	authRequestTimeoutMs: number;
+	sendRequestTimeoutMs: number;
 	socketTimeoutMs: number;
 	maxConnections: number;
 	maxConcurrentData: number;
@@ -21,11 +27,21 @@ function envString(name: string, fallback: string): string {
 	return value && value.length > 0 ? value : fallback;
 }
 
-function envNumber(name: string, fallback: number): number {
+function envNumber(
+	name: string,
+	fallback: number,
+	minimum = 1,
+	maximum = Number.MAX_SAFE_INTEGER,
+): number {
 	const value = process.env[name];
 	if (!value) return fallback;
 	const parsed = Number(value);
-	return Number.isFinite(parsed) ? parsed : fallback;
+	if (!Number.isSafeInteger(parsed) || parsed < minimum || parsed > maximum) {
+		throw new Error(
+			`${name} must be an integer between ${minimum} and ${maximum}`,
+		);
+	}
+	return parsed;
 }
 
 export function loadConfig(): GatewayConfig {
@@ -36,17 +52,23 @@ export function loadConfig(): GatewayConfig {
 		).replace(/\/$/, ""),
 		sendPath: envString("INBOUND_SEND_PATH", "/emails"),
 		hostname: envString("SMTP_HOSTNAME", "smtp.inboundemail.com"),
-		starttlsPort: envNumber("SMTP_STARTTLS_PORT", 587),
-		implicitTlsPort: envNumber("SMTP_IMPLICIT_TLS_PORT", 465),
+		starttlsPort: envNumber("SMTP_STARTTLS_PORT", 587, 0, 65_535),
+		implicitTlsPort: envNumber("SMTP_IMPLICIT_TLS_PORT", 465, 0, 65_535),
 		maxMessageBytes: envNumber("SMTP_MAX_MESSAGE_BYTES", 25 * 1024 * 1024),
-		tlsKeyPath: process.env.SMTP_TLS_KEY_PATH ?? null,
-		tlsCertPath: process.env.SMTP_TLS_CERT_PATH ?? null,
+		maxRecipients: envNumber("SMTP_MAX_RECIPIENTS", 50, 1, 50),
+		tlsKeyPath: process.env.SMTP_TLS_KEY_PATH || null,
+		tlsCertPath: process.env.SMTP_TLS_CERT_PATH || null,
+		tlsHandshakeTimeoutMs: envNumber("SMTP_TLS_HANDSHAKE_TIMEOUT_MS", 10_000),
 		allowInsecureAuth: process.env.SMTP_ALLOW_INSECURE_AUTH === "true",
 		authFailureWindowMs: envNumber("SMTP_AUTH_FAILURE_WINDOW_MS", 15 * 60_000),
 		authFailureLimit: envNumber("SMTP_AUTH_FAILURE_LIMIT", 10),
+		authFailureIpLimit: envNumber("SMTP_AUTH_FAILURE_IP_LIMIT", 50),
+		maxAuthFailureRecords: envNumber("SMTP_MAX_AUTH_FAILURE_RECORDS", 10_000),
+		authRequestTimeoutMs: envNumber("SMTP_AUTH_REQUEST_TIMEOUT_MS", 10_000),
+		sendRequestTimeoutMs: envNumber("SMTP_SEND_REQUEST_TIMEOUT_MS", 30_000),
 		socketTimeoutMs: envNumber("SMTP_SOCKET_TIMEOUT_MS", 60_000),
 		maxConnections: envNumber("SMTP_MAX_CONNECTIONS", 50),
 		maxConcurrentData: envNumber("SMTP_MAX_CONCURRENT_DATA", 2),
-		maxDataQueue: envNumber("SMTP_MAX_DATA_QUEUE", 20),
+		maxDataQueue: envNumber("SMTP_MAX_DATA_QUEUE", 20, 0),
 	};
 }

--- a/packages/smtp-gateway/src/mapper.test.ts
+++ b/packages/smtp-gateway/src/mapper.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "bun:test";
+import { SmtpRelayError } from "./api-client.ts";
+import { idempotencyKeyFor, mapRawMessage } from "./mapper.ts";
+
+function message(headers: string[], body = "Hello"): Buffer {
+	return Buffer.from([...headers, "", body].join("\r\n"));
+}
+
+describe("mapRawMessage", () => {
+	it("limits visible recipients to accepted envelope recipients", async () => {
+		const mapped = await mapRawMessage(
+			message([
+				"From: Sender <sender@example.com>",
+				"To: Allowed Person <ALLOWED@example.com>, Intruder <intruder@example.com>",
+				"Cc: Other Person <other@example.com>, Extra <extra@example.com>",
+				"Subject: Envelope authority",
+			]),
+			{
+				mailFrom: "sender@example.com",
+				rcptTo: [
+					"allowed@example.com",
+					"OTHER@example.com",
+					"hidden@example.com",
+				],
+			},
+		);
+
+		expect(mapped.fromAddress).toBe("sender@example.com");
+		expect(mapped.payload.to).toEqual(["Allowed Person <ALLOWED@example.com>"]);
+		expect(mapped.payload.cc).toEqual(["Other Person <other@example.com>"]);
+		expect(mapped.payload.bcc).toEqual(["hidden@example.com"]);
+		expect(JSON.stringify(mapped.payload)).not.toContain(
+			"intruder@example.com",
+		);
+		expect(JSON.stringify(mapped.payload)).not.toContain("extra@example.com");
+	});
+
+	it("deduplicates recipients case-insensitively while preserving names and visibility", async () => {
+		const mapped = await mapRawMessage(
+			message([
+				"From: sender@example.com",
+				"To: Primary Name <primary@example.com>, Duplicate <PRIMARY@example.com>",
+				"Cc: Wrong Visibility <primary@example.com>, Copy Name <copy@example.com>",
+			]),
+			{
+				mailFrom: "sender@example.com",
+				rcptTo: [
+					"PRIMARY@example.com",
+					"primary@example.com",
+					"COPY@example.com",
+					"Hidden@example.com",
+					"hidden@example.com",
+				],
+			},
+		);
+
+		expect(mapped.payload.to).toEqual(["Primary Name <primary@example.com>"]);
+		expect(mapped.payload.cc).toEqual(["Copy Name <copy@example.com>"]);
+		expect(mapped.payload.bcc).toEqual(["Hidden@example.com"]);
+	});
+
+	it("keeps BCC-only recipients hidden", async () => {
+		const mapped = await mapRawMessage(
+			message([
+				"From: sender@example.com",
+				"To: undisclosed-recipients:;",
+				"Bcc: Hidden Name <hidden@example.com>",
+			]),
+			{
+				mailFrom: "sender@example.com",
+				rcptTo: ["hidden@example.com"],
+			},
+		);
+
+		expect(mapped.payload.to).toEqual([]);
+		expect(mapped.payload.bcc).toEqual(["hidden@example.com"]);
+		expect(mapped.payload.cc).toBeUndefined();
+	});
+
+	it("supports CC-only messages without converting recipients to To", async () => {
+		const mapped = await mapRawMessage(
+			message(["From: sender@example.com", "Cc: Copy Name <copy@example.com>"]),
+			{
+				mailFrom: "sender@example.com",
+				rcptTo: ["copy@example.com"],
+			},
+		);
+
+		expect(mapped.payload.to).toEqual([]);
+		expect(mapped.payload.cc).toEqual(["Copy Name <copy@example.com>"]);
+		expect(mapped.payload.bcc).toBeUndefined();
+	});
+
+	it("classifies accepted recipients as BCC when visible headers were not accepted", async () => {
+		const mapped = await mapRawMessage(
+			message([
+				"From: sender@example.com",
+				"To: rejected@example.com",
+				"Cc: also-rejected@example.com",
+			]),
+			{
+				mailFrom: "sender@example.com",
+				rcptTo: ["actual@example.com"],
+			},
+		);
+
+		expect(mapped.payload.to).toEqual([]);
+		expect(mapped.payload.cc).toBeUndefined();
+		expect(mapped.payload.bcc).toEqual(["actual@example.com"]);
+	});
+
+	it("rejects messages without accepted envelope recipients", async () => {
+		const result = mapRawMessage(
+			message(["From: sender@example.com", "To: header@example.com"]),
+			{ mailFrom: "sender@example.com", rcptTo: [] },
+		);
+
+		await expect(result).rejects.toBeInstanceOf(SmtpRelayError);
+		await expect(result).rejects.toMatchObject({ responseCode: 550 });
+	});
+
+	it("rejects messages without a header or envelope sender", async () => {
+		await expect(
+			mapRawMessage(message(["To: recipient@example.com"]), {
+				mailFrom: null,
+				rcptTo: ["recipient@example.com"],
+			}),
+		).rejects.toMatchObject({ responseCode: 550 });
+	});
+
+	it("retains reply-to and permitted custom headers", async () => {
+		const mapped = await mapRawMessage(
+			message([
+				"From: sender@example.com",
+				"To: recipient@example.com",
+				"Reply-To: Reply Name <reply@example.com>",
+				"X-Custom: custom value",
+				"In-Reply-To: <parent@example.com>",
+			]),
+			{
+				mailFrom: "sender@example.com",
+				rcptTo: ["recipient@example.com"],
+			},
+		);
+
+		expect(mapped.payload.reply_to).toEqual(["Reply Name <reply@example.com>"]);
+		expect(mapped.payload.headers).toMatchObject({
+			"x-custom": "custom value",
+			"in-reply-to": "<parent@example.com>",
+		});
+	});
+});
+
+describe("idempotencyKeyFor", () => {
+	const raw = message(["From: sender@example.com", "To: one@example.com"]);
+
+	it("uses the complete stable credential identity instead of a shared prefix", () => {
+		const envelope = {
+			mailFrom: "sender@example.com",
+			rcptTo: ["one@example.com"],
+		};
+
+		expect(
+			idempotencyKeyFor(raw, "same-prefix-different-one", envelope),
+		).not.toBe(idempotencyKeyFor(raw, "same-prefix-different-two", envelope));
+	});
+
+	it("normalizes sender case and recipient ordering, casing, and duplicates", () => {
+		expect(
+			idempotencyKeyFor(raw, "credential", {
+				mailFrom: " Sender@Example.com ",
+				rcptTo: ["TWO@example.com", "one@example.com", "ONE@example.com"],
+			}),
+		).toBe(
+			idempotencyKeyFor(raw, "credential", {
+				mailFrom: "sender@example.com",
+				rcptTo: ["one@example.com", "two@example.com"],
+			}),
+		);
+	});
+
+	it("changes when the accepted sender, recipients, or message changes", () => {
+		const envelope = {
+			mailFrom: "sender@example.com",
+			rcptTo: ["one@example.com"],
+		};
+		const baseline = idempotencyKeyFor(raw, "credential", envelope);
+
+		expect(
+			idempotencyKeyFor(raw, "credential", {
+				...envelope,
+				mailFrom: "other@example.com",
+			}),
+		).not.toBe(baseline);
+		expect(
+			idempotencyKeyFor(raw, "credential", {
+				...envelope,
+				rcptTo: ["other@example.com"],
+			}),
+		).not.toBe(baseline);
+		expect(
+			idempotencyKeyFor(Buffer.from("different"), "credential", envelope),
+		).not.toBe(baseline);
+	});
+});

--- a/packages/smtp-gateway/src/mapper.ts
+++ b/packages/smtp-gateway/src/mapper.ts
@@ -15,23 +15,26 @@ export interface MappedRawMessage {
 
 const FORWARDED_HEADERS = ["in-reply-to", "references"];
 
-function addressList(value: AddressObject | AddressObject[] | undefined): {
-	formatted: string[];
-	bare: string[];
-} {
+function addressList(
+	value: AddressObject | AddressObject[] | undefined,
+	allowed?: Set<string>,
+	seen?: Set<string>,
+): string[] {
 	const objects = value ? (Array.isArray(value) ? value : [value]) : [];
 	const formatted: string[] = [];
-	const bare: string[] = [];
 	for (const object of objects) {
 		for (const entry of object.value) {
 			if (!entry.address) continue;
-			bare.push(entry.address.toLowerCase());
+			const normalized = entry.address.toLowerCase();
+			if (allowed && !allowed.has(normalized)) continue;
+			if (seen?.has(normalized)) continue;
+			seen?.add(normalized);
 			formatted.push(
 				entry.name ? `${entry.name} <${entry.address}>` : entry.address,
 			);
 		}
 	}
-	return { formatted, bare };
+	return formatted;
 }
 
 function customHeaders(parsed: ParsedMail): Record<string, string> | undefined {
@@ -48,9 +51,25 @@ function customHeaders(parsed: ParsedMail): Record<string, string> | undefined {
 	return Object.keys(headers).length > 0 ? headers : undefined;
 }
 
-export function idempotencyKeyFor(raw: Buffer, apiKey: string): string {
+export function idempotencyKeyFor(
+	raw: Buffer,
+	credentialId: string,
+	envelope: RelayEnvelope,
+): string {
+	const recipients = [
+		...new Set(
+			envelope.rcptTo.map((recipient) => recipient.trim().toLowerCase()),
+		),
+	].sort();
 	return `smtp-${createHash("sha256")
-		.update(apiKey.slice(0, 12))
+		.update(
+			JSON.stringify({
+				credentialId,
+				mailFrom: envelope.mailFrom?.trim().toLowerCase() ?? null,
+				recipients,
+			}),
+		)
+		.update("\0")
 		.update(raw)
 		.digest("hex")
 		.slice(0, 48)}`;
@@ -74,19 +93,28 @@ export async function mapRawMessage(
 		? `${fromEntry.name} <${fromAddress}>`
 		: fromAddress;
 
-	const to = addressList(parsed.to);
-	const cc = addressList(parsed.cc);
-	const visible = new Set([...to.bare, ...cc.bare]);
-	const bcc = envelope.rcptTo.filter(
-		(recipient) => !visible.has(recipient.toLowerCase()),
-	);
-
-	if (to.formatted.length === 0 && bcc.length === 0) {
+	const envelopeRecipients = new Map<string, string>();
+	for (const recipient of envelope.rcptTo) {
+		const address = recipient.trim();
+		const normalized = address.toLowerCase();
+		if (address && !envelopeRecipients.has(normalized)) {
+			envelopeRecipients.set(normalized, address);
+		}
+	}
+	if (envelopeRecipients.size === 0) {
 		throw new SmtpRelayError({
 			responseCode: 550,
 			message: "5.1.3 No valid recipients",
 		});
 	}
+
+	const allowed = new Set(envelopeRecipients.keys());
+	const visible = new Set<string>();
+	const to = addressList(parsed.to, allowed, visible);
+	const cc = addressList(parsed.cc, allowed, visible);
+	const bcc = [...envelopeRecipients]
+		.filter(([normalized]) => !visible.has(normalized))
+		.map(([, address]) => address);
 
 	const replyTo = addressList(parsed.replyTo);
 	const html =
@@ -106,13 +134,13 @@ export async function mapRawMessage(
 		fromAddress: fromAddress.toLowerCase(),
 		payload: {
 			from,
-			to: to.formatted.length > 0 ? to.formatted : bcc,
+			to,
 			subject: parsed.subject ?? "",
 			...(html !== undefined ? { html } : {}),
 			...(text !== undefined ? { text } : {}),
-			...(cc.formatted.length > 0 ? { cc: cc.formatted } : {}),
-			...(to.formatted.length > 0 && bcc.length > 0 ? { bcc } : {}),
-			...(replyTo.formatted.length > 0 ? { reply_to: replyTo.formatted } : {}),
+			...(cc.length > 0 ? { cc } : {}),
+			...(bcc.length > 0 ? { bcc } : {}),
+			...(replyTo.length > 0 ? { reply_to: replyTo } : {}),
 			...(customHeaders(parsed) ? { headers: customHeaders(parsed) } : {}),
 			...(attachments.length > 0 ? { attachments } : {}),
 		},

--- a/packages/smtp-gateway/src/server.test.ts
+++ b/packages/smtp-gateway/src/server.test.ts
@@ -1,0 +1,1062 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { createConnection, type Socket } from "node:net";
+import { PassThrough } from "node:stream";
+import { connect as connectTls } from "node:tls";
+import {
+	SMTPServer,
+	type SMTPServerAuthentication,
+	type SMTPServerAuthenticationResponse,
+	type SMTPServerDataStream,
+	type SMTPServerOptions,
+	type SMTPServerSession,
+} from "smtp-server";
+import type { SmtpIdentity } from "./api-client.ts";
+import { type GatewayConfig, loadConfig } from "./config.ts";
+import { SmtpGateway } from "./server.ts";
+
+interface GatewayInspection {
+	activeData: number;
+	authFailures: Map<string, { count: number; windowStart: number }>;
+	successfulAuth: Map<string, number>;
+	tlsHandshakeTimers: Map<string, ReturnType<typeof setTimeout>>;
+	sessionDataStreams: Map<string, SMTPServerDataStream>;
+	dataQueue: unknown[];
+	servers: SMTPServer[];
+	baseOptions(
+		tls: { key: Buffer; cert: Buffer; minVersion: "TLSv1.2" } | null,
+	): SMTPServerOptions;
+	handleAuth(
+		auth: SMTPServerAuthentication,
+		session: SMTPServerSession,
+	): Promise<SMTPServerAuthenticationResponse>;
+	handleData(
+		stream: SMTPServerDataStream,
+		session: SMTPServerSession,
+	): Promise<string>;
+	acquireDataSlot(stream?: SMTPServerDataStream): Promise<() => void>;
+	listen(server: SMTPServer, port: number, label: string): void;
+}
+
+const identity: SmtpIdentity = {
+	credentialId: "credential-id",
+	userId: "user-id",
+	loginAddress: "sender@example.com",
+	type: "smtp",
+	accessMode: "read_write",
+	sendingMode: "identity",
+	sendingName: null,
+	sendingAddress: "sender@example.com",
+	allowedDomains: [],
+};
+
+function gateway(overrides: Partial<GatewayConfig> = {}): {
+	gateway: SmtpGateway;
+	inspect: GatewayInspection;
+	config: GatewayConfig;
+} {
+	const config = {
+		...loadConfig(),
+		apiBaseUrl: "https://example.com/api/e2",
+		tlsKeyPath: null,
+		tlsCertPath: null,
+		...overrides,
+	};
+	const instance = new SmtpGateway(config);
+	return {
+		gateway: instance,
+		inspect: instance as unknown as GatewayInspection,
+		config,
+	};
+}
+
+function session(
+	overrides: {
+		secure?: boolean;
+		user?: { apiKey: string; identity: SmtpIdentity };
+		recipients?: string[];
+		remoteAddress?: string;
+	} = {},
+): SMTPServerSession {
+	return {
+		id: "session-id",
+		localAddress: "127.0.0.1",
+		localPort: 587,
+		remoteAddress: overrides.remoteAddress ?? "192.0.2.1",
+		remotePort: 12_345,
+		clientHostname: "client.example.com",
+		openingCommand: "EHLO",
+		hostNameAppearsAs: "client.example.com",
+		envelope: {
+			mailFrom: { address: "sender@example.com", args: {} },
+			rcptTo: (overrides.recipients ?? []).map((address) => ({
+				address,
+				args: {},
+			})),
+		},
+		secure: overrides.secure ?? true,
+		transmissionType: "ESMTPSA",
+		tlsOptions: {},
+		user: overrides.user,
+	} as unknown as SMTPServerSession;
+}
+
+function authentication(
+	username: string,
+	password: string,
+): SMTPServerAuthentication {
+	return {
+		method: "PLAIN",
+		username,
+		password,
+		validatePassword: (candidate) => candidate === password,
+	};
+}
+
+function dataStream(content: string): SMTPServerDataStream {
+	const stream = new PassThrough() as SMTPServerDataStream;
+	stream.sizeExceeded = false;
+	stream.end(content);
+	return stream;
+}
+
+function socketResponse(socket: Socket): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const onError = (error: Error) => {
+			socket.removeListener("data", onData);
+			reject(error);
+		};
+		const onData = (chunk: Buffer) => {
+			socket.removeListener("error", onError);
+			resolve(chunk.toString());
+		};
+		socket.once("data", onData);
+		socket.once("error", onError);
+	});
+}
+
+async function smtpCommand(socket: Socket, command: string): Promise<string> {
+	const response = socketResponse(socket);
+	socket.write(`${command}\r\n`);
+	return response;
+}
+
+async function eventually(assertion: () => boolean): Promise<void> {
+	const deadline = Date.now() + 1_000;
+	while (!assertion()) {
+		if (Date.now() >= deadline) throw new Error("Timed out waiting for state");
+		await new Promise<void>((resolve) => setTimeout(resolve, 5));
+	}
+}
+
+afterEach(() => mock.restore());
+
+describe("SmtpGateway TLS startup", () => {
+	it("refuses to start without TLS unless insecure authentication is explicit", () => {
+		const { gateway: instance, inspect } = gateway({
+			implicitTlsPort: 0,
+			allowInsecureAuth: false,
+		});
+
+		expect(() => instance.start()).toThrow("SMTP_ALLOW_INSECURE_AUTH=true");
+		expect(inspect.servers).toHaveLength(0);
+	});
+
+	it("rejects incomplete certificate and private-key configuration", () => {
+		for (const paths of [
+			{ tlsKeyPath: "/missing/key", tlsCertPath: null },
+			{ tlsKeyPath: null, tlsCertPath: "/missing/cert" },
+		]) {
+			const { gateway: instance } = gateway({
+				...paths,
+				implicitTlsPort: 0,
+				allowInsecureAuth: true,
+			});
+			expect(() => instance.start()).toThrow("must both be configured");
+		}
+	});
+
+	it("never permits implicit TLS without certificates, even in development", () => {
+		const { gateway: instance, inspect } = gateway({
+			allowInsecureAuth: true,
+			implicitTlsPort: 465,
+		});
+
+		expect(() => instance.start()).toThrow("implicit TLS listener");
+		expect(inspect.servers).toHaveLength(0);
+	});
+
+	it("rejects configurations with no listeners before binding sockets", () => {
+		const { gateway: instance } = gateway({
+			starttlsPort: 0,
+			implicitTlsPort: 0,
+			allowInsecureAuth: true,
+		});
+
+		expect(() => instance.start()).toThrow("No listeners configured");
+	});
+
+	it("applies TLS 1.2 without advertising an unsupported server handshake option", () => {
+		const { inspect } = gateway();
+		const options = inspect.baseOptions({
+			key: Buffer.from("key"),
+			cert: Buffer.from("certificate"),
+			minVersion: "TLSv1.2",
+		});
+
+		expect(options.minVersion).toBe("TLSv1.2");
+		expect(options.handshakeTimeout).toBeUndefined();
+		expect(options.disabledCommands).toEqual([]);
+		expect(inspect.baseOptions(null).disabledCommands).toEqual(["STARTTLS"]);
+	});
+
+	it("caps underlying TCP connections and closes stalled implicit TLS handshakes", async () => {
+		const { gateway: instance, inspect } = gateway({
+			maxConnections: 3,
+			tlsHandshakeTimeoutMs: 20,
+		});
+		spyOn(console, "log").mockImplementation(() => {});
+		spyOn(console, "error").mockImplementation(() => {});
+		const server = new SMTPServer({
+			...inspect.baseOptions(null),
+			secure: true,
+		});
+		inspect.listen(server, 0, "test implicit TLS");
+		await new Promise<void>((resolve) =>
+			server.server.once("listening", resolve),
+		);
+
+		try {
+			expect(server.server.maxConnections).toBe(3);
+			const address = server.server.address();
+			if (!address || typeof address === "string") {
+				throw new Error("Expected TCP listener address");
+			}
+			const socket = createConnection({
+				host: "127.0.0.1",
+				port: address.port,
+			});
+			await new Promise<void>((resolve, reject) => {
+				socket.once("close", resolve);
+				socket.once("error", reject);
+			});
+			expect(socket.destroyed).toBe(true);
+			expect(inspect.tlsHandshakeTimers.size).toBe(0);
+		} finally {
+			await instance.stop();
+		}
+	});
+
+	it("keeps healthy implicit TLS sessions alive beyond the handshake deadline", async () => {
+		const { gateway: instance, inspect } = gateway({
+			tlsHandshakeTimeoutMs: 250,
+			socketTimeoutMs: 2_000,
+		});
+		spyOn(console, "log").mockImplementation(() => {});
+		spyOn(console, "error").mockImplementation(() => {});
+		const server = new SMTPServer({
+			...inspect.baseOptions(null),
+			secure: true,
+			disableReverseLookup: true,
+		});
+		inspect.listen(server, 0, "healthy implicit TLS");
+		await new Promise<void>((resolve) =>
+			server.server.once("listening", resolve),
+		);
+
+		try {
+			const address = server.server.address();
+			if (!address || typeof address === "string") {
+				throw new Error("Expected TCP listener address");
+			}
+			const socket = connectTls({
+				host: "127.0.0.1",
+				port: address.port,
+				rejectUnauthorized: false,
+			});
+			try {
+				const greeting = await new Promise<string>((resolve, reject) => {
+					socket.once("data", (chunk: Buffer) => resolve(chunk.toString()));
+					socket.once("error", reject);
+				});
+				expect(greeting).toStartWith("220 ");
+				expect(inspect.tlsHandshakeTimers.size).toBe(0);
+				await new Promise<void>((resolve) => setTimeout(resolve, 300));
+				expect(socket.destroyed).toBe(false);
+				const response = new Promise<string>((resolve) => {
+					socket.once("data", (chunk: Buffer) => resolve(chunk.toString()));
+				});
+				socket.write("NOOP\r\n");
+				expect(await response).toStartWith("250 ");
+			} finally {
+				socket.destroy();
+			}
+		} finally {
+			await instance.stop();
+		}
+	});
+
+	it("terminates stalled STARTTLS upgrades at the configured handshake deadline", async () => {
+		const { gateway: instance, inspect } = gateway({
+			tlsHandshakeTimeoutMs: 40,
+			socketTimeoutMs: 2_000,
+		});
+		spyOn(console, "log").mockImplementation(() => {});
+		spyOn(console, "error").mockImplementation(() => {});
+		const server = new SMTPServer({
+			...inspect.baseOptions(null),
+			secure: false,
+			disabledCommands: [],
+			disableReverseLookup: true,
+		});
+		inspect.listen(server, 0, "stalled STARTTLS");
+		await new Promise<void>((resolve) =>
+			server.server.once("listening", resolve),
+		);
+
+		try {
+			const address = server.server.address();
+			if (!address || typeof address === "string") {
+				throw new Error("Expected TCP listener address");
+			}
+			const socket = createConnection({
+				host: "127.0.0.1",
+				port: address.port,
+			});
+			expect(await socketResponse(socket)).toStartWith("220 ");
+			expect(await smtpCommand(socket, "EHLO client.example.com")).toStartWith(
+				"250-",
+			);
+			expect(await smtpCommand(socket, "STARTTLS invalid")).toStartWith("501 ");
+			expect(inspect.tlsHandshakeTimers.size).toBe(0);
+			const response = socketResponse(socket);
+			socket.write("START");
+			expect(inspect.tlsHandshakeTimers.size).toBe(0);
+			socket.write("TLS\r\n");
+			expect(await response).toStartWith("220 ");
+			expect(inspect.tlsHandshakeTimers.size).toBe(1);
+			await new Promise<void>((resolve, reject) => {
+				socket.once("close", resolve);
+				socket.once("error", reject);
+			});
+			expect(socket.destroyed).toBe(true);
+			expect(inspect.tlsHandshakeTimers.size).toBe(0);
+		} finally {
+			await instance.stop();
+		}
+	});
+
+	it("keeps successful STARTTLS sessions alive beyond the handshake deadline", async () => {
+		const { gateway: instance, inspect } = gateway({
+			tlsHandshakeTimeoutMs: 100,
+			socketTimeoutMs: 2_000,
+		});
+		spyOn(console, "log").mockImplementation(() => {});
+		spyOn(console, "error").mockImplementation(() => {});
+		const server = new SMTPServer({
+			...inspect.baseOptions(null),
+			secure: false,
+			disabledCommands: [],
+			disableReverseLookup: true,
+		});
+		inspect.listen(server, 0, "healthy STARTTLS");
+		await new Promise<void>((resolve) =>
+			server.server.once("listening", resolve),
+		);
+
+		try {
+			const address = server.server.address();
+			if (!address || typeof address === "string") {
+				throw new Error("Expected TCP listener address");
+			}
+			const socket = createConnection({
+				host: "127.0.0.1",
+				port: address.port,
+			});
+			expect(await socketResponse(socket)).toStartWith("220 ");
+			expect(await smtpCommand(socket, "EHLO client.example.com")).toStartWith(
+				"250-",
+			);
+			expect(await smtpCommand(socket, "STARTTLS")).toStartWith("220 ");
+			const secure = connectTls({ socket, rejectUnauthorized: false });
+			try {
+				await new Promise<void>((resolve, reject) => {
+					secure.once("secureConnect", resolve);
+					secure.once("error", reject);
+				});
+				expect(
+					await smtpCommand(secure, "EHLO secure.example.com"),
+				).toStartWith("250-");
+				expect(inspect.tlsHandshakeTimers.size).toBe(0);
+				await new Promise<void>((resolve) => setTimeout(resolve, 150));
+				expect(secure.destroyed).toBe(false);
+				expect(await smtpCommand(secure, "NOOP")).toStartWith("250 ");
+			} finally {
+				secure.destroy();
+			}
+		} finally {
+			await instance.stop();
+		}
+	});
+});
+
+describe("SmtpGateway authentication", () => {
+	it("independently rejects AUTH on insecure sessions", async () => {
+		const { inspect } = gateway({ allowInsecureAuth: false });
+		const fetchMock = spyOn(globalThis, "fetch");
+
+		await expect(
+			inspect.handleAuth(
+				authentication("sender@example.com", "secret"),
+				session({
+					secure: false,
+				}),
+			),
+		).rejects.toMatchObject({ responseCode: 538 });
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("permits insecure AUTH only with the explicit development override", async () => {
+		const { inspect } = gateway({ allowInsecureAuth: true });
+		spyOn(globalThis, "fetch").mockResolvedValue(Response.json(identity));
+
+		const result = await inspect.handleAuth(
+			authentication("sender@example.com", "secret"),
+			session({ secure: false }),
+		);
+
+		expect(result.user).toMatchObject({ apiKey: "secret", identity });
+	});
+
+	it("throttles repeated failures for each login and IP pair", async () => {
+		const { inspect } = gateway({
+			authFailureLimit: 2,
+			authFailureIpLimit: 20,
+		});
+		const attempt = () =>
+			inspect.handleAuth(authentication("sender@example.com", ""), session());
+
+		await expect(attempt()).rejects.toMatchObject({ responseCode: 535 });
+		await expect(attempt()).rejects.toMatchObject({ responseCode: 535 });
+		await expect(attempt()).rejects.toMatchObject({ responseCode: 421 });
+	});
+
+	it("limits aggregate IP failures without blocking recently successful users", async () => {
+		const { inspect } = gateway({
+			authFailureLimit: 10,
+			authFailureIpLimit: 3,
+		});
+		spyOn(globalThis, "fetch").mockImplementation(
+			Object.assign(async () => Response.json(identity), {
+				preconnect: globalThis.fetch.preconnect,
+			}),
+		);
+		const valid = () =>
+			inspect.handleAuth(
+				authentication("sender@example.com", "secret"),
+				session(),
+			);
+
+		await expect(valid()).resolves.toBeDefined();
+		for (let index = 0; index < 3; index++) {
+			await expect(
+				inspect.handleAuth(
+					authentication(`bad-${index}@example.com`, ""),
+					session(),
+				),
+			).rejects.toMatchObject({ responseCode: 535 });
+		}
+
+		await expect(
+			inspect.handleAuth(
+				authentication("new@example.com", "secret"),
+				session(),
+			),
+		).rejects.toMatchObject({ responseCode: 421 });
+		await expect(valid()).resolves.toBeDefined();
+	});
+
+	it("does not evict blocked login records when unrelated failures flood the cache", async () => {
+		const { inspect } = gateway({
+			authFailureLimit: 2,
+			authFailureIpLimit: 100,
+			maxAuthFailureRecords: 6,
+		});
+		const blockedSession = session({ remoteAddress: "192.0.2.10" });
+		for (let index = 0; index < 2; index++) {
+			await expect(
+				inspect.handleAuth(
+					authentication("blocked@example.com", ""),
+					blockedSession,
+				),
+			).rejects.toMatchObject({ responseCode: 535 });
+		}
+		for (let index = 0; index < 20; index++) {
+			await expect(
+				inspect.handleAuth(
+					authentication(`noise-${index}@example.com`, ""),
+					session({ remoteAddress: `192.0.2.${index + 20}` }),
+				),
+			).rejects.toMatchObject({ responseCode: 535 });
+		}
+
+		expect(inspect.authFailures.size).toBeLessThanOrEqual(6);
+		await expect(
+			inspect.handleAuth(
+				authentication("blocked@example.com", "secret"),
+				blockedSession,
+			),
+		).rejects.toMatchObject({ responseCode: 421 });
+	});
+
+	it("does not evict blocked IP records when other addresses flood the cache", async () => {
+		const { inspect } = gateway({
+			authFailureLimit: 100,
+			authFailureIpLimit: 2,
+			maxAuthFailureRecords: 6,
+		});
+		const blockedSession = session({ remoteAddress: "192.0.2.10" });
+		for (let index = 0; index < 2; index++) {
+			await expect(
+				inspect.handleAuth(
+					authentication(`blocked-${index}@example.com`, ""),
+					blockedSession,
+				),
+			).rejects.toMatchObject({ responseCode: 535 });
+		}
+		for (let index = 0; index < 20; index++) {
+			await expect(
+				inspect.handleAuth(
+					authentication(`noise-${index}@example.com`, ""),
+					session({ remoteAddress: `192.0.2.${index + 20}` }),
+				),
+			).rejects.toMatchObject({ responseCode: 535 });
+		}
+
+		expect(inspect.authFailures.size).toBeLessThanOrEqual(6);
+		await expect(
+			inspect.handleAuth(
+				authentication("new@example.com", "secret"),
+				blockedSession,
+			),
+		).rejects.toMatchObject({ responseCode: 421 });
+	});
+
+	it("fails closed when every bounded failure record is an active block", async () => {
+		const { inspect } = gateway({
+			authFailureLimit: 1,
+			authFailureIpLimit: 1,
+			maxAuthFailureRecords: 2,
+		});
+
+		await expect(
+			inspect.handleAuth(
+				authentication("blocked@example.com", ""),
+				session({ remoteAddress: "192.0.2.10" }),
+			),
+		).rejects.toMatchObject({ responseCode: 535 });
+		expect(inspect.authFailures.size).toBe(2);
+		await expect(
+			inspect.handleAuth(
+				authentication("unknown@example.com", ""),
+				session({ remoteAddress: "192.0.2.20" }),
+			),
+		).rejects.toMatchObject({ responseCode: 421 });
+		expect(inspect.authFailures.size).toBe(2);
+	});
+
+	it("bounds retained authentication failure and success records", async () => {
+		const { inspect } = gateway({
+			authFailureLimit: 100,
+			authFailureIpLimit: 100,
+			maxAuthFailureRecords: 4,
+		});
+
+		for (let index = 0; index < 10; index++) {
+			await expect(
+				inspect.handleAuth(
+					authentication(`bad-${index}@example.com`, ""),
+					session(),
+				),
+			).rejects.toMatchObject({ responseCode: 535 });
+		}
+		expect(inspect.authFailures.size).toBeLessThanOrEqual(4);
+
+		spyOn(globalThis, "fetch").mockImplementation(
+			Object.assign(async () => Response.json(identity), {
+				preconnect: globalThis.fetch.preconnect,
+			}),
+		);
+		for (let index = 0; index < 10; index++) {
+			await inspect.handleAuth(
+				authentication(`valid-${index}@example.com`, "secret"),
+				session(),
+			);
+		}
+		expect(inspect.successfulAuth.size).toBeLessThanOrEqual(4);
+	});
+});
+
+describe("SmtpGateway envelope limits", () => {
+	it("authorizes MAIL FROM before accepting the transaction", async () => {
+		const { inspect } = gateway();
+		const options = inspect.baseOptions(null);
+		const authenticated = session({ user: { apiKey: "secret", identity } });
+
+		const accepted = await new Promise<Error | null | undefined>((resolve) => {
+			options.onMailFrom?.(
+				{ address: "SENDER@example.com", args: {} },
+				authenticated,
+				resolve,
+			);
+		});
+		expect(accepted).toBeUndefined();
+
+		const rejected = await new Promise<Error | null | undefined>((resolve) => {
+			options.onMailFrom?.(
+				{ address: "other@example.com", args: {} },
+				authenticated,
+				resolve,
+			);
+		});
+		expect(rejected).toMatchObject({ responseCode: 553 });
+	});
+
+	it("accepts authenticated RFC-valid null reverse paths", async () => {
+		const { inspect } = gateway();
+		const authenticated = session({ user: { apiKey: "secret", identity } });
+		const result = await new Promise<Error | null | undefined>((resolve) => {
+			inspect
+				.baseOptions(null)
+				.onMailFrom?.({ address: "", args: {} }, authenticated, resolve);
+		});
+
+		expect(result).toBeUndefined();
+	});
+
+	it("rejects MAIL FROM before authentication", async () => {
+		const { inspect } = gateway();
+		const rejected = await new Promise<Error | null | undefined>((resolve) => {
+			inspect
+				.baseOptions(null)
+				.onMailFrom?.(
+					{ address: "sender@example.com", args: {} },
+					session(),
+					resolve,
+				);
+		});
+
+		expect(rejected).toMatchObject({ responseCode: 530 });
+	});
+
+	it("continues validating header senders for null reverse paths", async () => {
+		const { inspect } = gateway();
+		const active = session({
+			user: { apiKey: "secret", identity },
+			recipients: ["recipient@example.com"],
+		});
+		active.envelope.mailFrom = { address: "", args: {} };
+		const fetchMock = spyOn(globalThis, "fetch");
+
+		await expect(
+			inspect.handleData(
+				dataStream(
+					"From: intruder@example.com\r\nTo: recipient@example.com\r\n\r\nHello",
+				),
+				active,
+			),
+		).rejects.toMatchObject({ responseCode: 553 });
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(inspect.activeData).toBe(0);
+	});
+
+	it("relays authorized header senders with a null reverse path", async () => {
+		const { inspect } = gateway();
+		const active = session({
+			user: { apiKey: "secret", identity },
+			recipients: ["recipient@example.com"],
+		});
+		active.envelope.mailFrom = { address: "", args: {} };
+		spyOn(console, "log").mockImplementation(() => {});
+		spyOn(globalThis, "fetch").mockResolvedValue(
+			Response.json({ id: "null-sender-message" }),
+		);
+
+		await expect(
+			inspect.handleData(
+				dataStream(
+					"From: sender@example.com\r\nTo: recipient@example.com\r\n\r\nHello",
+				),
+				active,
+			),
+		).resolves.toBe("Queued as null-sender-message");
+		expect(inspect.activeData).toBe(0);
+	});
+
+	it("enforces the SES hard maximum even for programmatic configuration", async () => {
+		const { inspect } = gateway({ maxRecipients: 100 });
+		const active = session({
+			recipients: Array.from(
+				{ length: 50 },
+				(_unused, index) => `recipient-${index}@example.com`,
+			),
+		});
+		const rejected = await new Promise<Error | null | undefined>((resolve) => {
+			inspect
+				.baseOptions(null)
+				.onRcptTo?.(
+					{ address: "extra@example.com", args: {} },
+					active,
+					resolve,
+				);
+		});
+
+		expect(rejected).toMatchObject({ responseCode: 452 });
+	});
+
+	it("enforces the distinct recipient limit without rejecting duplicate RCPT", async () => {
+		const { inspect } = gateway({ maxRecipients: 1 });
+		const active = session({ recipients: ["first@example.com"] });
+		const options = inspect.baseOptions(null);
+
+		const duplicate = await new Promise<Error | null | undefined>((resolve) => {
+			options.onRcptTo?.(
+				{ address: "FIRST@example.com", args: {} },
+				active,
+				resolve,
+			);
+		});
+		expect(duplicate).toBeUndefined();
+
+		const rejected = await new Promise<Error | null | undefined>((resolve) => {
+			options.onRcptTo?.(
+				{ address: "second@example.com", args: {} },
+				active,
+				resolve,
+			);
+		});
+		expect(rejected).toMatchObject({ responseCode: 452 });
+	});
+});
+
+describe("SmtpGateway DATA concurrency", () => {
+	it("queues waiting messages and hands released slots directly to them", async () => {
+		const { inspect } = gateway({ maxConcurrentData: 1, maxDataQueue: 1 });
+		const releaseFirst = await inspect.acquireDataSlot();
+		const waiting = inspect.acquireDataSlot();
+
+		expect(() => inspect.acquireDataSlot()).toThrow("Gateway busy");
+		expect(inspect.activeData).toBe(1);
+		releaseFirst();
+		const releaseSecond = await waiting;
+		expect(inspect.activeData).toBe(1);
+		releaseSecond();
+		expect(inspect.activeData).toBe(0);
+	});
+
+	it("destroys queued DATA streams when their SMTP session closes", async () => {
+		const { inspect } = gateway({ maxConcurrentData: 1, maxDataQueue: 1 });
+		const release = await inspect.acquireDataSlot();
+		const stream = new PassThrough() as SMTPServerDataStream;
+		const active = session({ user: { apiKey: "secret", identity } });
+		const options = inspect.baseOptions(null);
+		const rejected = new Promise<Error | null | undefined>((resolve) => {
+			options.onData?.(stream, active, resolve);
+		});
+
+		expect(inspect.dataQueue).toHaveLength(1);
+		expect(inspect.sessionDataStreams.get(active.id)).toBe(stream);
+		options.onClose?.(active, () => {});
+		expect(stream.destroyed).toBe(true);
+		await expect(rejected).resolves.toMatchObject({ responseCode: 451 });
+		expect(inspect.dataQueue).toHaveLength(0);
+		expect(inspect.sessionDataStreams.size).toBe(0);
+		release();
+		expect(inspect.activeData).toBe(0);
+	});
+
+	it("destroys active DATA streams and releases slots when their SMTP session closes", async () => {
+		const { inspect } = gateway({ maxConcurrentData: 1, maxDataQueue: 0 });
+		const stream = new PassThrough() as SMTPServerDataStream;
+		const active = session({
+			user: { apiKey: "secret", identity },
+			recipients: ["recipient@example.com"],
+		});
+		const options = inspect.baseOptions(null);
+		const rejected = new Promise<Error | null | undefined>((resolve) => {
+			options.onData?.(stream, active, resolve);
+		});
+		await Promise.resolve();
+
+		expect(inspect.activeData).toBe(1);
+		expect(inspect.sessionDataStreams.get(active.id)).toBe(stream);
+		options.onClose?.(active, () => {});
+		await expect(rejected).resolves.toMatchObject({ responseCode: 451 });
+		expect(inspect.activeData).toBe(0);
+		expect(inspect.sessionDataStreams.size).toBe(0);
+	});
+
+	it("removes completed DATA streams from their SMTP session", async () => {
+		const { inspect } = gateway();
+		spyOn(console, "log").mockImplementation(() => {});
+		spyOn(globalThis, "fetch").mockResolvedValue(
+			Response.json({ id: "completed-message" }),
+		);
+		const active = session({
+			user: { apiKey: "secret", identity },
+			recipients: ["recipient@example.com"],
+		});
+		const stream = dataStream(
+			"From: sender@example.com\r\nTo: recipient@example.com\r\n\r\nHello",
+		);
+
+		const result = await new Promise<string | undefined>((resolve, reject) => {
+			inspect.baseOptions(null).onData?.(stream, active, (error, message) => {
+				if (error) reject(error);
+				else resolve(message);
+			});
+		});
+		await eventually(() => inspect.sessionDataStreams.size === 0);
+		expect(result).toBe("Queued as completed-message");
+		expect(inspect.activeData).toBe(0);
+	});
+
+	it("removes disconnected queued streams without leaking DATA slots", async () => {
+		const { inspect } = gateway({ maxConcurrentData: 1, maxDataQueue: 1 });
+		const release = await inspect.acquireDataSlot();
+		const stream = new PassThrough() as SMTPServerDataStream;
+		const waiting = inspect.acquireDataSlot(stream);
+
+		expect(inspect.dataQueue).toHaveLength(1);
+		stream.destroy();
+		await expect(waiting).rejects.toMatchObject({ responseCode: 451 });
+		expect(inspect.dataQueue).toHaveLength(0);
+		release();
+		expect(inspect.activeData).toBe(0);
+		const replacement = await inspect.acquireDataSlot();
+		expect(inspect.activeData).toBe(1);
+		replacement();
+		expect(inspect.activeData).toBe(0);
+	});
+
+	it("skips canceled queued streams and grants the next live waiter", async () => {
+		const { inspect } = gateway({ maxConcurrentData: 1, maxDataQueue: 2 });
+		const release = await inspect.acquireDataSlot();
+		const canceledStream = new PassThrough() as SMTPServerDataStream;
+		const liveStream = new PassThrough() as SMTPServerDataStream;
+		const canceled = inspect.acquireDataSlot(canceledStream);
+		const live = inspect.acquireDataSlot(liveStream);
+
+		canceledStream.destroy();
+		await expect(canceled).rejects.toMatchObject({ responseCode: 451 });
+		release();
+		const releaseLive = await live;
+		expect(inspect.activeData).toBe(1);
+		releaseLive();
+		expect(inspect.activeData).toBe(0);
+		liveStream.destroy();
+	});
+
+	it("rejects queued stream errors without reserving a processing slot", async () => {
+		const { inspect } = gateway({ maxConcurrentData: 1, maxDataQueue: 1 });
+		const release = await inspect.acquireDataSlot();
+		const stream = new PassThrough() as SMTPServerDataStream;
+		const waiting = inspect.acquireDataSlot(stream);
+
+		stream.destroy(new Error("client disconnected"));
+		await expect(waiting).rejects.toMatchObject({ responseCode: 451 });
+		expect(inspect.dataQueue).toHaveLength(0);
+		release();
+		expect(inspect.activeData).toBe(0);
+	});
+
+	it("releases active DATA slots when a stream closes during collection", async () => {
+		const { inspect } = gateway({ maxConcurrentData: 1, maxDataQueue: 0 });
+		const stream = new PassThrough() as SMTPServerDataStream;
+		const pending = inspect.handleData(
+			stream,
+			session({
+				user: { apiKey: "secret", identity },
+				recipients: ["recipient@example.com"],
+			}),
+		);
+		await Promise.resolve();
+		stream.destroy();
+
+		await expect(pending).rejects.toMatchObject({ responseCode: 451 });
+		expect(inspect.activeData).toBe(0);
+	});
+
+	it("drains rejected DATA streams after a full queue", async () => {
+		const { inspect } = gateway({ maxConcurrentData: 1, maxDataQueue: 0 });
+		const release = await inspect.acquireDataSlot();
+		const stream = dataStream("From: sender@example.com\r\n\r\nHello");
+		const ended = new Promise<void>((resolve) => stream.once("end", resolve));
+		const active = session({ user: { apiKey: "secret", identity } });
+
+		const rejected = await new Promise<Error | null | undefined>((resolve) => {
+			inspect.baseOptions(null).onData?.(stream, active, resolve);
+		});
+		await ended;
+		expect(rejected).toMatchObject({ responseCode: 451 });
+		release();
+	});
+
+	it("drains unauthenticated DATA streams", async () => {
+		const { inspect } = gateway();
+		const stream = dataStream("From: sender@example.com\r\n\r\nHello");
+		const ended = new Promise<void>((resolve) => stream.once("end", resolve));
+
+		const rejected = await new Promise<Error | null | undefined>((resolve) => {
+			inspect.baseOptions(null).onData?.(stream, session(), resolve);
+		});
+		await ended;
+		expect(rejected).toMatchObject({ responseCode: 530 });
+	});
+
+	it("releases queued and active DATA slots after real SMTP clients disconnect", async () => {
+		const { gateway: instance, inspect } = gateway({
+			allowInsecureAuth: true,
+			maxConcurrentData: 1,
+			maxDataQueue: 1,
+			socketTimeoutMs: 2_000,
+		});
+		spyOn(console, "log").mockImplementation(() => {});
+		spyOn(console, "error").mockImplementation(() => {});
+		spyOn(globalThis, "fetch").mockImplementation(
+			Object.assign(async () => Response.json(identity), {
+				preconnect: globalThis.fetch.preconnect,
+			}),
+		);
+		const server = new SMTPServer({
+			...inspect.baseOptions(null),
+			secure: false,
+			disableReverseLookup: true,
+		});
+		inspect.listen(server, 0, "DATA disconnect integration");
+		await new Promise<void>((resolve) =>
+			server.server.once("listening", resolve),
+		);
+		const sockets: Socket[] = [];
+
+		try {
+			const address = server.server.address();
+			if (!address || typeof address === "string") {
+				throw new Error("Expected TCP listener address");
+			}
+			const open = async () => {
+				const socket = createConnection({
+					host: "127.0.0.1",
+					port: address.port,
+				});
+				sockets.push(socket);
+				expect(await socketResponse(socket)).toStartWith("220 ");
+				expect(
+					await smtpCommand(socket, "EHLO client.example.com"),
+				).toStartWith("250-");
+				const credentials = Buffer.from(
+					"\0sender@example.com\0secret",
+				).toString("base64");
+				expect(
+					await smtpCommand(socket, `AUTH PLAIN ${credentials}`),
+				).toStartWith("235 ");
+				expect(
+					await smtpCommand(socket, "MAIL FROM:<sender@example.com>"),
+				).toStartWith("250 ");
+				expect(
+					await smtpCommand(socket, "RCPT TO:<recipient@example.com>"),
+				).toStartWith("250 ");
+				return socket;
+			};
+			const [active, queued] = await Promise.all([open(), open()]);
+			expect(await smtpCommand(active, "DATA")).toStartWith("354 ");
+			expect(await smtpCommand(queued, "DATA")).toStartWith("354 ");
+			await eventually(
+				() =>
+					inspect.activeData === 1 &&
+					inspect.dataQueue.length === 1 &&
+					inspect.sessionDataStreams.size === 2,
+			);
+
+			queued.destroy();
+			await eventually(
+				() =>
+					inspect.activeData === 1 &&
+					inspect.dataQueue.length === 0 &&
+					inspect.sessionDataStreams.size === 1,
+			);
+			active.destroy();
+			await eventually(
+				() =>
+					inspect.activeData === 0 &&
+					inspect.dataQueue.length === 0 &&
+					inspect.sessionDataStreams.size === 0,
+			);
+		} finally {
+			for (const socket of sockets) socket.destroy();
+			await instance.stop();
+		}
+	});
+
+	it("keeps idempotency stable across password rotation for the same credential", async () => {
+		const { inspect } = gateway();
+		spyOn(console, "log").mockImplementation(() => {});
+		const fetchMock = spyOn(globalThis, "fetch").mockImplementation(
+			Object.assign(async () => Response.json({ id: "message-id" }), {
+				preconnect: globalThis.fetch.preconnect,
+			}),
+		);
+		const content =
+			"From: sender@example.com\r\nTo: recipient@example.com\r\n\r\nHello";
+		for (const password of ["original-password", "rotated-password"]) {
+			await inspect.handleData(
+				dataStream(content),
+				session({
+					user: { apiKey: password, identity },
+					recipients: ["recipient@example.com"],
+				}),
+			);
+		}
+
+		const first = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+		const second = new Headers(fetchMock.mock.calls[1]?.[1]?.headers);
+		expect(first.get("Idempotency-Key")).toBe(second.get("Idempotency-Key"));
+		expect(first.get("Authorization")).toBe("Bearer original-password");
+		expect(second.get("Authorization")).toBe("Bearer rotated-password");
+	});
+
+	it("releases DATA slots when upstream send requests time out", async () => {
+		const { inspect } = gateway({
+			maxConcurrentData: 1,
+			maxDataQueue: 0,
+			sendRequestTimeoutMs: 5,
+		});
+		spyOn(globalThis, "fetch").mockImplementation(
+			Object.assign(
+				(
+					_input: Parameters<typeof fetch>[0],
+					options?: Parameters<typeof fetch>[1],
+				) => {
+					return new Promise<Response>((_resolve, reject) => {
+						options?.signal?.addEventListener("abort", () => {
+							reject(options.signal?.reason);
+						});
+					});
+				},
+				{ preconnect: globalThis.fetch.preconnect },
+			),
+		);
+
+		await expect(
+			inspect.handleData(
+				dataStream(
+					"From: sender@example.com\r\nTo: recipient@example.com\r\n\r\nHello",
+				),
+				session({
+					user: { apiKey: "secret", identity },
+					recipients: ["recipient@example.com"],
+				}),
+			),
+		).rejects.toMatchObject({ responseCode: 451 });
+		expect(inspect.activeData).toBe(0);
+	});
+});

--- a/packages/smtp-gateway/src/server.ts
+++ b/packages/smtp-gateway/src/server.ts
@@ -126,13 +126,12 @@ export class SmtpGateway {
 		session: SMTPServerSession,
 	): Promise<SMTPServerAuthenticationResponse> {
 		const ip = session.remoteAddress;
-		this.assertNotThrottled(ip);
-
 		const username = (auth.username ?? "").trim().toLowerCase();
 		const password = (auth.password ?? "").trim();
+		this.assertNotThrottled(ip, username);
 
 		if (!username.includes("@") || password.length === 0) {
-			this.recordFailure(ip);
+			this.recordFailure(ip, username);
 			throw new SmtpRelayError({
 				responseCode: 535,
 				message: "5.7.8 Authentication failed: invalid mailbox credentials",
@@ -141,14 +140,14 @@ export class SmtpGateway {
 
 		const identity = await this.client.authenticateSmtp(username, password);
 		if (!identity) {
-			this.recordFailure(ip);
+			this.recordFailure(ip, username);
 			throw new SmtpRelayError({
 				responseCode: 535,
 				message: "5.7.8 Authentication failed: invalid mailbox credentials",
 			});
 		}
 
-		this.authFailures.delete(ip);
+		this.authFailures.delete(this.authKey(ip, username));
 		const user: AuthenticatedUser = { apiKey: password, identity };
 		return { user };
 	}
@@ -242,13 +241,14 @@ export class SmtpGateway {
 		this.activeData--;
 	}
 
-	private assertNotThrottled(ip: string): void {
-		const record = this.authFailures.get(ip);
+	private assertNotThrottled(ip: string, username: string): void {
+		const key = this.authKey(ip, username);
+		const record = this.authFailures.get(key);
 		if (!record) return;
 		const expired =
 			Date.now() - record.windowStart > this.config.authFailureWindowMs;
 		if (expired) {
-			this.authFailures.delete(ip);
+			this.authFailures.delete(key);
 			return;
 		}
 		if (record.count >= this.config.authFailureLimit) {
@@ -259,14 +259,19 @@ export class SmtpGateway {
 		}
 	}
 
-	private recordFailure(ip: string): void {
+	private recordFailure(ip: string, username: string): void {
 		const now = Date.now();
-		const record = this.authFailures.get(ip);
+		const key = this.authKey(ip, username);
+		const record = this.authFailures.get(key);
 		if (!record || now - record.windowStart > this.config.authFailureWindowMs) {
-			this.authFailures.set(ip, { count: 1, windowStart: now });
+			this.authFailures.set(key, { count: 1, windowStart: now });
 			return;
 		}
 		record.count += 1;
+	}
+
+	private authKey(ip: string, username: string): string {
+		return `${ip}\0${username}`;
 	}
 }
 

--- a/packages/smtp-gateway/src/server.ts
+++ b/packages/smtp-gateway/src/server.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import type { Socket } from "node:net";
 import {
 	SMTPServer,
 	type SMTPServerAuthentication,
@@ -25,13 +26,25 @@ interface FailureRecord {
 	windowStart: number;
 }
 
+interface DataQueueEntry {
+	stream?: SMTPServerDataStream;
+	resolve: (release: () => void) => void;
+	reject: (error: SmtpRelayError) => void;
+	cancel: () => void;
+	cleanup: () => void;
+	canceled: boolean;
+}
+
 export class SmtpGateway {
 	private config: GatewayConfig;
 	private client: InboundApiClient;
 	private authFailures = new Map<string, FailureRecord>();
+	private successfulAuth = new Map<string, number>();
+	private tlsHandshakeTimers = new Map<string, ReturnType<typeof setTimeout>>();
+	private sessionDataStreams = new Map<string, SMTPServerDataStream>();
 	private servers: SMTPServer[] = [];
 	private activeData = 0;
-	private dataQueue: Array<(release: () => void) => void> = [];
+	private dataQueue: DataQueueEntry[] = [];
 
 	constructor(config: GatewayConfig) {
 		this.config = config;
@@ -40,6 +53,19 @@ export class SmtpGateway {
 
 	start(): void {
 		const tls = this.tlsOptions();
+		if (this.config.starttlsPort === 0 && this.config.implicitTlsPort === 0) {
+			throw new Error("No listeners configured");
+		}
+		if (!tls && !this.config.allowInsecureAuth) {
+			throw new Error(
+				"SMTP_TLS_KEY_PATH and SMTP_TLS_CERT_PATH are required unless SMTP_ALLOW_INSECURE_AUTH=true",
+			);
+		}
+		if (this.config.implicitTlsPort > 0 && !tls) {
+			throw new Error(
+				"SMTP_TLS_KEY_PATH and SMTP_TLS_CERT_PATH are required for the implicit TLS listener (set SMTP_IMPLICIT_TLS_PORT=0 to disable)",
+			);
+		}
 		if (this.config.starttlsPort > 0) {
 			this.listen(
 				new SMTPServer({ ...this.baseOptions(tls), secure: false }),
@@ -48,19 +74,11 @@ export class SmtpGateway {
 			);
 		}
 		if (this.config.implicitTlsPort > 0) {
-			if (!tls) {
-				throw new Error(
-					"SMTP_TLS_KEY_PATH and SMTP_TLS_CERT_PATH are required for the implicit TLS listener (set SMTP_IMPLICIT_TLS_PORT=0 to disable)",
-				);
-			}
 			this.listen(
 				new SMTPServer({ ...this.baseOptions(tls), secure: true }),
 				this.config.implicitTlsPort,
 				"implicit TLS",
 			);
-		}
-		if (this.servers.length === 0) {
-			throw new Error("No listeners configured");
 		}
 	}
 
@@ -75,16 +93,26 @@ export class SmtpGateway {
 		);
 	}
 
-	private tlsOptions(): { key: Buffer; cert: Buffer } | null {
+	private tlsOptions(): {
+		key: Buffer;
+		cert: Buffer;
+		minVersion: "TLSv1.2";
+	} | null {
+		if (Boolean(this.config.tlsKeyPath) !== Boolean(this.config.tlsCertPath)) {
+			throw new Error(
+				"SMTP_TLS_KEY_PATH and SMTP_TLS_CERT_PATH must both be configured",
+			);
+		}
 		if (!this.config.tlsKeyPath || !this.config.tlsCertPath) return null;
 		return {
 			key: readFileSync(this.config.tlsKeyPath),
 			cert: readFileSync(this.config.tlsCertPath),
+			minVersion: "TLSv1.2",
 		};
 	}
 
 	private baseOptions(
-		tls: { key: Buffer; cert: Buffer } | null,
+		tls: { key: Buffer; cert: Buffer; minVersion: "TLSv1.2" } | null,
 	): SMTPServerOptions {
 		return {
 			name: this.config.hostname,
@@ -96,20 +124,110 @@ export class SmtpGateway {
 			socketTimeout: this.config.socketTimeoutMs,
 			maxClients: this.config.maxConnections,
 			...(tls ?? {}),
+			onSecure: (socket, session, callback) => {
+				const key = this.handshakeKey(
+					socket.remoteAddress ?? session.remoteAddress,
+					socket.remotePort ?? session.remotePort,
+					socket.localPort ?? session.localPort,
+				);
+				const timer = this.tlsHandshakeTimers.get(key);
+				if (timer) {
+					clearTimeout(timer);
+					this.tlsHandshakeTimers.delete(key);
+				}
+				socket.setTimeout(this.config.socketTimeoutMs);
+				callback();
+			},
 			onAuth: (auth, session, callback) => {
 				this.handleAuth(auth, session)
 					.then((response) => callback(null, response))
 					.catch((error: unknown) => callback(toSmtpError(error)));
 			},
+			onMailFrom: (address, session, callback) => {
+				try {
+					const user = session.user as AuthenticatedUser | undefined;
+					if (!user?.identity) {
+						throw new SmtpRelayError({
+							responseCode: 530,
+							message: "5.7.0 Authentication required",
+						});
+					}
+					if (address.address) {
+						this.assertSenderAllowed(user.identity, address.address);
+					}
+					callback();
+				} catch (error: unknown) {
+					callback(toSmtpError(error));
+				}
+			},
+			onRcptTo: (address, session, callback) => {
+				const duplicate = session.envelope.rcptTo.some(
+					(recipient) =>
+						recipient.address.toLowerCase() === address.address.toLowerCase(),
+				);
+				if (
+					!duplicate &&
+					session.envelope.rcptTo.length >=
+						Math.min(this.config.maxRecipients, 50)
+				) {
+					callback(
+						toSmtpError(
+							new SmtpRelayError({
+								responseCode: 452,
+								message: "4.5.3 Too many recipients",
+							}),
+						),
+					);
+					return;
+				}
+				callback();
+			},
 			onData: (stream, session, callback) => {
+				this.sessionDataStreams.set(session.id, stream);
 				this.handleData(stream, session)
 					.then((message) => callback(null, message))
-					.catch((error: unknown) => callback(toSmtpError(error)));
+					.catch((error: unknown) => {
+						stream.resume();
+						callback(toSmtpError(error));
+					})
+					.finally(() => {
+						if (this.sessionDataStreams.get(session.id) === stream) {
+							this.sessionDataStreams.delete(session.id);
+						}
+					});
+			},
+			onClose: (session, callback) => {
+				const stream = this.sessionDataStreams.get(session.id);
+				if (stream) {
+					this.sessionDataStreams.delete(session.id);
+					stream.destroy();
+				}
+				const key = this.handshakeKey(
+					session.remoteAddress,
+					session.remotePort,
+					session.localPort,
+				);
+				const timer = this.tlsHandshakeTimers.get(key);
+				if (timer) {
+					clearTimeout(timer);
+					this.tlsHandshakeTimers.delete(key);
+				}
+				callback?.();
 			},
 		};
 	}
 
 	private listen(server: SMTPServer, port: number, label: string): void {
+		server.server.maxConnections = this.config.maxConnections;
+		if (server.options.secure) {
+			server.server.on("connection", (socket) => {
+				this.startHandshakeTimer(socket);
+			});
+		} else if (!server.options.disabledCommands?.includes("STARTTLS")) {
+			server.server.on("connection", (socket) => {
+				this.monitorStartTls(socket);
+			});
+		}
 		server.on("error", (error) => {
 			console.error(`[smtp-gateway] ${label} listener error`, error);
 		});
@@ -121,10 +239,65 @@ export class SmtpGateway {
 		this.servers.push(server);
 	}
 
+	private monitorStartTls(socket: Socket): void {
+		let command = "";
+		let overflow = false;
+		const onData = (chunk: Buffer | string) => {
+			const bytes = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+			for (const byte of bytes) {
+				if (byte === 10) {
+					if (!overflow && command.trim().toUpperCase() === "STARTTLS") {
+						socket.removeListener("data", onData);
+						this.startHandshakeTimer(socket);
+						return;
+					}
+					command = "";
+					overflow = false;
+					continue;
+				}
+				if (command.length < 512) {
+					command += String.fromCharCode(byte);
+				} else {
+					overflow = true;
+				}
+			}
+		};
+		socket.on("data", onData);
+		socket.once("close", () => socket.removeListener("data", onData));
+	}
+
+	private startHandshakeTimer(socket: Socket): void {
+		const key = this.handshakeKey(
+			socket.remoteAddress ?? "",
+			socket.remotePort ?? 0,
+			socket.localPort ?? 0,
+		);
+		const previous = this.tlsHandshakeTimers.get(key);
+		if (previous) clearTimeout(previous);
+		const timer = setTimeout(() => {
+			this.tlsHandshakeTimers.delete(key);
+			socket.destroy();
+		}, this.config.tlsHandshakeTimeoutMs);
+		timer.unref();
+		this.tlsHandshakeTimers.set(key, timer);
+		socket.once("close", () => {
+			if (this.tlsHandshakeTimers.get(key) === timer) {
+				clearTimeout(timer);
+				this.tlsHandshakeTimers.delete(key);
+			}
+		});
+	}
+
 	private async handleAuth(
 		auth: SMTPServerAuthentication,
 		session: SMTPServerSession,
 	): Promise<SMTPServerAuthenticationResponse> {
+		if (!session.secure && !this.config.allowInsecureAuth) {
+			throw new SmtpRelayError({
+				responseCode: 538,
+				message: "5.7.11 Encryption required for authentication",
+			});
+		}
 		const ip = session.remoteAddress;
 		const username = (auth.username ?? "").trim().toLowerCase();
 		const password = (auth.password ?? "").trim();
@@ -147,7 +320,11 @@ export class SmtpGateway {
 			});
 		}
 
-		this.authFailures.delete(this.authKey(ip, username));
+		const key = this.authKey(ip, username);
+		this.authFailures.delete(key);
+		this.successfulAuth.delete(key);
+		this.successfulAuth.set(key, Date.now());
+		this.limitRecords(this.successfulAuth);
 		const user: AuthenticatedUser = { apiKey: password, identity };
 		return { user };
 	}
@@ -164,8 +341,14 @@ export class SmtpGateway {
 			});
 		}
 
-		const release = await this.acquireDataSlot();
+		const release = await this.acquireDataSlot(stream);
 		try {
+			if (stream.destroyed && !stream.readableEnded) {
+				throw new SmtpRelayError({
+					responseCode: 451,
+					message: "4.3.0 SMTP connection closed before message processing",
+				});
+			}
 			const raw = await collectStream(stream, this.config.maxMessageBytes);
 			if (stream.sizeExceeded) {
 				throw new SmtpRelayError({
@@ -192,7 +375,7 @@ export class SmtpGateway {
 			const result = await this.client.sendEmail(
 				user.apiKey,
 				mapped.payload,
-				idempotencyKeyFor(raw, user.apiKey),
+				idempotencyKeyFor(raw, user.identity.credentialId, envelope),
 			);
 			console.log(
 				`[smtp-gateway] relayed message ${result.id} from=${mapped.payload.from} recipients=${envelope.rcptTo.length}`,
@@ -218,7 +401,7 @@ export class SmtpGateway {
 		}
 	}
 
-	private acquireDataSlot(): Promise<() => void> {
+	private acquireDataSlot(stream?: SMTPServerDataStream): Promise<() => void> {
 		if (this.activeData < this.config.maxConcurrentData) {
 			this.activeData++;
 			return Promise.resolve(() => this.releaseDataSlot());
@@ -229,29 +412,87 @@ export class SmtpGateway {
 				message: "4.3.2 Gateway busy, try again later",
 			});
 		}
-		return new Promise((resolve) => this.dataQueue.push(resolve));
+		return new Promise((resolve, reject) => {
+			const entry: DataQueueEntry = {
+				stream,
+				resolve,
+				reject,
+				canceled: false,
+				cancel: () => {
+					if (entry.canceled) return;
+					entry.canceled = true;
+					entry.cleanup();
+					const index = this.dataQueue.indexOf(entry);
+					if (index >= 0) this.dataQueue.splice(index, 1);
+					entry.reject(
+						new SmtpRelayError({
+							responseCode: 451,
+							message: "4.3.0 SMTP connection closed before message processing",
+						}),
+					);
+				},
+				cleanup: () => {
+					stream?.removeListener("close", entry.cancel);
+					stream?.removeListener("error", entry.cancel);
+				},
+			};
+			if (stream?.destroyed) {
+				entry.cancel();
+				return;
+			}
+			stream?.once("close", entry.cancel);
+			stream?.once("error", entry.cancel);
+			this.dataQueue.push(entry);
+		});
 	}
 
 	private releaseDataSlot(): void {
-		const next = this.dataQueue.shift();
-		if (next) {
-			next(() => this.releaseDataSlot());
+		while (this.dataQueue.length > 0) {
+			const next = this.dataQueue.shift();
+			if (!next) break;
+			if (next.canceled || next.stream?.destroyed) {
+				next.cancel();
+				continue;
+			}
+			next.cleanup();
+			next.resolve(() => this.releaseDataSlot());
 			return;
 		}
 		this.activeData--;
 	}
 
 	private assertNotThrottled(ip: string, username: string): void {
+		const now = Date.now();
 		const key = this.authKey(ip, username);
-		const record = this.authFailures.get(key);
-		if (!record) return;
-		const expired =
-			Date.now() - record.windowStart > this.config.authFailureWindowMs;
-		if (expired) {
-			this.authFailures.delete(key);
-			return;
+		const record = this.failureRecord(key, now);
+		if (record && record.count >= this.config.authFailureLimit) {
+			throw new SmtpRelayError({
+				responseCode: 421,
+				message: "4.7.0 Too many failed authentication attempts, slow down",
+			});
 		}
-		if (record.count >= this.config.authFailureLimit) {
+		const successfulAt = this.successfulAuth.get(key);
+		if (successfulAt !== undefined) {
+			if (now - successfulAt <= this.config.authFailureWindowMs) return;
+			this.successfulAuth.delete(key);
+		}
+		const aggregate = this.failureRecord(this.ipAuthKey(ip), now);
+		if (aggregate && aggregate.count >= this.config.authFailureIpLimit) {
+			throw new SmtpRelayError({
+				responseCode: 421,
+				message: "4.7.0 Too many failed authentication attempts, slow down",
+			});
+		}
+		if (
+			!record &&
+			!aggregate &&
+			this.authFailures.size >= this.config.maxAuthFailureRecords &&
+			[...this.authFailures].every(
+				([failureKey, failure]) =>
+					now - failure.windowStart <= this.config.authFailureWindowMs &&
+					this.failureBlocked(failureKey, failure),
+			)
+		) {
 			throw new SmtpRelayError({
 				responseCode: 421,
 				message: "4.7.0 Too many failed authentication attempts, slow down",
@@ -261,17 +502,75 @@ export class SmtpGateway {
 
 	private recordFailure(ip: string, username: string): void {
 		const now = Date.now();
-		const key = this.authKey(ip, username);
+		for (const key of [this.authKey(ip, username), this.ipAuthKey(ip)]) {
+			const record = this.failureRecord(key, now);
+			if (record) {
+				record.count += 1;
+				continue;
+			}
+			if (this.reserveFailureRecord(now)) {
+				this.authFailures.set(key, { count: 1, windowStart: now });
+			}
+		}
+	}
+
+	private reserveFailureRecord(now: number): boolean {
+		if (this.authFailures.size < this.config.maxAuthFailureRecords) return true;
+		let candidate: string | undefined;
+		for (const [key, record] of this.authFailures) {
+			if (now - record.windowStart > this.config.authFailureWindowMs) {
+				this.authFailures.delete(key);
+				return true;
+			}
+			if (this.failureBlocked(key, record)) continue;
+			if (candidate === undefined || key.startsWith("user:")) {
+				candidate = key;
+				if (key.startsWith("user:")) break;
+			}
+		}
+		if (candidate === undefined) return false;
+		this.authFailures.delete(candidate);
+		return true;
+	}
+
+	private failureBlocked(key: string, record: FailureRecord): boolean {
+		const limit = key.startsWith("ip:")
+			? this.config.authFailureIpLimit
+			: this.config.authFailureLimit;
+		return record.count >= limit;
+	}
+
+	private failureRecord(key: string, now: number): FailureRecord | undefined {
 		const record = this.authFailures.get(key);
-		if (!record || now - record.windowStart > this.config.authFailureWindowMs) {
-			this.authFailures.set(key, { count: 1, windowStart: now });
+		if (record && now - record.windowStart > this.config.authFailureWindowMs) {
+			this.authFailures.delete(key);
 			return;
 		}
-		record.count += 1;
+		return record;
+	}
+
+	private limitRecords<T>(records: Map<string, T>): void {
+		while (records.size > this.config.maxAuthFailureRecords) {
+			const oldest = records.keys().next().value;
+			if (oldest === undefined) return;
+			records.delete(oldest);
+		}
+	}
+
+	private handshakeKey(
+		remoteAddress: string,
+		remotePort: number,
+		localPort: number,
+	): string {
+		return `${remoteAddress.replace(/^::ffff:/, "")}\0${remotePort}\0${localPort}`;
 	}
 
 	private authKey(ip: string, username: string): string {
-		return `${ip}\0${username}`;
+		return `user:${ip}\0${username}`;
+	}
+
+	private ipAuthKey(ip: string): string {
+		return `ip:${ip}`;
 	}
 }
 
@@ -286,8 +585,18 @@ function collectStream(
 			total += chunk.length;
 			if (total <= maxBytes) chunks.push(chunk);
 		});
-		stream.on("end", () => resolve(Buffer.concat(chunks)));
-		stream.on("error", reject);
+		stream.once("end", () => resolve(Buffer.concat(chunks)));
+		stream.once("error", reject);
+		stream.once("close", () => {
+			if (!stream.readableEnded) {
+				reject(
+					new SmtpRelayError({
+						responseCode: 451,
+						message: "4.3.0 SMTP connection closed during message processing",
+					}),
+				);
+			}
+		});
 	});
 }
 

--- a/packages/smtp-gateway/tsconfig.json
+++ b/packages/smtp-gateway/tsconfig.json
@@ -4,7 +4,7 @@
 		"module": "ESNext",
 		"moduleResolution": "bundler",
 		"lib": ["ES2022"],
-		"types": ["node"],
+		"types": ["node", "bun-types"],
 		"strict": true,
 		"allowImportingTsExtensions": true,
 		"noEmit": true,

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { unstable_doesMiddlewareMatch } from "next/dist/experimental/testing/server/middleware-testing-utils";
+import { NextRequest } from "next/server";
+import { HOMEPAGE_EXPERIMENT_COOKIE } from "@/lib/homepage-experiment";
+import { config, proxy } from "@/proxy";
+
+afterEach(() => {
+	spyOn(Math, "random").mockRestore();
+});
+
+describe("homepage experiment proxy", () => {
+	it.each([
+		"control",
+		"redesign",
+	] as const)("keeps an existing %s assignment without resetting its cookie", (variant) => {
+		const request = new NextRequest("https://inbound.new/", {
+			headers: {
+				cookie: `${HOMEPAGE_EXPERIMENT_COOKIE}=${variant}`,
+			},
+		});
+
+		const response = proxy(request);
+
+		expect(request.cookies.get(HOMEPAGE_EXPERIMENT_COOKIE)?.value).toBe(
+			variant,
+		);
+		expect(response.cookies.get(HOMEPAGE_EXPERIMENT_COOKIE)).toBeUndefined();
+		expect(response.headers.get("set-cookie")).toBeNull();
+	});
+
+	it.each([
+		["control", "redesign"],
+		["redesign", "control"],
+	] as const)("overrides an existing %s assignment with variant=%s", (existing, override) => {
+		const url = `https://inbound.new/?variant=${override}&source=newsletter`;
+		const request = new NextRequest(url, {
+			headers: {
+				cookie: `${HOMEPAGE_EXPERIMENT_COOKIE}=${existing}`,
+			},
+		});
+
+		const response = proxy(request);
+
+		expect(request.cookies.get(HOMEPAGE_EXPERIMENT_COOKIE)?.value).toBe(
+			override,
+		);
+		expect(response.cookies.get(HOMEPAGE_EXPERIMENT_COOKIE)?.value).toBe(
+			override,
+		);
+		expect(response.headers.get("x-middleware-request-cookie")).toContain(
+			`${HOMEPAGE_EXPERIMENT_COOKIE}=${override}`,
+		);
+		expect(request.nextUrl.href).toBe(url);
+		expect(response.headers.get("location")).toBeNull();
+	});
+
+	it("assigns control to a missing cookie below the random midpoint", () => {
+		spyOn(Math, "random").mockReturnValue(0.49);
+		const request = new NextRequest("https://inbound.new/");
+
+		const response = proxy(request);
+
+		expect(request.cookies.get(HOMEPAGE_EXPERIMENT_COOKIE)?.value).toBe(
+			"control",
+		);
+		expect(response.cookies.get(HOMEPAGE_EXPERIMENT_COOKIE)?.value).toBe(
+			"control",
+		);
+		expect(response.headers.get("x-middleware-request-cookie")).toBe(
+			`${HOMEPAGE_EXPERIMENT_COOKIE}=control`,
+		);
+	});
+
+	it("replaces an invalid cookie with redesign at the random midpoint", () => {
+		spyOn(Math, "random").mockReturnValue(0.5);
+		const request = new NextRequest("https://inbound.new/", {
+			headers: {
+				cookie: `${HOMEPAGE_EXPERIMENT_COOKIE}=invalid`,
+			},
+		});
+
+		const response = proxy(request);
+
+		expect(request.cookies.get(HOMEPAGE_EXPERIMENT_COOKIE)?.value).toBe(
+			"redesign",
+		);
+		expect(response.cookies.get(HOMEPAGE_EXPERIMENT_COOKIE)?.value).toBe(
+			"redesign",
+		);
+	});
+
+	it("ignores an invalid variant override and keeps a valid cookie", () => {
+		const request = new NextRequest("https://inbound.new/?variant=invalid", {
+			headers: {
+				cookie: `${HOMEPAGE_EXPERIMENT_COOKIE}=control`,
+			},
+		});
+
+		const response = proxy(request);
+
+		expect(request.cookies.get(HOMEPAGE_EXPERIMENT_COOKIE)?.value).toBe(
+			"control",
+		);
+		expect(response.headers.get("set-cookie")).toBeNull();
+	});
+
+	it("persists assignments for 90 days with browser-accessible lax cookies", () => {
+		spyOn(Math, "random").mockReturnValue(0);
+
+		const response = proxy(new NextRequest("https://inbound.new/"));
+		const cookie = response.cookies.get(HOMEPAGE_EXPERIMENT_COOKIE);
+
+		expect(cookie).toMatchObject({
+			name: HOMEPAGE_EXPERIMENT_COOKIE,
+			value: "control",
+			maxAge: 90 * 24 * 60 * 60,
+			path: "/",
+			sameSite: "lax",
+			secure: process.env.NODE_ENV === "production",
+			httpOnly: false,
+		});
+		expect(response.headers.get("set-cookie")).toContain("Max-Age=7776000");
+		expect(response.headers.get("set-cookie")).not.toContain("HttpOnly");
+	});
+
+	it("matches only the homepage", () => {
+		expect(
+			unstable_doesMiddlewareMatch({ config, nextConfig: {}, url: "/" }),
+		).toBe(true);
+		expect(
+			unstable_doesMiddlewareMatch({
+				config,
+				nextConfig: {},
+				url: "/?variant=redesign&source=newsletter",
+			}),
+		).toBe(true);
+		expect(
+			unstable_doesMiddlewareMatch({ config, nextConfig: {}, url: "/pricing" }),
+		).toBe(false);
+		expect(
+			unstable_doesMiddlewareMatch({ config, nextConfig: {}, url: "/api/e2" }),
+		).toBe(false);
+	});
+});

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,38 @@
+import { type NextRequest, NextResponse } from "next/server";
+import {
+	HOMEPAGE_EXPERIMENT_COOKIE,
+	type HomepageVariant,
+	isHomepageVariant,
+} from "@/lib/homepage-experiment";
+
+export function proxy(request: NextRequest) {
+	const override = request.nextUrl.searchParams.get("variant");
+	const existing = request.cookies.get(HOMEPAGE_EXPERIMENT_COOKIE)?.value;
+	const variant: HomepageVariant = isHomepageVariant(override)
+		? override
+		: isHomepageVariant(existing)
+			? existing
+			: Math.random() < 0.5
+				? "control"
+				: "redesign";
+
+	if (variant !== existing) {
+		request.cookies.set(HOMEPAGE_EXPERIMENT_COOKIE, variant);
+	}
+
+	const response = NextResponse.next({ request: { headers: request.headers } });
+
+	if (variant !== existing) {
+		response.cookies.set(HOMEPAGE_EXPERIMENT_COOKIE, variant, {
+			maxAge: 90 * 24 * 60 * 60,
+			path: "/",
+			sameSite: "lax",
+			secure: process.env.NODE_ENV === "production",
+			httpOnly: false,
+		});
+	}
+
+	return response;
+}
+
+export const config = { matcher: "/" };


### PR DESCRIPTION
## Behavior

`sent_emails` now declares a same-user unique constraint on `(user_id, idempotency_key)`. The key column remains nullable, so PostgreSQL still allows multiple rows with `NULL` idempotency keys.

The immediate `/api/e2/emails` insert uses that constraint as its conflict boundary. A conflict is looked up within the same `userId` and uses the existing replay behavior: a sent record returns `200` with its ID, and a non-sent record returns `503` with `Retry-After: 60`. The conflict path returns before SES is called. An `Idempotency-Key` body mismatch is not newly validated. No `scheduled_at` behavior was addressed in this change.

## Tests

Attempted:
`bun test app/api/e2/e2e.test.ts --test-name-pattern "prevents duplicate outbound records for concurrent idempotency-key sends"`

The test did not run because `INBOUND_API_KEY` was missing in the environment.

## Migration And Duplicate Data

This branch updates `lib/db/schema.ts`, but Drizzle migration generation and push were not run. Before deploying, from the repo root with `DATABASE_URL` set, run `bunx drizzle-kit generate`, review the generated migration for `sent_emails_user_idempotency_key_unique`, then run `bunx drizzle-kit push`.

Before applying the new unique constraint, check for preexisting duplicate non-null same-user keys. This count-only query should return `0` before the constraint is applied:

```sql
SELECT COUNT(*) AS duplicate_user_idempotency_key_groups
FROM (
  SELECT "user_id", "idempotency_key"
  FROM "sent_emails"
  WHERE "idempotency_key" IS NOT NULL
  GROUP BY "user_id", "idempotency_key"
  HAVING COUNT(*) > 1
) AS duplicate_keys;
```

Do not delete or alter existing data to make the constraint fit. If the count is nonzero, stop and resolve those records using the appropriate data review process before applying it.

## Caveat

Postgres and SES are not one transaction. If SES accepts a message but the process fails before marking the `sentEmails` row as sent, the database can remain non-sent while SES may have accepted the message; the existing retry semantics return `503` for that non-sent key rather than proving provider outcome.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes touch email send deduplication (DB migration required), authentication/rate limiting, and IMAP access control; misconfiguration or duplicate idempotency rows could block deploys or affect deliverability and login behavior.
> 
> **Overview**
> **Concurrent send idempotency** is enforced with a per-user unique `(user_id, idempotency_key)` on `sent_emails`, an insert that uses `onConflictDoNothing`, and shared replay logic: successful sends return the existing `id`, in-flight/failed keys return **503** with `Retry-After`. An E2E test fires two parallel POSTs with the same key. Send validation also requires at least one `to`/`cc`/`bcc` recipient and accepts optional attachment `content_id`.
> 
> **Outbound MIME** no longer puts **Bcc** in generated headers; empty **To** becomes `undisclosed-recipients:;` with unit tests.
> 
> **E2 API auth** refactors ban/rate-limit checks into `enforceAuthenticatedUserAndRateLimit` (used for session/API keys and `mail_`/`imap_` send auth). Mailbox and SMTP authenticate endpoints get Redis limits keyed by trusted client IP plus normalized login, with 429/503 responses. Managed credential verification **rethrows** verifier outages instead of treating them as invalid passwords.
> 
> **Homepage** splits into a cookie-driven **control vs redesign** experiment: the old layout lives in `HomepageControl`, the new marketing page is the redesign variant, with view tracking and `homepage_variant` on analytics events.
> 
> **IMAP gateway** gets stricter config (timeouts, APPEND size, TLS 1.2), auth fetch timeouts and non-401 error propagation, per-IP+username brute-force limits, Guard-blocked / scope-filtered mail sync and FETCH, read-only enforcement for scope folders and mismatched SELECT, vendor protocol tightening (no CONDSTORE/PLAIN-CLIENTTOKEN, configurable APPEND limit), graceful shutdown, and **nodemailer** 9.x.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fb414f9847f4e56321a0ff5dc835b435537885f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->