### PR TITLE
Fix domain search beyond the first 100 domains

### DIFF
--- a/app/(main)/emails/page.tsx
+++ b/app/(main)/emails/page.tsx
@@ -45,7 +45,7 @@ export default function EmailsPage() {
     isLoading,
     error,
     refetch: refetchDomains
-  } = useDomainsListV2Query({ limit: 100 })
+  } = useDomainsListV2Query({ limit: 100, fetchAll: true })
 
 
 
@@ -258,4 +258,3 @@ export default function EmailsPage() {
     </div>
   )
 }
-

--- a/features/domains/hooks/useDomainV2Hooks.test.ts
+++ b/features/domains/hooks/useDomainV2Hooks.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, expect, spyOn, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import {
+	domainV2Keys,
+	type GetDomainsResponse,
+	useDomainsListV2Query,
+} from "@/features/domains/hooks/useDomainV2Hooks";
+
+const targetId = "indm_domain_on_second_page";
+const domains = Array.from({ length: 169 }, (_, index) => ({
+	id: index === 120 ? targetId : `domain-${index}`,
+	domain: index === 120 ? "older-bakery.example" : `bakery-${index}.test`,
+	status: "verified",
+	canReceiveEmails: true,
+	stats: {
+		totalEmailAddresses: 0,
+		activeEmailAddresses: 0,
+		hasCatchAll: false,
+	},
+}));
+const requests: URL[] = [];
+const clients: QueryClient[] = [];
+let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">>;
+
+afterEach(() => {
+	fetchSpy?.mockRestore();
+	for (const client of clients) client.clear();
+	clients.length = 0;
+	requests.length = 0;
+});
+
+function mockPages(failOffset?: number) {
+	fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+		const url = new URL(input instanceof Request ? input.url : String(input));
+		requests.push(url);
+		const offset = Number(url.searchParams.get("offset") ?? 0);
+		const limit = Math.min(Number(url.searchParams.get("limit") ?? 50), 100);
+		if (offset === failOffset) {
+			return Response.json(
+				{ message: "Domain list unavailable" },
+				{ status: 503 },
+			);
+		}
+		return Response.json({
+			data: domains.slice(offset, offset + limit),
+			pagination: {
+				limit,
+				offset,
+				total: domains.length,
+				hasMore: offset + limit < domains.length,
+			},
+		});
+	});
+}
+
+function domainQuery(params: Parameters<typeof useDomainsListV2Query>[0]) {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	clients.push(client);
+	function Probe() {
+		useDomainsListV2Query(params);
+		return null;
+	}
+	renderToString(
+		createElement(QueryClientProvider, { client }, createElement(Probe)),
+	);
+	const query = client.getQueryCache().find<GetDomainsResponse>({
+		queryKey: domainV2Keys.list(params),
+		exact: true,
+	});
+	if (!query) throw new Error("Domain query was not registered");
+	return client.fetchQuery({ ...query.options, queryKey: query.queryKey });
+}
+
+test("loads domains beyond the first 100 so name and ID searches find them", async () => {
+	mockPages();
+	const result = await domainQuery({ limit: 100, fetchAll: true });
+	expect(requests.map((url) => url.searchParams.get("offset"))).toEqual([
+		"0",
+		"100",
+	]);
+	expect(result.data).toHaveLength(169);
+	expect(
+		result.data.filter((domain) => domain.domain.includes("older-bakery")),
+	).toEqual([domains[120]]);
+	expect(result.data.find((domain) => domain.id === targetId)).toEqual(
+		domains[120],
+	);
+	expect(result.meta.verifiedCount).toBe(169);
+	expect(result.pagination).toEqual({
+		limit: 169,
+		offset: 0,
+		total: 169,
+		hasMore: false,
+	});
+});
+
+test("preserves single-page queries and their pagination", async () => {
+	mockPages();
+	const result = await domainQuery({ limit: 100 });
+	expect(requests).toHaveLength(1);
+	expect(result.data).toHaveLength(100);
+	expect(result.data.some((domain) => domain.id === targetId)).toBe(false);
+	expect(result.pagination.hasMore).toBe(true);
+});
+
+test("follows server page sizes and carries filters to every page", async () => {
+	mockPages();
+	const result = await domainQuery({
+		limit: 1000,
+		fetchAll: true,
+		status: "verified",
+		canReceive: "true",
+	});
+	expect(result.data).toHaveLength(169);
+	expect(requests.map((url) => url.searchParams.get("offset"))).toEqual([
+		"0",
+		"100",
+	]);
+	for (const url of requests) {
+		expect(url.searchParams.get("status")).toBe("verified");
+		expect(url.searchParams.get("canReceive")).toBe("true");
+		expect(url.searchParams.has("fetchAll")).toBe(false);
+	}
+});
+
+test("reports later-page failures instead of returning an incomplete list", async () => {
+	mockPages(100);
+	await expect(domainQuery({ limit: 100, fetchAll: true })).rejects.toBeInstanceOf(
+		Error,
+	);
+	expect(requests).toHaveLength(2);
+});

