### PR TITLE
Prevent concurrent E2 email sends with idempotency keys

### DIFF
--- a/app/api/e2/e2e.test.ts
+++ b/app/api/e2/e2e.test.ts
@@ -1618,6 +1618,71 @@ describe("E2 API - Email E2E", () => {
 	);
 
 	it(
+		"prevents duplicate outbound records for concurrent idempotency-key sends",
+		async () => {
+			const token = makeToken("idem-race");
+			const subject = `[[[DEV||| E2E Idempotency Race ${token}`;
+			const idempotencyKey = `e2e-idempotency-race-${token}`;
+			const payload = {
+				from: E2E_SENDER_ADDRESS,
+				to: E2E_RECIPIENT_ADDRESS,
+				subject,
+				text: `Idempotency race text marker ${token}`,
+				html: `<p>Idempotency race html marker <strong>${token}</strong></p>`,
+			};
+			const requestOptions: RequestInit = {
+				method: "POST",
+				headers: {
+					"Idempotency-Key": idempotencyKey,
+				},
+				body: JSON.stringify(payload),
+			};
+
+			const [firstSend, secondSend] = await Promise.all([
+				apiJsonWithKey<SendEmailResponse | { error: string }>(
+					"/emails",
+					API_KEY as string,
+					requestOptions,
+				),
+				apiJsonWithKey<SendEmailResponse | { error: string }>(
+					"/emails",
+					API_KEY as string,
+					requestOptions,
+				),
+			]);
+
+			const sends = [firstSend, secondSend];
+			expect(
+				sends.every(
+					(send) => send.response.status === 200 || send.response.status === 503,
+				),
+			).toBe(true);
+
+			const successfulIds = sends.flatMap((send) =>
+				send.response.status === 200 && "id" in send.data
+					? [send.data.id]
+					: [],
+			);
+			expect(successfulIds.length).toBeGreaterThanOrEqual(1);
+			expect(new Set(successfulIds).size).toBe(1);
+
+			const sentMatches = await waitForExactSubjectEmailCount(
+				"sent",
+				subject,
+				1,
+			);
+			expect(sentMatches).toBeDefined();
+			if (!sentMatches) {
+				return;
+			}
+
+			expect(sentMatches.length).toBe(1);
+			expect(sentMatches[0]?.id).toBe(successfulIds[0]);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
 		"deduplicates repeated inbound webhook payloads for the same message",
 		async () => {
 			const token = makeToken("dedupe");

--- a/app/api/e2/emails/send.ts
+++ b/app/api/e2/emails/send.ts
@@ -3,6 +3,7 @@ import { Client as QStashClient } from "@upstash/qstash";
 import { waitUntil } from "@vercel/functions";
 import { Autumn as autumn } from "autumn-js";
 import { and, eq } from "drizzle-orm";
+import type { InferSelectModel } from "drizzle-orm";
 import { Elysia, t } from "elysia";
 import { nanoid } from "nanoid";
 import { buildSentEmailTags } from "@/app/api/e2/helper/ses-email-tags";
@@ -184,10 +185,12 @@ export const sendEmail = new Elysia().post(
 
 		// Check for idempotency key
 		const idempotencyKey = request.headers.get("Idempotency-Key");
-		if (idempotencyKey) {
-			console.log("🔑 Idempotency key provided:", idempotencyKey);
+		const findExistingIdempotencyEmail = async () => {
+			if (!idempotencyKey) {
+				return undefined;
+			}
 
-			const existingEmail = await db
+			const [existingEmail] = await db
 				.select()
 				.from(sentEmails)
 				.where(
@@ -198,12 +201,33 @@ export const sendEmail = new Elysia().post(
 				)
 				.limit(1);
 
-			if (existingEmail.length > 0) {
-				console.log(
-					"♻️ Idempotent request - returning existing email:",
-					existingEmail[0].id,
-				);
-				return { id: existingEmail[0].id };
+			return existingEmail;
+		};
+		const returnExistingIdempotencyResponse = (
+			existingEmail: InferSelectModel<typeof sentEmails>,
+		) => {
+			if (existingEmail.status !== SENT_EMAIL_STATUS.SENT) {
+				set.status = 503;
+				set.headers["Retry-After"] = "60";
+				return {
+					error:
+						"An email with this idempotency key has not been successfully sent. Please try again later.",
+				};
+			}
+
+			console.log(
+				"♻️ Idempotent request - returning existing email:",
+				existingEmail.id,
+			);
+			return { id: existingEmail.id };
+		};
+
+		if (idempotencyKey) {
+			console.log("🔑 Idempotency key provided:", idempotencyKey);
+
+			const existingEmail = await findExistingIdempotencyEmail();
+			if (existingEmail) {
+				return returnExistingIdempotencyResponse(existingEmail);
 			}
 		}
 
@@ -475,31 +499,46 @@ export const sendEmail = new Elysia().post(
 		const emailId = nanoid();
 		console.log("💾 Creating sent email record:", emailId);
 
-		await db.insert(sentEmails).values({
-			id: emailId,
-			from: body.from,
-			fromAddress,
-			fromDomain,
-			to: JSON.stringify(toAddresses),
-			cc: ccAddresses.length > 0 ? JSON.stringify(ccAddresses) : null,
-			bcc: bccAddresses.length > 0 ? JSON.stringify(bccAddresses) : null,
-			replyTo:
-				replyToAddresses.length > 0 ? JSON.stringify(replyToAddresses) : null,
-			subject: body.subject,
-			textBody: body.text,
-			htmlBody: body.html,
-			headers: body.headers ? JSON.stringify(body.headers) : null,
-			attachments:
-				processedAttachments.length > 0
-					? JSON.stringify(attachmentsToStorageFormat(processedAttachments))
-					: null,
-			tags: body.tags ? JSON.stringify(body.tags) : null,
-			status: SENT_EMAIL_STATUS.PENDING,
-			userId,
-			idempotencyKey,
-			createdAt: new Date(),
-			updatedAt: new Date(),
-		});
+		const [createdEmail] = await db
+			.insert(sentEmails)
+			.values({
+				id: emailId,
+				from: body.from,
+				fromAddress,
+				fromDomain,
+				to: JSON.stringify(toAddresses),
+				cc: ccAddresses.length > 0 ? JSON.stringify(ccAddresses) : null,
+				bcc: bccAddresses.length > 0 ? JSON.stringify(bccAddresses) : null,
+				replyTo:
+					replyToAddresses.length > 0 ? JSON.stringify(replyToAddresses) : null,
+				subject: body.subject,
+				textBody: body.text,
+				htmlBody: body.html,
+				headers: body.headers ? JSON.stringify(body.headers) : null,
+				attachments:
+					processedAttachments.length > 0
+						? JSON.stringify(attachmentsToStorageFormat(processedAttachments))
+						: null,
+				tags: body.tags ? JSON.stringify(body.tags) : null,
+				status: SENT_EMAIL_STATUS.PENDING,
+				userId,
+				idempotencyKey: idempotencyKey || null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			})
+			.onConflictDoNothing({
+				target: [sentEmails.userId, sentEmails.idempotencyKey],
+			})
+			.returning({ id: sentEmails.id });
+
+		if (!createdEmail) {
+			const existingEmail = await findExistingIdempotencyEmail();
+			if (!existingEmail) {
+				throw new Error("Sent email insert returned no row");
+			}
+
+			return returnExistingIdempotencyResponse(existingEmail);
+		}
 
 		// Check if SES is configured
 		if (!sesClient) {
@@ -682,6 +721,7 @@ export const sendEmail = new Elysia().post(
 			403: ErrorResponse,
 			429: ErrorResponse,
 			500: ErrorResponse,
+			503: ErrorResponse,
 		},
 		detail: {
 			tags: ["Emails"],

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -610,6 +610,9 @@ export const sentEmails = pgTable(
 			table.userId,
 			table.firstOpenedAt,
 		),
+		uniqueUserIdempotencyKey: unique(
+			"sent_emails_user_idempotency_key_unique",
+		).on(table.userId, table.idempotencyKey),
 	}),
 );
 


### PR DESCRIPTION
## Summary

Isolates the immediate email-send idempotency change from #181 onto a branch based directly on `main`. This PR changes only three files.

- Declare a unique constraint on `sent_emails (user_id, idempotency_key)`. Nullable keys remain supported.
- Use `onConflictDoNothing` at the immediate-send insert boundary and return before SES is called when another request already owns the same key. Existing sent records replay with HTTP 200 and their ID; pending or failed records return HTTP 503 with `Retry-After: 60`.
- Add an E2E test issuing two concurrent sends with the same key and checking for one outbound record.

## Scope

No homepage experiment, IMAP/SMTP gateway hardening, shared-auth changes, attachment schema changes, MIME changes, or recipient-validation changes from #181 are included. #181 remains unchanged.

Scheduled-send idempotency and request-body mismatch validation are not addressed.

## Verification

- Passed Bun syntax checks for all three changed TypeScript files.
- Passed `git diff --check origin/main...HEAD`.
- Confirmed the branch contains one commit and only the send handler, database schema, and concurrency test differ from `main`.
- Live send E2E was not run: its setup starts a local Next.js dev server and ngrok tunnel, which require separate approval in this repository.

## Required Before Deployment

The database migration is not included or applied. Read-only inspection of the locally configured database found no unique index for `(user_id, idempotency_key)`.

Manually generate, review, and apply the migration before deploying this code. Check for duplicate non-null same-user keys first; if duplicates exist, stop for appropriate data review rather than deleting or altering records automatically.

The insert conflict target is unconditional, so deployment without the unique index will fail immediate sends even when no idempotency key is supplied.

## Known Limitations

PostgreSQL and SES are not one transaction. An accepted SES message can remain non-sent in the database after a process failure. Pending and failed keys currently continue returning 503; this extraction does not add recovery or provider-outcome reconciliation.

Other writers to `sent_emails`, including the reply handler and legacy SMTP relay, retain their existing lookup-then-insert behavior and can receive unique violations under concurrent same-key requests once the constraint is installed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core outbound send path and requires a migration; wrong deploy order or duplicate legacy rows can break sends or change client-visible status codes for in-flight idempotency keys.
> 
> **Overview**
> **Hardens immediate E2 `/emails` sends** so the same user + `Idempotency-Key` cannot create two outbound `sent_emails` rows when requests race.
> 
> Adds a **unique constraint** on `sent_emails (user_id, idempotency_key)` and switches the immediate-send insert to **`onConflictDoNothing`** on that pair. The winner proceeds to SES; the loser reloads the existing row and returns the shared idempotency response **without calling SES again**.
> 
> **Idempotent replay behavior changes:** repeats return **HTTP 200** with the existing email id only when status is **`sent`**; **pending** or **failed** rows return **HTTP 503** with **`Retry-After: 60`**. The OpenAPI schema documents **503**.
> 
> Adds an **E2E test** that fires two concurrent POSTs with the same idempotency key and asserts a single sent record (200 or 503 on the loser while in-flight).
> 
> **Deploy note:** a DB migration must land before this code; the conflict target is always used on insert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57f349be88f2e2509a72bb4118a69a38589dc186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->