### PR TITLE
fix: avoid loading full email payloads in received listings

### DIFF
--- a/app/api/e2/emails/list.ts
+++ b/app/api/e2/emails/list.ts
@@ -421,7 +421,23 @@ export const listEmails = new Elysia().get(
       }
 
       const receivedEmails = await db
-        .select()
+        .select({
+          id: structuredEmails.id,
+          recipient: structuredEmails.recipient,
+          messageId: structuredEmails.messageId,
+          fromData: structuredEmails.fromData,
+          toData: structuredEmails.toData,
+          ccData: structuredEmails.ccData,
+          subject: structuredEmails.subject,
+          textBody: structuredEmails.textBody,
+          attachments: structuredEmails.attachments,
+          parseSuccess: structuredEmails.parseSuccess,
+          createdAt: structuredEmails.createdAt,
+          isRead: structuredEmails.isRead,
+          readAt: structuredEmails.readAt,
+          isArchived: structuredEmails.isArchived,
+          threadId: structuredEmails.threadId,
+        })
         .from(structuredEmails)
         .where(and(...receivedConditions))
         .orderBy(desc(structuredEmails.createdAt))


### PR DESCRIPTION
## Summary

Replace the received-email list query's implicit all-column selection with the 15 columns consumed by its existing mapper. This excludes 21 unused columns, including raw MIME content, full HTML, headers, references and guard metadata, before the database response crosses Neon HTTP.

Only `app/api/e2/emails/list.ts` changes. The mapper and public response schema are unchanged; this is a non-UI query-payload fix, so visual evidence is N/A.

## Confirmed failure and baseline

Existing production request logs confirmed repeated failures of a deep 100-row received-email page because the database response exceeded **67,108,864 bytes (64 MiB)**. The failure occurs before the route can reduce the full records to list metadata. No private logs, request identifiers, account/domain values, mail data or SQL parameters are included here.

The affected production revision was `1d852a4e2002602205db7f0083b5cc65668ccce8`. Its list route and structured-email schema match this PR's upstream-main base, `61b9be584e7f51a50a6514c47f1f2d8055942c4c`. Current upstream refs and open/merged PRs were checked; this fix was not already present. No unrelated local or deployment-branch commits are included.

The inspected received-email writer stores attachment **metadata only**: filename, content type, size, content ID and disposition. The original MIME content is stored separately in the now-omitted `rawContent` column. No database JSON casts or attachment-parser changes are needed for this focused fix.

## Preserved behavior and scope

- Authentication and owner scoping; domain, address, search, status and time filters.
- Existing ordering, limit/offset, count query, response fields, timestamps, previews and `has_more`.
- The shared received query within `type=all` uses the same projection; sent and scheduled query branches are untouched.
- No row skipping, timestamp substitutions, tie-breaker changes, rate changes, dependencies, migrations or schema changes.
- No tests/helpers were added to the repository. The existing live E2 suite was not run or extended; verification used the standalone pure harness below.

## Verification

Run in an isolated worktree with **Bun 1.4.0 / Drizzle 0.43.1**, reusing existing installed dependencies without installation or lockfile changes. The harness extracts the actual base/head query and mapper code, compiles both with `drizzle.mock()`, and decodes synthetic result rows using Drizzle's prepared-query mapper. It never imports the application DB/auth modules and never executes a query or starts a server.

| Check | Result |
| --- | --- |
| 10 received filter variants | Same generated WHERE/order/limit/offset, parameters and count query |
| Shared `type=all` received query | Same non-projection query semantics and parameters |
| Actual selected fields | 36 columns before; exactly the 15 mapper inputs after; large unused fields excluded |
| 5 mapper fixtures | Identical output, including long/Unicode/newline previews, attachment metadata and malformed attachment JSON |
| 100-row page with large synthetic omitted MIME/HTML/header fields | All 100 rows retained; identical mapper output; row-array JSON reduced from **86,468,431** to **29,431 bytes** |

Additional commands/results:

```sh
git diff --check
git diff --cached --check
bun --no-env-file node_modules/@biomejs/biome/bin/biome lint app/api/e2/emails/list.ts --max-diagnostics=5
```

Whitespace checks, Bun route transpilation and a scoped staged-source secret-pattern scan passed. **Targeted Biome lint is not green:** it reports the same five pre-existing `noExplicitAny` errors before and after (address parser, email accumulator, and three condition arrays). This PR introduces no new lint errors and does not expand into unrelated type cleanup. The existing Biome installation was invoked directly from the shared dependency checkout; the command above uses the equivalent normal-checkout path.

## Limitations and follow-up

Projection removes unnecessary payload transfer, but it is **not an absolute aggregate-byte guarantee**: retained `textBody`, subject/address JSON and attachment metadata remain unbounded. The synthetic byte figures describe row-array JSON, not a measurement of the production page or complete Neon protocol response.

