### PR TITLE
Expose stored envelope recipients in E2 responses

### DIFF
--- a/app/api/e2/domains/list.ts
+++ b/app/api/e2/domains/list.ts
@@ -108,6 +108,7 @@ const PaginationSchema = t.Object({
 const ListDomainsResponse = t.Object({
   data: t.Array(DomainSchema),
   pagination: PaginationSchema,
+  capabilities: t.Object({ envelopeRecipients: t.Boolean() }),
 });
 
 export const listDomains = new Elysia().get(
@@ -417,6 +418,7 @@ export const listDomains = new Elysia().get(
 
     const response = {
       data: enhancedDomains,
+      capabilities: { envelopeRecipients: true },
       pagination: {
         limit,
         offset,

--- a/app/api/e2/emails/get.ts
+++ b/app/api/e2/emails/get.ts
@@ -15,6 +15,9 @@ const EmailDetailSchema = t.Object({
   ]),
   from: t.String(),
   to: t.Array(t.String()),
+  envelope_recipient: t.Optional(
+    t.Nullable(t.String({ description: "Stored delivery recipient for received emails, independent of message headers" }))
+  ),
   cc: t.Optional(t.Nullable(t.Array(t.String()))),
   bcc: t.Optional(t.Nullable(t.Array(t.String()))),
   reply_to: t.Optional(t.Nullable(t.Array(t.String()))),
@@ -102,6 +105,7 @@ export const getEmail = new Elysia().get(
         object: "email" as const,
         id: email.id,
         type: "received" as const,
+        envelope_recipient: email.recipient,
         from: parseFromData(email.fromData),
         to: parseAddressesFromData(email.toData),
         cc: parseAddressesFromData(email.ccData),

--- a/app/api/e2/emails/list.ts
+++ b/app/api/e2/emails/list.ts
@@ -114,6 +114,9 @@ const EmailItemSchema = t.Object({
   to: t.Array(t.String(), {
     description: "Array of recipient email addresses",
   }),
+  envelope_recipient: t.Optional(
+    t.Nullable(t.String({ description: "Stored delivery recipient for received emails, independent of message headers" }))
+  ),
   cc: t.Optional(
     t.Array(t.String(), {
       description: "Array of CC recipient email addresses",
@@ -441,6 +444,7 @@ export const listEmails = new Elysia().get(
         emails.push({
           id: email.id,
           type: "received" as const,
+          envelope_recipient: email.recipient,
           message_id: email.messageId,
           from: fromParsed.address,
           from_name: fromParsed.name,

--- a/app/api/e2/mail/threads-get.ts
+++ b/app/api/e2/mail/threads-get.ts
@@ -66,6 +66,9 @@ const ThreadMessageSchema = t.Object({
   to: t.Array(t.String(), {
     description: "Array of recipient email addresses",
   }),
+  envelope_recipient: t.Optional(
+    t.Nullable(t.String({ description: "Stored delivery recipient for inbound messages, independent of message headers" }))
+  ),
   cc: t.Array(t.String(), {
     description: "Array of CC recipient email addresses",
   }),
@@ -304,6 +307,7 @@ export const getThread = new Elysia().get(
         id: email.id,
         message_id: email.messageId,
         type: "inbound" as const,
+        envelope_recipient: email.recipient,
         thread_position: email.threadPosition || 0,
 
         // Content


### PR DESCRIPTION
## Summary
- Expose nullable `envelope_recipient` from the stored delivery recipient on received email list/detail responses and inbound thread messages.
- Advertise `capabilities.envelopeRecipients: true` on domain discovery so Inbox SDK can detect the metadata.
- Include only the four existing envelope-metadata file changes, isolated on current `main`; unrelated local gateway, UI, and SDK changes are excluded.

## Compatibility and Scope
These are additive response fields. Existing To/Cc data and query behavior are unchanged; consumers must use the stored envelope recipient rather than infer delivery from message headers. Historical rows may return null.

This PR does not change address-filter semantics, snapshot pagination, or attachment addressability.

## Verification
- `git diff --check` passed.
- Bun TypeScript syntax checks passed for all four changed files.
- No tests added, as requested. Test suites and application build were not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive response fields on read-only E2 endpoints with no auth, query, or write-path changes.
> 
> **Overview**
> Adds **stored delivery recipient** metadata to E2 read APIs so clients can tell which address actually received an inbound message without inferring it from `To`/`Cc` headers.
> 
> **Received email list and detail** now include optional nullable `envelope_recipient`, mapped from the stored `recipient` field on received rows only (sent/scheduled payloads are unchanged).
> 
> **Thread messages** include the same field on **inbound** messages in `GET /mail/threads/:id`.
> 
> **Domain list** advertises **`capabilities.envelopeRecipients: true`** so the Inbox SDK can detect support during domain discovery.
> 
> All changes are additive OpenAPI/schema fields; filtering, pagination, and existing `to`/`cc` behavior are untouched. Older rows may return `null` where no envelope recipient was persisted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 997261c7cc7ee456252cde76470efc2a5e822b21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->