### PR TITLE
Fix case-sensitive delivery matching for legacy email addresses

### DIFF
--- a/lib/email-management/email-router.ts
+++ b/lib/email-management/email-router.ts
@@ -6,7 +6,7 @@
  */
 
 import { Autumn as autumn } from "autumn-js";
-import { and, asc, eq, or, sql } from "drizzle-orm";
+import { and, asc, eq, ilike, or, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import type { Endpoint } from "@/features/endpoints/types";
 import { getTenantSendingInfoForDomainOrParent } from "@/lib/aws-ses/identity-arn-helper";
@@ -550,7 +550,10 @@ async function findEndpointForEmail(
 			.from(emailAddresses)
 			.where(
 				and(
-					eq(emailAddresses.address, recipient),
+					ilike(
+						emailAddresses.address,
+						recipient.trim().replace(/[\\%_]/g, "\\$&"),
+					),
 					eq(emailAddresses.isActive, true),
 					eq(emailAddresses.userId, userId),
 				),

--- a/lib/email-management/webhook-trigger.ts
+++ b/lib/email-management/webhook-trigger.ts
@@ -5,7 +5,7 @@
  */
 
 import { createHash, createHmac } from "crypto";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, ilike, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
 	emailAddresses,
@@ -219,8 +219,12 @@ export async function triggerEmailAction(
 			.from(emailAddresses)
 			.where(
 				and(
-					eq(emailAddresses.address, emailData.recipient),
+					ilike(
+						emailAddresses.address,
+						emailData.recipient.trim().replace(/[\\%_]/g, "\\$&"),
+					),
 					eq(emailAddresses.isActive, true),
+					eq(emailAddresses.userId, emailData.userId),
 				),
 			)
 			.limit(1);
@@ -238,7 +242,13 @@ export async function triggerEmailAction(
 		const webhookRecord = await db
 			.select()
 			.from(webhooks)
-			.where(and(eq(webhooks.id, webhookId), eq(webhooks.isActive, true)))
+			.where(
+				and(
+					eq(webhooks.id, webhookId),
+					eq(webhooks.isActive, true),
+					eq(webhooks.userId, emailData.userId),
+				),
+			)
 			.limit(1);
 
 		if (!webhookRecord[0]) {


### PR DESCRIPTION
## Problem
Incoming recipients are normalized to lowercase, but legacy email-address records can retain mixed case. Exact equality in both the main router and the legacy webhook fallback misses those records. With no catch-all route, the email is stored without a delivery attempt and appears as "No delivery."

## Changes
- Match recipients case-insensitively with Drizzle `ilike` in both delivery paths.
- Trim recipient whitespace and escape backslash, percent, and underscore so matching remains literal rather than allowing wildcard expansion.
- Preserve active-address filtering and main-router tenant scoping; add tenant scoping to legacy address and webhook lookups.
- No stored-data changes, migrations, or automatic delivery retries.

## Verification
- Reproduced the mismatch with a reported email: the original lookup found no address despite an active mixed-case address and endpoint; no delivery records existed.
- Read-only database checks using the updated matching predicates found the active endpoint for lowercase, uppercase, and whitespace-padded variants.
- Percent/underscore inputs and a different tenant returned no match.
- Targeted Biome lint passed with three pre-existing unused-variable/function warnings.
- `git diff --check` passed on the PR branch.
- Verification was read-only query-level testing, not an end-to-end delivery retry. No automated regression tests were added.

This PR contains only the two recipient-routing files and is independent of the domain-search fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core inbound routing and webhook fallback; wrong matching could skip or mis-associate delivery, though tenant filters and literal escaping limit blast radius.
> 
> **Overview**
> Fixes inbound mail showing **“No delivery”** when the normalized (lowercase) recipient no longer matches **legacy mixed-case** rows in `email_addresses`.
> 
> **Recipient lookup** in `findEndpointForEmail` (`email-router.ts`) and the legacy fallback in `webhook-trigger.ts` now uses Drizzle **`ilike`** instead of **`eq`**, with **trim** and escaping of `\`, `%`, and `_` so `ilike` stays a literal match. Active-address filters are unchanged; the main router already scoped by `userId`.
> 
> The legacy webhook path also adds **`userId`** on the address lookup and on the **`webhooks`** fetch so another tenant cannot satisfy the match. No schema migrations or automatic retries for already-stored messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 105c2bdcc32bdaa344c3d204b329415f25188387. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->