### PR TITLE
Add stable MIME-part attachment downloads

### DIFF
--- a/app/api/e2/attachments/get.ts
+++ b/app/api/e2/attachments/get.ts
@@ -1,10 +1,11 @@
+import { createHash } from "node:crypto"
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3"
+import { eq, and } from "drizzle-orm"
 import { Elysia, t } from "elysia"
-import { validateAndRateLimit } from "../lib/auth"
+import { simpleParser, type Attachment } from "mailparser"
+import { validateAndRateLimit } from "@/app/api/e2/lib/auth"
 import { db } from "@/lib/db"
 import { structuredEmails, sesEvents } from "@/lib/db/schema"
-import { eq, and } from "drizzle-orm"
-import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3"
-import { simpleParser } from "mailparser"
 
 // Error Response schema for OpenAPI
 const ErrorResponse = t.Object({
@@ -12,25 +13,9 @@ const ErrorResponse = t.Object({
   details: t.Optional(t.String()),
 })
 
-export const getAttachment = new Elysia().get(
-  "/attachments/:id/:filename",
-  async ({ request, params, set }) => {
-    console.log("📥 GET /api/e2/attachments/:id/:filename - Request started")
-    console.log(`   Email ID: ${params.id}`)
-    console.log(`   Filename (raw): ${params.filename}`)
-    console.log(`   Filename (decoded): ${decodeURIComponent(params.filename)}`)
-
-    // Auth & rate limit validation - throws on error
-    const userId = await validateAndRateLimit(request, set)
-    console.log(`🔐 Attachment download - Authenticated userId: ${userId}`)
-
-    const { id: emailId, filename: attachmentFilename } = params
-
-    if (!emailId || !attachmentFilename) {
-      set.status = 400
-      return { error: "Email ID and attachment filename are required" }
-    }
-
+async function readAttachments(emailId: string, userId: string): Promise<
+  { attachments: Attachment[] } | { error: string }
+> {
     // Get the structured email to verify ownership and find SES event
     console.log(`🔎 Attachment download - Querying for structured email with: emailId=${emailId}, userId=${userId}`)
     const structuredEmail = await db
@@ -44,7 +29,6 @@ export const getAttachment = new Elysia().get(
 
     if (!structuredEmail.length) {
       console.error(`❌ Attachment download - Structured email not found: emailId=${emailId}, userId=${userId}`)
-      set.status = 404
       return { error: "Email not found or access denied" }
     }
 
@@ -53,7 +37,6 @@ export const getAttachment = new Elysia().get(
     const sesEventId = structuredEmail[0].sesEventId
     if (!sesEventId) {
       console.error(`❌ Attachment download - No SES event ID for email: ${emailId}`)
-      set.status = 404
       return { error: "Email event information not found" }
     }
 
@@ -69,7 +52,6 @@ export const getAttachment = new Elysia().get(
       .limit(1)
 
     if (!sesEvent.length) {
-      set.status = 404
       return { error: "Email content not found" }
     }
 
@@ -128,7 +110,6 @@ export const getAttachment = new Elysia().get(
 
     if (!rawEmailContent) {
       console.error(`❌ Attachment download - No email content available: s3BucketName=${s3BucketName}, s3ObjectKey=${s3ObjectKey}, emailContent=${emailContent ? "present" : "null"}`)
-      set.status = 404
       return { error: "Email content not available" }
     }
 
@@ -136,6 +117,47 @@ export const getAttachment = new Elysia().get(
 
     // Parse the email to find the attachment
     const parsed = await simpleParser(rawEmailContent)
+    return { attachments: parsed.attachments }
+}
+
+function attachmentId(attachment: Attachment, index: number): string {
+  const digest = createHash("sha256")
+    .update(JSON.stringify([index, attachment.filename ?? null, attachment.contentType,
+      attachment.contentId ?? null, attachment.contentDisposition]))
+    .update("\0")
+    .update(attachment.content)
+    .digest("hex")
+  return `part_v1_${index}_${digest}`
+}
+
+function attachmentResponse(attachment: Attachment): Response {
+  const filename = attachment.filename || "download"
+  const asciiFilename = filename.replace(/[^\x20-\x7e]|["\\]/g, "_")
+  return new Response(new Uint8Array(attachment.content), {
+    status: 200,
+    headers: {
+      "Content-Type": attachment.contentType || "application/octet-stream",
+      "Content-Disposition": `attachment; filename="${asciiFilename}"; filename*=UTF-8''${encodeURIComponent(filename)}`,
+      "Content-Length": String(attachment.content.length),
+      "Cache-Control": "private, max-age=3600",
+    },
+  })
+}
+
+export const getAttachment = new Elysia().get(
+  "/attachments/:id/:filename",
+  async ({ request, params, set }) => {
+    const userId = await validateAndRateLimit(request, set)
+    const { id: emailId, filename: attachmentFilename } = params
+    if (!emailId || !attachmentFilename) {
+      set.status = 400
+      return { error: "Email ID and attachment filename are required" }
+    }
+    const parsed = await readAttachments(emailId, userId)
+    if ("error" in parsed) {
+      set.status = 404
+      return parsed
+    }
 
     if (!parsed.attachments || parsed.attachments.length === 0) {
       console.warn(`⚠️ Attachment download - No attachments found in email ${emailId}`)
@@ -160,25 +182,7 @@ export const getAttachment = new Elysia().get(
 
     console.log(`✅ Attachment download - Found: ${attachment.filename} (${attachment.size} bytes)`)
 
-    // Encode filename for Content-Disposition header (RFC 5987)
-    // This handles non-ASCII characters properly
-    const safeFilename = attachment.filename || "download"
-    const asciiFilename = safeFilename.replace(/[^\x00-\x7F]/g, "_") // ASCII fallback
-    const encodedFilename = encodeURIComponent(safeFilename) // UTF-8 encoded
-
-    // Use both filename (ASCII fallback) and filename* (UTF-8 encoded) per RFC 5987
-    const contentDisposition = `attachment; filename="${asciiFilename}"; filename*=UTF-8''${encodedFilename}`
-
-    // Return the attachment as a Response with binary data
-    return new Response(new Uint8Array(attachment.content), {
-      status: 200,
-      headers: {
-        "Content-Type": attachment.contentType || "application/octet-stream",
-        "Content-Disposition": contentDisposition,
-        "Content-Length": attachment.size?.toString() || "0",
-        "Cache-Control": "private, max-age=3600",
-      },
-    })
+    return attachmentResponse(attachment)
   },
   {
     params: t.Object({
@@ -200,5 +204,90 @@ export const getAttachment = new Elysia().get(
         "Download an email attachment by email ID and filename. Returns the binary file content with appropriate Content-Type and Content-Disposition headers.",
     },
   }
+).get(
+  "/attachments/:id",
+  async ({ request, params, query, set }) => {
+    const userId = await validateAndRateLimit(request, set)
+    const parsed = await readAttachments(params.id, userId)
+    if ("error" in parsed) {
+      set.status = 404
+      return parsed
+    }
+    const limit = query.limit ?? 50
+    const offset = query.offset ?? 0
+    return {
+      data: parsed.attachments.slice(offset, offset + limit).map((attachment, index) => ({
+        id: attachmentId(attachment, offset + index),
+        filename: attachment.filename ?? null,
+        content_type: attachment.contentType,
+        size: attachment.content.length,
+        content_id: attachment.contentId ?? null,
+        inline: attachment.related || attachment.contentDisposition === "inline",
+      })),
+      pagination: { limit, offset, total: parsed.attachments.length, hasMore: offset + limit < parsed.attachments.length },
+    }
+  },
+  {
+    params: t.Object({ id: t.String() }),
+    query: t.Object({
+      limit: t.Optional(t.Integer({ minimum: 1, maximum: 100, default: 50 })),
+      offset: t.Optional(t.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER - 100, default: 0 })),
+    }),
+    response: {
+      200: t.Object({
+        data: t.Array(t.Object({
+          id: t.String({ description: "Message-scoped MIME part handle bound to its position, metadata and SHA-256 content digest" }),
+          filename: t.Nullable(t.String()),
+          content_type: t.String(),
+          size: t.Integer({ minimum: 0 }),
+          content_id: t.Nullable(t.String()),
+          inline: t.Boolean(),
+        })),
+        pagination: t.Object({ limit: t.Integer(), offset: t.Integer(), total: t.Integer(), hasMore: t.Boolean() }),
+      }),
+      400: ErrorResponse,
+      401: ErrorResponse,
+      404: ErrorResponse,
+      500: ErrorResponse,
+    },
+    detail: {
+      tags: ["Attachments"],
+      summary: "List received email attachments",
+      description: "Enumerate attachments from the stored MIME message, including unnamed parts and duplicate filenames. Use each stable id with /attachments/{id}/parts/{attachmentId}. Does not mark the email as read.",
+    },
+  },
+).get(
+  "/attachments/:id/parts/:attachmentId",
+  async ({ request, params, set }) => {
+    const userId = await validateAndRateLimit(request, set)
+    const parsed = await readAttachments(params.id, userId)
+    if ("error" in parsed) {
+      set.status = 404
+      return parsed
+    }
+    const index = Number(params.attachmentId.split("_")[2])
+    const attachment = Number.isSafeInteger(index) ? parsed.attachments[index] : undefined
+    if (!attachment || attachmentId(attachment, index) !== params.attachmentId) {
+      set.status = 404
+      return { error: "Attachment not found" }
+    }
+    return attachmentResponse(attachment)
+  },
+  {
+    params: t.Object({
+      id: t.String(),
+      attachmentId: t.String({ pattern: "^part_v1_(0|[1-9][0-9]*)_[a-f0-9]{64}$", maxLength: 96 }),
+    }),
+    response: {
+      400: ErrorResponse,
+      401: ErrorResponse,
+      404: ErrorResponse,
+      500: ErrorResponse,
+    },
+    detail: {
+      tags: ["Attachments"],
+      summary: "Download received email attachment by part ID",
+      description: "Download the exact MIME attachment returned by the attachment listing, without relying on a filename. A stale or mismatched part handle returns 404.",
+    },
+  },
 )
-


### PR DESCRIPTION
## Why this needs an upstream change

Received attachment metadata can omit filenames, and multiple MIME parts can share the same filename. The existing `GET /attachments/{id}/{filename}` reparses the stored message and returns the first filename match, so it cannot address unnamed parts or later duplicate-name parts. An adapter-side cache cannot recover bytes that no read endpoint can address.

Reviewed the registered E2 routes, email/thread detail serialization, parser metadata, and retry endpoint on main at `61b9be5` (including merged envelope-recipient PR #186). No read-only raw-MIME endpoint or stable received-part download handle is exposed. `rawContent` is internal to the mutating retry flow; received attachment metadata omits bytes. This PR is restricted to that retrieval gap.

## Changes

Only `app/api/e2/attachments/get.ts` changes:

- Add paginated `GET /attachments/{id}` with metadata derived from the actual stored MIME parts, not guessed filenames or historical metadata ordering. Unnamed filenames remain `null`.
- Add `GET /attachments/{id}/parts/{attachmentId}`. Versioned handles bind MIME-part position to a SHA-256 fingerprint of its metadata and bytes. Identical duplicate parts remain separately addressable by position; stale/mismatched handles return 404 instead of another part's bytes.
- Reuse the existing SES/S3 read path and fallback. Each handler calls `validateAndRateLimit`; the shared loader requires the matching `structuredEmails.id` **and** authenticated `userId` before accessing SES content or S3.
- Keep the filename endpoint, including its first-match behavior for duplicate filenames. No read/archive mutations, schema migrations, ingestion changes, or new dependencies. Response schemas remain status-code keyed.

Sent attachments, archive metadata, pagination redesigns, and SDK changes are intentionally excluded. The existing route registration already mounts the additional handlers through `getAttachment`.

## Verification

- `git diff --check`: passed.
- Biome lint of the changed file: passed, no new `any`.
- In-memory Bun TypeScript transpilation: passed (syntax check, not full typecheck/build).
- **65 assertions / 32 in-memory requests passed**, using the actual Elysia routes and mailparser with auth/database/S3 mocked and external fetch disabled. Checked unnamed parts, differing and identical duplicate names, exact binary and zero-byte downloads, Unicode/percent filenames, inline metadata, stable pagination/repeated IDs, stale/tampered handles, legacy filename compatibility, owner isolation before SES access, authentication rejection, missing content, and synthetic S3/fallback parity. The smoke runner explicitly exits after all awaited checks; no test/helper/fixture files were added.
- Existing `app/api/e2/helper/attachment-processor.test.ts`: **1 passed, 0 failed, 3 assertions**, with Bun `--no-env-file`.

## Deliberately unqualified

Draft for review. No live mail, credentials, real database/S3 calls, broad suites, upstream dev/build, deployment, or migrations were used. Real backing-store qualification and client adoption remain separate authorized work. The original dirty checkout/index and the integrated SDK were not modified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new read endpoints that stream attachment bytes from stored mail; ownership checks are unchanged but expanded surface area and digest-based handles need correct validation to avoid wrong-part downloads.
> 
> **Overview**
> Extends the E2 attachments API so clients can **list and download received MIME parts by stable handles**, not only by filename (which breaks on unnamed parts and duplicate names).
> 
> Shared **`readAttachments`** loads and parses the stored message after the same **owner + rate-limit** checks and SES/S3 fallback as before. **`GET /attachments/:id`** returns paginated part metadata (`filename` may be `null`, inline flag, sizes) with versioned ids **`part_v1_{index}_{sha256}`** derived from index, metadata, and bytes. **`GET /attachments/:id/parts/:attachmentId`** resolves a part by index and **re-validates the digest**, returning 404 on stale or tampered handles. Binary responses are centralized in **`attachmentResponse`** (RFC 5987 disposition; slightly stricter ASCII filename sanitization). The legacy **`GET /attachments/:id/:filename`** route remains with first-match filename behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 100b240202f84ea023cafbdb89f4ee93dffef907. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->