### PR TITLE
fix: restore E2 rate limit to 100 requests per second

### DIFF
--- a/app/api/e2/lib/auth.ts
+++ b/app/api/e2/lib/auth.ts
@@ -25,10 +25,10 @@ if (
 		token: process.env.UPSTASH_REDIS_REST_TOKEN,
 	});
 
-	// Rate limiter: 10 requests per second per account
+	// Rate limiter: 100 requests per second per account
 	ratelimit = new Ratelimit({
 		redis,
-		limiter: Ratelimit.slidingWindow(10, "1 s"),
+		limiter: Ratelimit.slidingWindow(100, "1 s"),
 		analytics: true,
 		prefix: "e2:ratelimit",
 	});

--- a/docs/api-reference/errors.mdx
+++ b/docs/api-reference/errors.mdx
@@ -15,7 +15,7 @@ The Inbound API returns standard HTTP status codes to indicate success or failur
 | `400` | Bad Request | Invalid request parameters or missing required fields |
 | `401` | Unauthorized | Invalid or missing API key |
 | `404` | Not Found | Requested resource does not exist |
-| `429` | Too Many Requests | Rate limit exceeded (2 requests/second) |
+| `429` | Too Many Requests | Rate limit exceeded (100 requests/second per account across E2 endpoints) |
 | `500` | Internal Server Error | Server error occurred |
 
 ## Common Error Types
@@ -61,8 +61,8 @@ The Inbound API returns standard HTTP status codes to indicate success or failur
 
 ### Rate Limiting (429)
 
-- **`Rate limit exceeded`** - Too many requests (limit: 2 per second)
-- **`Maximum 2 requests per second allowed. Upgrade or contact support for higher limits.`** - Rate limit details
+- **`Too Many Requests`** - Too many requests (limit: 100 per second per account across E2 endpoints)
+- **`Rate limit exceeded. Maximum 100 requests per second. Retry after 1 seconds.`** - Example rate limit message; the retry delay varies
 
 ### Server Errors (500)
 

--- a/docs/api-reference/rate-limits.mdx
+++ b/docs/api-reference/rate-limits.mdx
@@ -14,12 +14,12 @@ The response headers describe your current rate limit following every request in
 
 ## Default Rate Limits
 
-The default maximum rate limit is **10 requests per second** across all API endpoints. This applies uniformly to:
+The default maximum rate limit is **100 requests per second per account**, shared across authenticated E2 API endpoints. This single budget covers:
 
-- **Email sending endpoints**: 10 requests per second
-- **Email management endpoints**: 10 requests per second 
-- **Domain/configuration endpoints**: 10 requests per second
-- **All other API endpoints**: 10 requests per second
+- **Email sending endpoints**: 100 requests per second
+- **Email management endpoints**: 100 requests per second
+- **Domain/configuration endpoints**: 100 requests per second
+- **All other authenticated E2 endpoints**: 100 requests per second
 
 This number can be increased for trusted senders upon request.
 
@@ -29,8 +29,9 @@ After exceeding the rate limit, you'll receive a `429 Too Many Requests` respons
 
 ```json
 {
-  "error": "Rate limit exceeded",
-  "message": "Maximum 10 requests per second allowed. Upgrade or contact support for higher limits."
+  "error": "Too Many Requests",
+  "message": "Rate limit exceeded. Maximum 100 requests per second. Retry after 1 seconds.",
+  "statusCode": 429
 }
 ```
 


### PR DESCRIPTION
## Summary

Restore **100 requests per second per authenticated account** for E2 API requests. This is one shared account budget, not 100 per API key or per endpoint.

The previous production-only revision `1d852a4e2002602205db7f0083b5cc65668ccce8` used this budget, but that quota change was not on `main`. Redeploying `main` after #188 therefore restored its older 10-request setting. This PR ports only the two-line quota/comment change onto current main, `b62a6d6760b2978086867e53bcfeefde39d06dc8`; it does not merge the old deployment branch.