No live API/provider/database requests, full build, type-check, migration, merge or deployment were performed for this PR. After an explicitly authorized deployment, replay the previously failing metadata-only page to establish production recovery. This PR does not claim that live replay has passed.

<details>
<summary>Reproducible pure verification command (no database/server/network)</summary>

Run from this branch with its normal dependencies available. The optional `VERIFICATION_DEPENDENCY_ROOT` can point to an existing dependency checkout; no install is required.

```sh
bun --no-env-file - <<'TS'
import { execFileSync } from "node:child_process";
import { readFileSync } from "node:fs";
import { deepStrictEqual, strictEqual, ok } from "node:assert";

const dependencyRoot = process.env.VERIFICATION_DEPENDENCY_ROOT ?? process.cwd();
const load = (name: string) => import(Bun.resolveSync(name, dependencyRoot));
const core = await load("drizzle-orm/pg-core");
const { getTableColumns, eq, and, or, like, gte, desc, sql } = await load("drizzle-orm");
const { drizzle } = await load("drizzle-orm/neon-http");
globalThis.fetch = async () => { throw new Error("Network disabled for pure verification"); };
const base = "61b9be584e7f51a50a6514c47f1f2d8055942c4c";
const path = "app/api/e2/emails/list.ts";
const before = execFileSync("git", ["show", `${base}:${path}`], { encoding: "utf8" });
const after = readFileSync(path, "utf8");
const schema = execFileSync("git", ["show", `${base}:lib/db/schema.ts`], { encoding: "utf8" });
const transpile = (text: string) => new Bun.Transpiler({ loader: "ts" }).transformSync(text);
transpile(after);
const tableSource = schema.slice(schema.indexOf("export const structuredEmails ="), schema.indexOf("export const webhookDeliveries =")).replace("export const", "const");
const table = new Function(...Object.keys(core), `${transpile(tableSource)}; return structuredEmails;`)(...Object.values(core));
const db = drizzle.mock();

function compile(source: string) {
  const conditions = source.slice(source.indexOf("      const receivedConditions"), source.indexOf("      const receivedEmails ="));
  const query = source.slice(source.indexOf("      const receivedEmails ="), source.indexOf("      for (const email of receivedEmails)")).replace("const receivedEmails = await db", "const receivedQuery = db");
  const count = source.slice(source.indexOf("      const [{ count }] = await db"), source.indexOf("      receivedTotal = Number(count)")).replace("const [{ count }] = await db", "const countQuery = db");
  const helpers = source.slice(source.indexOf("function parseJsonField"), source.indexOf("// Calculate time threshold"));
  const loop = source.slice(source.indexOf("      for (const email of receivedEmails)"), source.indexOf("      // Get count for pagination"));
  const parameters = ["structuredEmails", "eq", "or", "like", "gte", "sql", "userId", "status", "timeThreshold", "resolvedDomain", "resolvedAddress", "searchQuery"];
  return {
    conditions: new Function(...parameters, `${transpile(conditions)}; return receivedConditions;`),
    query: new Function("db", "structuredEmails", "and", "desc", "receivedConditions", "type", "limit", "offset", "allTypeFetchLimit", `${transpile(query)}; return receivedQuery;`),
    count: new Function("db", "structuredEmails", "and", "sql", "receivedConditions", `${transpile(count)}; return countQuery;`),
    convert: new Function("receivedEmails", transpile(`${helpers}\nconst emails = []; ${loop}; return emails;`)),
  };
}
const old = compile(before);
const next = compile(after);
const variants = [{}, ...["delivered", "failed", "unread", "read", "archived"].map(status => ({ status })), { timeThreshold: new Date("2026-01-01") }, { resolvedAddress: "fictional@example.test" }, { searchQuery: "synthetic search" }, { resolvedDomain: null }];
function queries(compiled, variant = {}, type = "received") {
  const values = { status: "all", timeThreshold: null, resolvedDomain: "example.test", resolvedAddress: null, searchQuery: undefined, ...variant };
  const conditions = compiled.conditions(table, eq, or, like, gte, sql, "synthetic-owner", values.status, values.timeThreshold, values.resolvedDomain, values.resolvedAddress, values.searchQuery);
  return {
    list: compiled.query(db, table, and, desc, conditions, type, 100, 12000, 10000),
    count: compiled.count(db, table, and, sql, conditions),
  };
}
for (const variant of variants) {
  const a = queries(old, variant);
  const b = queries(next, variant);
  const x = a.list.toSQL(), y = b.list.toSQL();
  deepStrictEqual(x.params, y.params);
  strictEqual(x.sql.slice(x.sql.indexOf(" from ")), y.sql.slice(y.sql.indexOf(" from ")));
  deepStrictEqual(a.count.toSQL(), b.count.toSQL());
}
const allBefore = queries(old, {}, "all").list.toSQL();
const allAfter = queries(next, {}, "all").list.toSQL();
deepStrictEqual(allBefore.params, allAfter.params);
strictEqual(allBefore.sql.slice(allBefore.sql.indexOf(" from ")), allAfter.sql.slice(allAfter.sql.indexOf(" from ")));

const originalQuery = queries(old).list;
const projectedQuery = queries(next).list;
const originalFields = Object.keys(originalQuery.getSelectedFields());
const selected = Object.keys(projectedQuery.getSelectedFields());
const expected = ["id", "recipient", "messageId", "fromData", "toData", "ccData", "subject", "textBody", "attachments", "parseSuccess", "createdAt", "isRead", "readAt", "isArchived", "threadId"];
deepStrictEqual([...selected].sort(), [...expected].sort());
strictEqual(originalFields.length, 36);
strictEqual(selected.length, 15);
const omitted = originalFields.filter(key => !selected.includes(key));
for (const key of ["rawContent", "htmlBody", "headers", "guardMetadata", "references"]) ok(omitted.includes(key));
const baseline = { ...Object.fromEntries(Object.keys(getTableColumns(table)).map(key => [key, null])), id: "synthetic", recipient: "fictional@example.test", parseSuccess: true, createdAt: new Date("2026-01-01T00:00:00Z"), isRead: false, isArchived: false, userId: "synthetic-owner" };
const fixtures = [baseline, { ...baseline, textBody: "x".repeat(201), attachments: "[]" }, { ...baseline, textBody: " \n preview \n", attachments: JSON.stringify([{ filename: "fictional.txt", size: 10 }]), isRead: true, readAt: baseline.createdAt }, { ...baseline, textBody: "🙂".repeat(101), fromData: JSON.stringify({ addresses: [{ address: "sender@example.test", name: "Synthetic" }] }), toData: JSON.stringify({ addresses: [{ address: "fictional@example.test" }] }) }, { ...baseline, parseSuccess: false, isArchived: true, threadId: "synthetic-thread", attachments: "{" }];
function wireRows(query, records) {
  return records.map(record => Object.keys(query.getSelectedFields()).map(key => {
    const value = record[key];
    return value instanceof Date ? value.toISOString().slice(0, -1).replace("T", " ") : value;
  }));
}
function output(compiled, query, records) {
  const decoded = query._prepare().mapResult({ rows: wireRows(query, records) });
  return compiled.convert(decoded);
}
for (const fixture of fixtures) deepStrictEqual(output(old, originalQuery, [fixture]), output(next, projectedQuery, [fixture]));
const raw = "M".repeat(700 * 1024), html = "H".repeat(128 * 1024), headers = JSON.stringify({ "x-synthetic": "h".repeat(16 * 1024) });
const page = Array.from({ length: 100 }, (_, index) => ({ ...fixtures[index % fixtures.length], id: `synthetic-${index}`, rawContent: raw, htmlBody: html, headers }));
const oldOutput = output(old, originalQuery, page);
const newOutput = output(next, projectedQuery, page);
deepStrictEqual(newOutput, oldOutput);
strictEqual(newOutput.length, 100);
const arrayBytes = rows => 2 + rows.reduce((sum, row) => sum + Buffer.byteLength(JSON.stringify(row)), 0) + Math.max(0, rows.length - 1);
const fullRowArrayBytes = arrayBytes(wireRows(originalQuery, page));
const selectedRowArrayBytes = arrayBytes(wireRows(projectedQuery, page));
ok(fullRowArrayBytes > 67108864);
ok(selectedRowArrayBytes < 67108864);
console.log(JSON.stringify({ base, bun: Bun.version, drizzle: "0.43.1", queryVariants: variants.length, unchangedWhereOrderLimitOffsetParametersAndCount: true, sharedAllBranchQueryUnchanged: true, originalColumns: originalFields.length, selectedColumns: selected.length, omittedColumns: omitted, mapperFixtures: fixtures.length, fullPageRows: newOutput.length, identicalMapperOutput: true, syntheticFullRowArrayJsonBytes: fullRowArrayBytes, syntheticSelectedRowArrayJsonBytes: selectedRowArrayBytes, routeTranspilationPassed: true, databaseCalls: 0, networkCalls: 0 }, null, 2));
process.exit(0);
TS
```
</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow read-path optimization with no auth, filter, or response-schema changes; risk is mainly ensuring the projection stays aligned with the mapper if new list fields are added later.
> 
> **Overview**
> **Fixes oversized received-email list responses** by replacing implicit `select()` on `structuredEmails` with an explicit 15-column projection—the fields the existing list mapper already uses.
> 
> Heavy columns such as **`rawContent`**, **`htmlBody`**, **`headers`**, and guard metadata are no longer loaded over Neon HTTP for `type=received` and the received branch of `type=all`. Filters, ordering, pagination, counts, and the public list payload are unchanged; only the database row shape before mapping is smaller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16f0f87f155d568538bcd939e1c6d965f0306228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->