### PR TITLE
Allow calendar invitation attachments

### DIFF
--- a/app/api/e2/helper/attachment-processor.test.ts
+++ b/app/api/e2/helper/attachment-processor.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { processAttachments } from "@/app/api/e2/helper/attachment-processor";
+
+describe("processAttachments calendar invitations", () => {
+	it("accepts an ICS attachment while preserving MIME parameters and calendar bytes", async () => {
+		const calendar = Buffer.from(
+			[
+				"BEGIN:VCALENDAR",
+				"VERSION:2.0",
+				"PRODID:-//Example//Calendar Invitation//EN",
+				"METHOD:REQUEST",
+				"BEGIN:VEVENT",
+				"UID:calendar-invitation@example.com",
+				"DTSTAMP:20260827T120000Z",
+				"DTSTART:20260828T180000Z",
+				"DTEND:20260828T190000Z",
+				"SUMMARY:Café meetup",
+				"ORGANIZER:mailto:organizer@example.com",
+				"ATTENDEE;RSVP=TRUE:mailto:attendee@example.com",
+				"END:VEVENT",
+				"END:VCALENDAR",
+				"",
+			].join("\r\n"),
+			"utf8",
+		);
+		const content = calendar.toString("base64");
+		const contentType = "text/calendar; charset=utf-8; method=REQUEST";
+		const attachments = await processAttachments([
+			{
+				filename: "invitation.ics",
+				content,
+				content_type: contentType,
+			},
+		]);
+
+		expect(attachments).toHaveLength(1);
+		expect(attachments[0]).toMatchObject({
+			filename: "invitation.ics",
+			content,
+			contentType,
+			size: calendar.byteLength,
+		});
+		expect(Buffer.from(attachments[0].content, "base64")).toEqual(calendar);
+	});
+});

--- a/app/api/e2/helper/attachment-processor.ts
+++ b/app/api/e2/helper/attachment-processor.ts
@@ -59,6 +59,7 @@ const ALLOWED_CONTENT_TYPES = [
   
   // Text and Data
   'text/plain',
+  'text/calendar',
   'text/csv',
   'text/html',
   'text/css',


### PR DESCRIPTION
## Summary

POST /api/e2/emails rejects valid base64 ICS calendar invitations with `content_type: text/calendar; charset=utf-8; method=REQUEST` as HTTP 400:

> Attachment 1: File type 'text/calendar' is not supported. Please use a common document, image, text, or archive format.

The processor already normalizes MIME parameters for validation, but `text/calendar` is missing from its allowlist.

- Add only `text/calendar` to the text/data allowlist.
- Add a focused offline `processAttachments` regression test using a valid VCALENDAR/VEVENT with METHOD:REQUEST and example.com identities. Assert acceptance, preservation of the original MIME parameters/base64, and exact decoded UTF-8 calendar bytes.

## Verification

- `bun test app/api/e2/helper/attachment-processor.test.ts`: reproduced the exact rejection before the one-line fix; after the fix, 1 pass, 0 fail (3 assertions).
- Focused Biome lint on both changed files: no errors; one pre-existing unused-variable warning in the processor.
- `git diff --cached --check`: passed.

No real emails sent, deployment performed, or end-to-end Gmail verification claimed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single allowlist entry plus a unit test; no auth, routing, or attachment size/security rule changes beyond permitting calendar MIME type.
> 
> **Overview**
> **Calendar `.ics` attachments** (e.g. `text/calendar; charset=utf-8; method=REQUEST`) were rejected by `processAttachments` with HTTP 400 because `text/calendar` was not on the MIME allowlist, even though validation already strips MIME parameters before checking the type.
> 
> This PR adds **`text/calendar`** to the text/data allowed types in `attachment-processor.ts`, so send/reply flows that call `processAttachments` accept standard invitation payloads.
> 
> A **Bun regression test** exercises a realistic VCALENDAR/VEVENT with `METHOD:REQUEST` and checks that filename, full `contentType` string, base64 content, size, and decoded UTF-8 bytes are unchanged after processing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60650d26635328080be20cd48685bcc1a690b474. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->