## Scope and retained behavior

- `app/api/e2/lib/auth.ts`: change `Ratelimit.slidingWindow(10, "1 s")` to `Ratelimit.slidingWindow(100, "1 s")` and update its existing comment. The resulting auth file matches the prior 100-request deployment's auth file.
- Keep the **one-second sliding window**, shared authenticated `userId` key, `e2:ratelimit` prefix and analytics unchanged. Authentication, session precedence, ownership, ban checks, headers, retry handling and fail-closed behavior are unchanged.
- Update the existing rate-limit and error-reference pages to document 100 requests/second per account and the current 429 response example, replacing stale 10- and 2-request descriptions.
- Keep #188's received-list projection intact. No Superlocal/Gmail changes, mailbox-specific changes, schema changes, new dependencies, lockfile changes, or added test/helper files.

## Verification

All execution used `bun --no-env-file`. A standalone inline harness was used because current main has no suitable pure E2-auth/rate-limit test file; the live E2 suite was not run or extended.

The harness transpiled the actual base/candidate auth source into an isolated function, with in-memory auth/DB fixtures, a synthetic environment and network access disabled. Its limiter construction spy delegated to the **installed Upstash 2.0.7 JavaScript sliding-window algorithm**; Redis script results were supplied by a stub. No application auth/DB modules or secret files were imported.

| Check | Result |
| --- | --- |
| Base vs candidate limiter parameters | 10 vs 100 tokens; both use 1000ms windows and increment by 1 |
| Prefix and analytics | Unchanged: `e2:ratelimit`, analytics enabled |
| Scripted positive/zero/negative Redis remainders | Positive and zero accepted; negative becomes 429 with remaining clamped to 0 |
| Account partitioning | Two keys and different endpoint paths for one account use the same user identifier/window keys; another account uses different keys; session precedence preserved |
| Response metadata | Limit reflects actual 10/100 configuration; remaining/reset headers and calculated `Retry-After` preserved; existing headers retained |
| Auth/ban/service failures | Active ban 403 before limiting; missing user/credentials and auth failure 401; Redis failure or missing limiter 503 with `Retry-After: 60` |

Additional checks:

```sh
# Inline in-memory harness, run on base and candidate:
bun --no-env-file -

# Targeted existing linter, run before and after:
bun --no-env-file node_modules/@biomejs/biome/bin/biome lint app/api/e2/lib/auth.ts --max-diagnostics=5

git diff --check
git diff --cached --check
```

Bun 1.4.0 source transpilation and targeted Biome lint passed on base and candidate. Documentation JSON matches the verified 429 response example. Whitespace checks and a scoped staged-source secret-pattern scan passed. Existing installed dependencies were reused without installation.

## Verification limits / release boundary

**Redis Lua, distributed enforcement and an actual 100-allowed/101st-denied request sequence were not tested.** The network-free checks verify construction, Upstash's JavaScript handling of boundary results and the application's response/control flow; they are not a production load test.

No production/dev API calls, real database/Redis calls, full build, migration, merge, deployment or production reconfiguration were performed for this PR. No UI/layout changes; visual evidence is N/A. Merge and deployment remain separate approval steps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes enforced API throughput for all authenticated E2 traffic; misconfiguration could affect availability or abuse tolerance, though scope is limited to the Upstash limiter quota and docs.
> 
> **Overview**
> Restores the E2 API default rate limit from **10** to **100 requests per second per authenticated account**, using the same one-second sliding window and shared `userId` bucket in `validateAndRateLimit`.
> 
> Docs in **errors** and **rate-limits** are updated to match: per-account budget across E2 endpoints, `429` example with `Too Many Requests` / dynamic retry messaging, replacing outdated 2- and 10-request copy. Auth, ban checks, headers, and fail-closed behavior when Redis is missing are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb1acbcbdf86bc7984859f3bbe56a1e2901ce351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->