--- a/features/domains/hooks/useDomainV2Hooks.ts
+++ b/features/domains/hooks/useDomainV2Hooks.ts
@@ -172,30 +172,51 @@ export const domainV2Keys = {
 };
 
 // Hook for domains list (replacement for useDomainStatsQuery) - uses Elysia e2 API via Eden
-export const useDomainsListV2Query = (params?: GetDomainsRequest) => {
+export const useDomainsListV2Query = (
+	params?: GetDomainsRequest & { fetchAll?: boolean },
+) => {
 	return useQuery<GetDomainsResponse>({
 		queryKey: domainV2Keys.list(params),
-		queryFn: async () => {
-			const { data, error } = await client.api.e2.domains.get({
-				query: {
-					limit: params?.limit,
-					offset: params?.offset,
-					status: params?.status as
-						| "pending"
-						| "verified"
-						| "failed"
-						| undefined,
-					canReceive: params?.canReceive as "true" | "false" | undefined,
-					check: params?.check as "true" | undefined,
-				},
-			});
+		queryFn: async ({ signal }) => {
+			const domains: E2DomainWithStats[] = [];
+			let offset = params?.offset ?? 0;
+			let e2Response: E2DomainsListResponse;
+			do {
+				const { data, error } = await client.api.e2.domains.get({
+					fetch: { signal },
+					query: {
+						limit: params?.limit,
+						offset,
+						status: params?.status as
+							| "pending"
+							| "verified"
+							| "failed"
+							| undefined,
+						canReceive: params?.canReceive as "true" | "false" | undefined,
+						check: params?.check as "true" | undefined,
+					},
+				});
 
-			if (error) {
-				throw new Error(getEdenErrorMessage(error, "Failed to fetch domains"));
+				if (error) {
+					throw new Error(getEdenErrorMessage(error, "Failed to fetch domains"));
+				}
+
+				e2Response = data as E2DomainsListResponse;
+				domains.push(...e2Response.data);
+				offset = e2Response.pagination.offset + e2Response.pagination.limit;
+			} while (params?.fetchAll && e2Response.pagination.hasMore);
+
+			if (params?.fetchAll) {
+				e2Response = {
+					...e2Response,
+					data: domains,
+					pagination: {
+						...e2Response.pagination,
+						limit: domains.length,
+						offset: params.offset ?? 0,
+					},
+				};
 			}
-
-			// Type the e2 API response
-			const e2Response = data as E2DomainsListResponse;
 
 			// Calculate meta statistics from the data
 			const verifiedCount = e2Response.data.filter(


### PR DESCRIPTION
## Summary
The Domains page fetched only the newest 100 domains and searched that partial list locally. Older domains could be opened directly but never appeared in search.

- Opt the Domains page into fetching every API page before filtering.
- Preserve single-page behavior for other callers and separate the query cache entries.
- Carry filters and cancellation through subsequent requests; surface later-page failures instead of returning a partial list.
- Add regression tests using synthetic domain identifiers.

## Verification
- `bun test features/domains/hooks/useDomainV2Hooks.test.ts`: 4 tests pass on the PR branch.
- `git diff --check`: passes.
- Read-only verification with the affected account's 169 database records through the updated query hook loaded offsets 0 and 100 and found the previously missing domain. This used database-backed responses, not the deployed UI.
- Targeted lint remains blocked by three pre-existing `noExplicitAny` violations elsewhere in the hook.
- Not deployed or browser-verified with the updated code.

Only the three domain-search files are included; unrelated local changes and commits are excluded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared domain-list fetching used by the Domains page; multi-request `fetchAll` increases load and latency for large accounts, but other callers (e.g. logs, mailboxes) are unchanged.
> 
> **Overview**
> Fixes **domain search** on the Domains (`/emails`) page when an account has more than 100 domains: the UI only searched the first API page, so older domains by name or ID never showed up in results.
> 
> **`useDomainsListV2Query`** gains an optional **`fetchAll`** flag. When set, the hook walks paginated `e2/domains` responses until `hasMore` is false, merges rows, and normalizes pagination/meta over the full set. Filters stay on every request; **`fetchAll` is not sent to the API**; abort **`signal`** is honored; a failure on a later page **throws** instead of returning a partial list. Callers without `fetchAll` keep a single request and original pagination (separate React Query cache keys).
> 
> The Domains page opts in with **`{ limit: 100, fetchAll: true }`**. New **Bun tests** cover multi-page loading, unchanged single-page behavior, filter propagation, and later-page errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8feb9b0b82a58ee8caa792aa860f7cf0ae1c1618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->