### PR TITLE
perf: batch list queries and paginate email logs in Postgres

### DIFF
--- a/app/actions/primary.ts
+++ b/app/actions/primary.ts
@@ -1,7 +1,19 @@
 "use server";
 
 import { Autumn as autumn, Customer } from "autumn-js";
-import { and, desc, eq, gte, inArray, sql } from "drizzle-orm";
+import {
+	and,
+	count,
+	countDistinct,
+	desc,
+	eq,
+	exists,
+	gte,
+	inArray,
+	notExists,
+	or,
+	sql,
+} from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { headers } from "next/headers";
 import { NextRequest } from "next/server";
@@ -24,6 +36,7 @@ import {
 } from "@/lib/db/schema";
 import {
 	parseEmail as libParseEmail,
+	type ParsedEmailAddress,
 	sanitizeHtml,
 } from "@/lib/email-management/email-parser";
 
@@ -2860,9 +2873,7 @@ export async function getUnifiedEmailLogs(options?: {
 
 		const userId = session.user.id;
 
-		// Build where conditions FIRST so they can be reused for both queries and stats
-		// Build inbound where conditions
-		let inboundWhereConditions = [eq(structuredEmails.userId, userId)];
+		const inboundWhereConditions = [eq(structuredEmails.userId, userId)];
 
 		// Add time range filter
 		if (timeRangeStart) {
@@ -2904,26 +2915,44 @@ export async function getUnifiedEmailLogs(options?: {
 			);
 		}
 
-		// Add status filter for inbound emails at SQL level
+		const inboundDeliveryConditions = [
+			eq(endpointDeliveries.emailId, structuredEmails.emailId),
+		];
 		if (
-			statusFilter !== "all" &&
-			statusFilter !== "pending" &&
-			statusFilter !== "failed" &&
-			statusFilter !== "delivered"
+			statusFilter === "delivered" ||
+			statusFilter === "failed" ||
+			statusFilter === "pending"
 		) {
-			// Handle special inbound-only filters
-			if (statusFilter === "no_delivery") {
-				inboundWhereConditions.push(
-					sql`NOT EXISTS (
-            SELECT 1 FROM ${endpointDeliveries} 
-            WHERE ${endpointDeliveries.emailId} = ${structuredEmails.emailId}
-          )`,
-				);
-			} else if (statusFilter === "parse_failed") {
-				inboundWhereConditions.push(eq(structuredEmails.parseSuccess, false));
-			} else if (statusFilter === "opened") {
-				inboundWhereConditions.push(sql`false`);
-			}
+			inboundDeliveryConditions.push(
+				eq(
+					endpointDeliveries.status,
+					statusFilter === "delivered" ? "success" : statusFilter,
+				),
+			);
+			const hasMatchingDelivery = exists(
+				db
+					.select({ id: endpointDeliveries.id })
+					.from(endpointDeliveries)
+					.where(and(...inboundDeliveryConditions)),
+			);
+			inboundWhereConditions.push(
+				statusFilter === "failed"
+					? or(hasMatchingDelivery, eq(structuredEmails.parseSuccess, false))!
+					: hasMatchingDelivery,
+			);
+		} else if (statusFilter === "no_delivery") {
+			inboundWhereConditions.push(
+				notExists(
+					db
+						.select({ id: endpointDeliveries.id })
+						.from(endpointDeliveries)
+						.where(and(...inboundDeliveryConditions)),
+				),
+			);
+		} else if (statusFilter === "parse_failed") {
+			inboundWhereConditions.push(eq(structuredEmails.parseSuccess, false));
+		} else if (statusFilter === "opened") {
+			inboundWhereConditions.push(sql`false`);
 		}
 
 		// Add Guard filter for inbound emails
@@ -2941,8 +2970,7 @@ export async function getUnifiedEmailLogs(options?: {
 			}
 		}
 
-		// Build outbound where conditions
-		let outboundWhereConditions = [eq(sentEmails.userId, userId)];
+		const outboundWhereConditions = [eq(sentEmails.userId, userId)];
 
 		// Add time range filter
 		if (timeRangeStart) {
@@ -2982,213 +3010,265 @@ export async function getUnifiedEmailLogs(options?: {
 			outboundWhereConditions.push(eq(sentEmails.status, "pending"));
 		}
 
-		// We'll fetch both types and merge them at the SQL level
-		const combinedEmails: any[] = [];
+		if (typeFilter !== "all" && typeFilter !== "inbound") {
+			inboundWhereConditions.push(sql`false`);
+		}
+		if (typeFilter !== "all" && typeFilter !== "outbound") {
+			outboundWhereConditions.push(sql`false`);
+		}
 
-		// Fetch inbound emails if not filtered to outbound only
-		if (typeFilter === "all" || typeFilter === "inbound") {
-			// Fetch inbound emails - only fields needed for list view
-			const inboundEmailsRaw = await db
-				.select({
-					id: structuredEmails.id,
-					emailId: structuredEmails.emailId,
-					messageId: structuredEmails.messageId,
-					subject: structuredEmails.subject,
-					date: structuredEmails.date,
-					fromData: structuredEmails.fromData,
-					toData: structuredEmails.toData,
-					attachments: structuredEmails.attachments,
-					parseSuccess: structuredEmails.parseSuccess,
-					createdAt: structuredEmails.createdAt,
-					processingTimeMillis: sesEvents.processingTimeMillis,
-
-					// Guard fields
-					guardBlocked: structuredEmails.guardBlocked,
-					guardReason: structuredEmails.guardReason,
-					guardAction: structuredEmails.guardAction,
-				})
-				.from(structuredEmails)
-				.leftJoin(sesEvents, eq(structuredEmails.sesEventId, sesEvents.id))
-				.where(and(...inboundWhereConditions))
-				.orderBy(desc(structuredEmails.createdAt));
-
-			// Fetch deliveries for these emails separately to avoid cartesian product
-			const emailIds = inboundEmailsRaw.map((e) => e.emailId);
-			let deliveriesMap = new Map<string, any[]>();
-
-			if (emailIds.length > 0) {
-				const deliveries = await db
+		const matchingEmails = db
+			.select({
+				id: structuredEmails.id,
+				typeOrder: sql<number>`0`.as("type_order"),
+				createdAt: structuredEmails.createdAt,
+			})
+			.from(structuredEmails)
+			.where(and(...inboundWhereConditions))
+			.unionAll(
+				db
 					.select({
-						emailId: endpointDeliveries.emailId,
-						id: endpointDeliveries.id,
-						status: endpointDeliveries.status,
-						deliveryType: endpointDeliveries.deliveryType,
-						responseData: endpointDeliveries.responseData,
-						endpointName: endpoints.name,
-						endpointType: endpoints.type,
+						id: sentEmails.id,
+						typeOrder: sql<number>`1`.as("type_order"),
+						createdAt: sentEmails.createdAt,
 					})
-					.from(endpointDeliveries)
-					.leftJoin(endpoints, eq(endpointDeliveries.endpointId, endpoints.id))
-					.where(inArray(endpointDeliveries.emailId, emailIds));
+					.from(sentEmails)
+					.where(and(...outboundWhereConditions)),
+			)
+			.as("matching_emails");
 
-				// Group deliveries by emailId
-				deliveries.forEach((delivery) => {
-					if (!deliveriesMap.has(delivery.emailId!)) {
-						deliveriesMap.set(delivery.emailId!, []);
-					}
+		const [totalRow] = await db.select({ total: count() }).from(matchingEmails);
+		const total = totalRow?.total || 0;
+		const sliceStart = Math.trunc(offset) || 0;
+		const sliceEnd = Math.trunc(offset + limit) || 0;
+		const pageOffset =
+			sliceStart < 0
+				? Math.max(total + sliceStart, 0)
+				: Math.min(sliceStart, total);
+		const pageEnd =
+			sliceEnd < 0 ? Math.max(total + sliceEnd, 0) : Math.min(sliceEnd, total);
+		const pageLimit = Math.max(pageEnd - pageOffset, 0);
+		const page =
+			pageLimit > 0
+				? await db
+						.select()
+						.from(matchingEmails)
+						.orderBy(
+							desc(
+								sql`date_trunc('milliseconds', ${matchingEmails.createdAt})`,
+							),
+							matchingEmails.typeOrder,
+							desc(matchingEmails.createdAt),
+						)
+						.limit(pageLimit)
+						.offset(pageOffset)
+				: [];
+		const inboundIds = page
+			.filter((email) => email.typeOrder === 0)
+			.map((email) => email.id);
+		const outboundIds = page
+			.filter((email) => email.typeOrder === 1)
+			.map((email) => email.id);
 
-					// Parse responseData to extract error and responseCode
-					let parsedResponse: any = null;
-					try {
-						parsedResponse = delivery.responseData
-							? JSON.parse(delivery.responseData)
-							: null;
-					} catch (e) {
-						// Ignore parse errors
-					}
+		const [inboundEmailsRaw, outboundEmailsRaw] = await Promise.all([
+			inboundIds.length > 0
+				? db
+						.select({
+							id: structuredEmails.id,
+							emailId: structuredEmails.emailId,
+							messageId: structuredEmails.messageId,
+							subject: structuredEmails.subject,
+							date: structuredEmails.date,
+							fromData: structuredEmails.fromData,
+							toData: structuredEmails.toData,
+							attachments: structuredEmails.attachments,
+							parseSuccess: structuredEmails.parseSuccess,
+							createdAt: structuredEmails.createdAt,
+							processingTimeMillis: sesEvents.processingTimeMillis,
+							guardBlocked: structuredEmails.guardBlocked,
+							guardReason: structuredEmails.guardReason,
+							guardAction: structuredEmails.guardAction,
+						})
+						.from(structuredEmails)
+						.leftJoin(sesEvents, eq(structuredEmails.sesEventId, sesEvents.id))
+						.where(
+							and(
+								eq(structuredEmails.userId, userId),
+								inArray(structuredEmails.id, inboundIds),
+							),
+						)
+				: [],
+			outboundIds.length > 0
+				? db
+						.select({
+							id: sentEmails.id,
+							fromAddress: sentEmails.fromAddress,
+							fromDomain: sentEmails.fromDomain,
+							to: sentEmails.to,
+							subject: sentEmails.subject,
+							attachments: sentEmails.attachments,
+							status: sentEmails.status,
+							messageId: sentEmails.messageId,
+							provider: sentEmails.provider,
+							sentAt: sentEmails.sentAt,
+							firstOpenedAt: sentEmails.firstOpenedAt,
+							lastOpenedAt: sentEmails.lastOpenedAt,
+							createdAt: sentEmails.createdAt,
+						})
+						.from(sentEmails)
+						.where(
+							and(
+								eq(sentEmails.userId, userId),
+								inArray(sentEmails.id, outboundIds),
+							),
+						)
+				: [],
+		]);
 
-					deliveriesMap.get(delivery.emailId!)!.push({
-						id: delivery.id,
-						type: delivery.deliveryType || "unknown",
-						status: delivery.status || "unknown",
-						error: parsedResponse?.error || null,
-						responseCode:
-							parsedResponse?.statusCode ||
-							parsedResponse?.responseCode ||
-							null,
-						config: {
-							name: delivery.endpointName || "Unknown Endpoint",
-							type: delivery.endpointType || "unknown",
-						},
-					});
-				});
+		const emailIds = inboundEmailsRaw.map((e) => e.emailId);
+		const deliveries =
+			emailIds.length > 0
+				? await db
+						.select({
+							emailId: endpointDeliveries.emailId,
+							id: endpointDeliveries.id,
+							status: endpointDeliveries.status,
+							deliveryType: endpointDeliveries.deliveryType,
+							responseData: endpointDeliveries.responseData,
+							endpointName: endpoints.name,
+							endpointType: endpoints.type,
+						})
+						.from(endpointDeliveries)
+						.leftJoin(
+							endpoints,
+							eq(endpointDeliveries.endpointId, endpoints.id),
+						)
+						.where(inArray(endpointDeliveries.emailId, emailIds))
+				: [];
+
+		const formattedDeliveries = deliveries.map((delivery) => {
+			let parsedResponse: {
+				error?: string;
+				statusCode?: number;
+				responseCode?: number;
+			} | null = null;
+			try {
+				parsedResponse = delivery.responseData
+					? JSON.parse(delivery.responseData)
+					: null;
+			} catch {
+				parsedResponse = null;
 			}
 
-			// Process inbound emails - only build list view data
-			for (const row of inboundEmailsRaw) {
-				let parsedFromData = null;
-				let parsedToData = null;
-				let parsedAttachments = [];
-
-				try {
-					if (row.fromData) parsedFromData = JSON.parse(row.fromData);
-					if (row.toData) parsedToData = JSON.parse(row.toData);
-					if (row.attachments) parsedAttachments = JSON.parse(row.attachments);
-				} catch (e) {
-					console.error("Failed to parse inbound email data:", e);
-				}
-
-				const fromAddress =
-					parsedFromData?.addresses?.[0]?.address || "unknown";
-				const recipient = parsedToData?.addresses?.[0]?.address || "unknown";
-				const domain = recipient.split("@")[1] || "";
-
-				const emailDeliveries = deliveriesMap.get(row.emailId) || [];
-
-				// Apply status filter based on deliveries if needed
-				if (statusFilter === "delivered") {
-					if (!emailDeliveries.some((d) => d.status === "success")) {
-						continue;
-					}
-				} else if (statusFilter === "failed") {
-					if (
-						!emailDeliveries.some((d) => d.status === "failed") &&
-						row.parseSuccess !== false
-					) {
-						continue;
-					}
-				} else if (statusFilter === "pending") {
-					if (!emailDeliveries.some((d) => d.status === "pending")) {
-						continue;
-					}
-				}
-
-				combinedEmails.push({
-					type: "inbound",
-					id: row.id,
-					emailId: row.emailId,
-					messageId: row.messageId,
-					from: fromAddress,
-					recipient: recipient,
-					subject: row.subject || "No Subject",
-					domain: domain,
-					hasAttachments: parsedAttachments.length > 0,
-					parseSuccess: row.parseSuccess,
-					processingTimeMs: row.processingTimeMillis || 0,
-					createdAt: row.createdAt?.toISOString(),
-					deliveries: emailDeliveries,
-					guardBlocked: row.guardBlocked || false,
-					guardReason: row.guardReason || null,
-					guardAction: row.guardAction || null,
-				});
-			}
+			return {
+				emailId: delivery.emailId,
+				delivery: {
+					id: delivery.id,
+					type: delivery.deliveryType || "unknown",
+					status: delivery.status || "unknown",
+					error: parsedResponse?.error || null,
+					responseCode:
+						parsedResponse?.statusCode || parsedResponse?.responseCode || null,
+					config: {
+						name: delivery.endpointName || "Unknown Endpoint",
+						type: delivery.endpointType || "unknown",
+					},
+				},
+			};
+		});
+		const deliveriesMap = new Map<
+			string,
+			(typeof formattedDeliveries)[number]["delivery"][]
+		>();
+		for (const { emailId, delivery } of formattedDeliveries) {
+			if (emailId === null) continue;
+			const emailDeliveries = deliveriesMap.get(emailId) || [];
+			emailDeliveries.push(delivery);
+			deliveriesMap.set(emailId, emailDeliveries);
 		}
 
-		// Fetch outbound emails if not filtered to inbound only
-		if (typeFilter === "all" || typeFilter === "outbound") {
-			// Fetch outbound emails - only fields needed for list view
-			const outboundEmails = await db
-				.select({
-					id: sentEmails.id,
-					fromAddress: sentEmails.fromAddress,
-					fromDomain: sentEmails.fromDomain,
-					to: sentEmails.to,
-					subject: sentEmails.subject,
-					attachments: sentEmails.attachments,
-					status: sentEmails.status,
-					messageId: sentEmails.messageId,
-					provider: sentEmails.provider,
-					sentAt: sentEmails.sentAt,
-					firstOpenedAt: sentEmails.firstOpenedAt,
-					lastOpenedAt: sentEmails.lastOpenedAt,
-					createdAt: sentEmails.createdAt,
-				})
-				.from(sentEmails)
-				.where(and(...outboundWhereConditions))
-				.orderBy(desc(sentEmails.createdAt));
+		const inboundEmails = inboundEmailsRaw.map((row) => {
+			let parsedFromData: ParsedEmailAddress | null = null;
+			let parsedToData: ParsedEmailAddress | null = null;
+			let parsedAttachments: unknown[] = [];
 
-			// Process outbound emails - only build list view data
-			for (const email of outboundEmails) {
-				let toArray = [];
-				let parsedAttachments = [];
-
-				try {
-					if (email.to) toArray = JSON.parse(email.to);
-					if (email.attachments)
-						parsedAttachments = JSON.parse(email.attachments);
-				} catch (e) {
-					console.error("Failed to parse outbound email data:", e);
-				}
-
-				combinedEmails.push({
-					type: "outbound",
-					id: email.id,
-					emailId: email.id,
-					messageId: email.messageId || "",
-					from: email.fromAddress,
-					to: toArray,
-					subject: email.subject || "No Subject",
-					domain: email.fromDomain,
-					hasAttachments: parsedAttachments.length > 0,
-					status: email.status,
-					provider: email.provider || "ses",
-					sentAt: email.sentAt?.toISOString() || null,
-					firstOpenedAt: email.firstOpenedAt?.toISOString() || null,
-					lastOpenedAt: email.lastOpenedAt?.toISOString() || null,
-					createdAt: email.createdAt?.toISOString(),
-				});
+			try {
+				if (row.fromData) parsedFromData = JSON.parse(row.fromData);
+				if (row.toData) parsedToData = JSON.parse(row.toData);
+				if (row.attachments) parsedAttachments = JSON.parse(row.attachments);
+			} catch (e) {
+				console.error("Failed to parse inbound email data:", e);
 			}
-		}
 
-		// Sort combined emails by creation date (most recent first)
-		combinedEmails.sort(
-			(a, b) =>
-				new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+			const fromAddress = parsedFromData?.addresses?.[0]?.address || "unknown";
+			const recipient = parsedToData?.addresses?.[0]?.address || "unknown";
+			const domain = recipient.split("@")[1] || "";
+			const emailDeliveries = deliveriesMap.get(row.emailId) || [];
+
+			return {
+				type: "inbound" as const,
+				id: row.id,
+				emailId: row.emailId,
+				messageId: row.messageId,
+				from: fromAddress,
+				recipient: recipient,
+				subject: row.subject || "No Subject",
+				domain: domain,
+				hasAttachments: parsedAttachments.length > 0,
+				parseSuccess: row.parseSuccess,
+				processingTimeMs: row.processingTimeMillis || 0,
+				createdAt: row.createdAt?.toISOString(),
+				deliveries: emailDeliveries,
+				guardBlocked: row.guardBlocked || false,
+				guardReason: row.guardReason || null,
+				guardAction: row.guardAction || null,
+			};
+		});
+
+		const outboundEmails = outboundEmailsRaw.map((email) => {
+			let toArray: string[] = [];
+			let parsedAttachments: unknown[] = [];
+
+			try {
+				if (email.to) toArray = JSON.parse(email.to);
+				if (email.attachments)
+					parsedAttachments = JSON.parse(email.attachments);
+			} catch (e) {
+				console.error("Failed to parse outbound email data:", e);
+			}
+
+			return {
+				type: "outbound" as const,
+				id: email.id,
+				emailId: email.id,
+				messageId: email.messageId || "",
+				from: email.fromAddress,
+				to: toArray,
+				subject: email.subject || "No Subject",
+				domain: email.fromDomain,
+				hasAttachments: parsedAttachments.length > 0,
+				status: email.status,
+				provider: email.provider || "ses",
+				sentAt: email.sentAt?.toISOString() || null,
+				firstOpenedAt: email.firstOpenedAt?.toISOString() || null,
+				lastOpenedAt: email.lastOpenedAt?.toISOString() || null,
+				createdAt: email.createdAt?.toISOString(),
+			};
+		});
+
+		const inboundById = new Map(
+			inboundEmails.map((email) => [email.id, email]),
 		);
-
-		// Apply pagination AFTER sorting
-		const total = combinedEmails.length;
-		const paginatedEmails = combinedEmails.slice(offset, offset + limit);
+		const outboundById = new Map(
+			outboundEmails.map((email) => [email.id, email]),
+		);
+		const paginatedEmails = page.flatMap((email) => {
+			const hydratedEmail =
+				email.typeOrder === 0
+					? inboundById.get(email.id)
+					: outboundById.get(email.id);
+			return hydratedEmail ? [hydratedEmail] : [];
+		});
 
 		// Get unique domains from paginated results for filter dropdown (lightweight)
 		const uniqueDomainsSet = new Set<string>();
@@ -3243,60 +3323,30 @@ export async function getUnifiedEmailLogs(options?: {
 			.from(sentEmails)
 			.where(and(...lifetimeOutboundConditions));
 
-		// Inbound delivery stats - use separate queries for accuracy
-		const withDeliveriesQuery = db
-			.select({ count: sql<number>`COUNT(DISTINCT e.email_id)`.as("count") })
-			.from(sql`(
-        SELECT DISTINCT ${endpointDeliveries.emailId} as email_id
-        FROM ${endpointDeliveries}
-        INNER JOIN ${structuredEmails} ON ${endpointDeliveries.emailId} = ${structuredEmails.emailId}
-        WHERE ${structuredEmails.userId} = ${userId}
-      ) e`);
+		const deliveryStatsQuery = db
+			.select({
+				withDeliveries: countDistinct(endpointDeliveries.emailId),
+				successful: countDistinct(
+					sql`CASE WHEN ${endpointDeliveries.status} = 'success' THEN ${endpointDeliveries.emailId} END`,
+				),
+				failed: countDistinct(
+					sql`CASE WHEN ${endpointDeliveries.status} = 'failed' THEN ${endpointDeliveries.emailId} END`,
+				),
+				pending: countDistinct(
+					sql`CASE WHEN ${endpointDeliveries.status} = 'pending' THEN ${endpointDeliveries.emailId} END`,
+				),
+			})
+			.from(endpointDeliveries)
+			.innerJoin(
+				structuredEmails,
+				eq(endpointDeliveries.emailId, structuredEmails.emailId),
+			)
+			.where(eq(structuredEmails.userId, userId));
 
-		const successfulDeliveriesQuery = db
-			.select({ count: sql<number>`COUNT(DISTINCT e.email_id)`.as("count") })
-			.from(sql`(
-        SELECT DISTINCT ${endpointDeliveries.emailId} as email_id
-        FROM ${endpointDeliveries}
-        INNER JOIN ${structuredEmails} ON ${endpointDeliveries.emailId} = ${structuredEmails.emailId}
-        WHERE ${structuredEmails.userId} = ${userId}
-          AND ${endpointDeliveries.status} = 'success'
-      ) e`);
-
-		const failedDeliveriesQuery = db
-			.select({ count: sql<number>`COUNT(DISTINCT e.email_id)`.as("count") })
-			.from(sql`(
-        SELECT DISTINCT ${endpointDeliveries.emailId} as email_id
-        FROM ${endpointDeliveries}
-        INNER JOIN ${structuredEmails} ON ${endpointDeliveries.emailId} = ${structuredEmails.emailId}
-        WHERE ${structuredEmails.userId} = ${userId}
-          AND ${endpointDeliveries.status} = 'failed'
-      ) e`);
-
-		const pendingDeliveriesQuery = db
-			.select({ count: sql<number>`COUNT(DISTINCT e.email_id)`.as("count") })
-			.from(sql`(
-        SELECT DISTINCT ${endpointDeliveries.emailId} as email_id
-        FROM ${endpointDeliveries}
-        INNER JOIN ${structuredEmails} ON ${endpointDeliveries.emailId} = ${structuredEmails.emailId}
-        WHERE ${structuredEmails.userId} = ${userId}
-          AND ${endpointDeliveries.status} = 'pending'
-      ) e`);
-
-		const [
-			inboundStats,
-			outboundStats,
-			withDeliveries,
-			successfulDeliveries,
-			failedDeliveries,
-			pendingDeliveries,
-		] = await Promise.all([
+		const [inboundStats, outboundStats, deliveryStats] = await Promise.all([
 			inboundStatsQuery,
 			outboundStatsQuery,
-			withDeliveriesQuery,
-			successfulDeliveriesQuery,
-			failedDeliveriesQuery,
-			pendingDeliveriesQuery,
+			deliveryStatsQuery,
 		]);
 
 		const inboundStatsRow = inboundStats[0] || {
@@ -3313,12 +3363,10 @@ export async function getUnifiedEmailLogs(options?: {
 		};
 
 		// Parse counts as numbers to avoid string concatenation
-		const withDeliveriesCount = Number(withDeliveries[0]?.count || 0);
-		const successfulDeliveriesCount = Number(
-			successfulDeliveries[0]?.count || 0,
-		);
-		const failedDeliveriesCount = Number(failedDeliveries[0]?.count || 0);
-		const pendingDeliveriesCount = Number(pendingDeliveries[0]?.count || 0);
+		const withDeliveriesCount = deliveryStats[0]?.withDeliveries || 0;
+		const successfulDeliveriesCount = deliveryStats[0]?.successful || 0;
+		const failedDeliveriesCount = deliveryStats[0]?.failed || 0;
+		const pendingDeliveriesCount = deliveryStats[0]?.pending || 0;
 
 		const stats = {
 			totalEmails:

--- a/app/api/e2/endpoints/list.ts
+++ b/app/api/e2/endpoints/list.ts
@@ -1,8 +1,8 @@
 import { Elysia, t } from "elysia";
-import { validateAndRateLimit } from "../lib/auth";
+import { validateAndRateLimit } from "@/app/api/e2/lib/auth";
 import { db } from "@/lib/db";
 import { endpoints, emailGroups, endpointDeliveries } from "@/lib/db/schema";
-import { eq, and, desc, asc, count, ilike, or } from "drizzle-orm";
+import { eq, and, desc, asc, count, ilike, inArray, max, or } from "drizzle-orm";
 
 // Request/Response Types (OpenAPI-compatible)
 const ListEndpointsQuery = t.Object({
@@ -153,77 +153,105 @@ export const listEndpoints = new Elysia().get(
 
     // Enhance endpoints with additional data
     console.log("🔧 Enhancing endpoints with additional data");
-    const enhancedEndpoints = await Promise.all(
-      userEndpoints.map(async (endpoint) => {
-        let groupEmails: string[] | null = null;
-
-        // Add group emails for email_group endpoints
-        if (endpoint.type === "email_group") {
-          const groupEmailsResult = await db
-            .select({ emailAddress: emailGroups.emailAddress })
+    const endpointIds = userEndpoints.map((endpoint) => endpoint.id);
+    const groupEndpointIds = userEndpoints
+      .filter((endpoint) => endpoint.type === "email_group")
+      .map((endpoint) => endpoint.id);
+    const [deliveryStatsRows, groupEmailRows] = await Promise.all([
+      endpointIds.length > 0
+        ? db
+            .select({
+              endpointId: endpointDeliveries.endpointId,
+              status: endpointDeliveries.status,
+              total: count(),
+              attempted: count(endpointDeliveries.lastAttemptAt),
+              lastDelivery: max(endpointDeliveries.lastAttemptAt),
+            })
+            .from(endpointDeliveries)
+            .where(inArray(endpointDeliveries.endpointId, endpointIds))
+            .groupBy(endpointDeliveries.endpointId, endpointDeliveries.status)
+        : Promise.resolve([]),
+      groupEndpointIds.length > 0
+        ? db
+            .select({
+              endpointId: emailGroups.endpointId,
+              emailAddress: emailGroups.emailAddress,
+            })
             .from(emailGroups)
-            .where(eq(emailGroups.endpointId, endpoint.id))
-            .orderBy(emailGroups.createdAt);
+            .where(inArray(emailGroups.endpointId, groupEndpointIds))
+            .orderBy(emailGroups.createdAt)
+        : Promise.resolve([]),
+    ]);
+    const deliveryStatsByEndpoint = new Map<
+      string,
+      {
+        total: number;
+        successful: number;
+        failed: number;
+        lastDelivery: Date | null;
+        hasMissingAttempt: boolean;
+      }
+    >();
+    for (const row of deliveryStatsRows) {
+      const stats = deliveryStatsByEndpoint.get(row.endpointId) ?? {
+        total: 0,
+        successful: 0,
+        failed: 0,
+        lastDelivery: null,
+        hasMissingAttempt: false,
+      };
+      stats.total += row.total;
+      if (row.status === "success") stats.successful += row.total;
+      if (row.status === "failed") stats.failed += row.total;
+      stats.hasMissingAttempt ||= row.attempted < row.total;
+      if (
+        row.lastDelivery &&
+        (!stats.lastDelivery || row.lastDelivery > stats.lastDelivery)
+      ) {
+        stats.lastDelivery = row.lastDelivery;
+      }
+      deliveryStatsByEndpoint.set(row.endpointId, stats);
+    }
+    const groupEmailsByEndpoint = new Map<string, string[]>();
+    for (const row of groupEmailRows) {
+      const addresses = groupEmailsByEndpoint.get(row.endpointId) ?? [];
+      addresses.push(row.emailAddress);
+      groupEmailsByEndpoint.set(row.endpointId, addresses);
+    }
+    const enhancedEndpoints = userEndpoints.map((endpoint) => {
+      const groupEmails = endpoint.type === "email_group"
+        ? groupEmailsByEndpoint.get(endpoint.id) ?? []
+        : null;
+      const stats = deliveryStatsByEndpoint.get(endpoint.id);
+      const lastDeliveryDate = stats?.hasMissingAttempt
+        ? null
+        : stats?.lastDelivery;
 
-          groupEmails = groupEmailsResult.map((g) => g.emailAddress);
-        }
-
-        // Get delivery statistics
-        const deliveryStatsResult = await db
-          .select({
-            total: count(),
-            status: endpointDeliveries.status,
-          })
-          .from(endpointDeliveries)
-          .where(eq(endpointDeliveries.endpointId, endpoint.id))
-          .groupBy(endpointDeliveries.status);
-
-        let totalDeliveries = 0;
-        let successfulDeliveries = 0;
-        let failedDeliveries = 0;
-
-        for (const stat of deliveryStatsResult) {
-          totalDeliveries += stat.total;
-          if (stat.status === "success") successfulDeliveries += stat.total;
-          if (stat.status === "failed") failedDeliveries += stat.total;
-        }
-
-        // Get the most recent delivery date
-        const lastDeliveryResult = await db
-          .select({ lastDelivery: endpointDeliveries.lastAttemptAt })
-          .from(endpointDeliveries)
-          .where(eq(endpointDeliveries.endpointId, endpoint.id))
-          .orderBy(desc(endpointDeliveries.lastAttemptAt))
-          .limit(1);
-
-        const lastDeliveryDate = lastDeliveryResult[0]?.lastDelivery || null;
-
-        return {
-          id: endpoint.id,
-          name: endpoint.name,
-          type: endpoint.type as "webhook" | "email" | "email_group",
-          config: JSON.parse(endpoint.config),
-          isActive: endpoint.isActive || false,
-          description: endpoint.description,
-          userId: endpoint.userId,
-          createdAt: endpoint.createdAt
-            ? new Date(endpoint.createdAt).toISOString()
-            : new Date().toISOString(),
-          updatedAt: endpoint.updatedAt
-            ? new Date(endpoint.updatedAt).toISOString()
-            : new Date().toISOString(),
-          groupEmails,
-          deliveryStats: {
-            total: totalDeliveries,
-            successful: successfulDeliveries,
-            failed: failedDeliveries,
-            lastDelivery: lastDeliveryDate
-              ? new Date(lastDeliveryDate).toISOString()
-              : null,
-          },
-        };
-      })
-    );
+      return {
+        id: endpoint.id,
+        name: endpoint.name,
+        type: endpoint.type as "webhook" | "email" | "email_group",
+        config: JSON.parse(endpoint.config),
+        isActive: endpoint.isActive || false,
+        description: endpoint.description,
+        userId: endpoint.userId,
+        createdAt: endpoint.createdAt
+          ? new Date(endpoint.createdAt).toISOString()
+          : new Date().toISOString(),
+        updatedAt: endpoint.updatedAt
+          ? new Date(endpoint.updatedAt).toISOString()
+          : new Date().toISOString(),
+        groupEmails,
+        deliveryStats: {
+          total: stats?.total ?? 0,
+          successful: stats?.successful ?? 0,
+          failed: stats?.failed ?? 0,
+          lastDelivery: lastDeliveryDate
+            ? new Date(lastDeliveryDate).toISOString()
+            : null,
+        },
+      };
+    });
 
     console.log("✅ Successfully enhanced all endpoints");
 

--- a/app/api/e2/mail/threads-list.ts
+++ b/app/api/e2/mail/threads-list.ts
@@ -1,6 +1,6 @@
 import { Elysia, t } from "elysia";
-import { validateAndRateLimit } from "../lib/auth";
-import { getThreadParticipantNames } from "../lib/participants";
+import { validateAndRateLimit } from "@/app/api/e2/lib/auth";
+import { getThreadParticipantNames } from "@/app/api/e2/lib/participants";
 import { db } from "@/lib/db";
 import {
   emailThreads,
@@ -9,7 +9,7 @@ import {
   emailDomains,
   emailAddresses,
 } from "@/lib/db/schema";
-import { eq, and, desc, sql, or, like } from "drizzle-orm";
+import { eq, and, desc, sql, or, like, inArray, count } from "drizzle-orm";
 
 // Query parameters schema with full OpenAPI descriptions
 const ListThreadsQuerySchema = t.Object({
@@ -183,127 +183,136 @@ const ListThreadsErrorResponse = t.Object({
   error: t.String({ description: "Error message describing what went wrong" }),
 });
 
-// Helper to get latest message for a thread
-async function getLatestMessageForThread(threadId: string, userId: string) {
-  // Get latest inbound message
-  const latestInbound = await db
-    .select({
-      id: structuredEmails.id,
-      subject: structuredEmails.subject,
-      fromData: structuredEmails.fromData,
-      textBody: structuredEmails.textBody,
-      isRead: structuredEmails.isRead,
-      attachments: structuredEmails.attachments,
-      date: structuredEmails.date,
-      threadPosition: structuredEmails.threadPosition,
-    })
-    .from(structuredEmails)
-    .where(
-      and(
-        eq(structuredEmails.threadId, threadId),
-        eq(structuredEmails.userId, userId)
+async function getLatestMessageResolver(threadIds: string[], userId: string) {
+  const [latestInbound, latestOutbound] = await Promise.all([
+    db
+      .selectDistinctOn([structuredEmails.threadId], {
+        threadId: structuredEmails.threadId,
+        id: structuredEmails.id,
+        subject: structuredEmails.subject,
+        fromData: structuredEmails.fromData,
+        textBody: structuredEmails.textBody,
+        isRead: structuredEmails.isRead,
+        attachments: structuredEmails.attachments,
+        date: structuredEmails.date,
+        threadPosition: structuredEmails.threadPosition,
+      })
+      .from(structuredEmails)
+      .where(
+        and(
+          inArray(structuredEmails.threadId, threadIds),
+          eq(structuredEmails.userId, userId)
+        )
       )
-    )
-    .orderBy(desc(structuredEmails.threadPosition))
-    .limit(1);
+      .orderBy(structuredEmails.threadId, desc(structuredEmails.threadPosition)),
+    db
+      .selectDistinctOn([sentEmails.threadId], {
+        threadId: sentEmails.threadId,
+        id: sentEmails.id,
+        subject: sentEmails.subject,
+        from: sentEmails.from,
+        textBody: sentEmails.textBody,
+        attachments: sentEmails.attachments,
+        sentAt: sentEmails.sentAt,
+        threadPosition: sentEmails.threadPosition,
+      })
+      .from(sentEmails)
+      .where(
+        and(
+          inArray(sentEmails.threadId, threadIds),
+          eq(sentEmails.userId, userId)
+        )
+      )
+      .orderBy(sentEmails.threadId, desc(sentEmails.threadPosition)),
+  ]);
 
-  // Get latest outbound message
-  const latestOutbound = await db
-    .select({
-      id: sentEmails.id,
-      subject: sentEmails.subject,
-      from: sentEmails.from,
-      textBody: sentEmails.textBody,
-      attachments: sentEmails.attachments,
-      sentAt: sentEmails.sentAt,
-      threadPosition: sentEmails.threadPosition,
-    })
-    .from(sentEmails)
-    .where(
-      and(eq(sentEmails.threadId, threadId), eq(sentEmails.userId, userId))
-    )
-    .orderBy(desc(sentEmails.threadPosition))
-    .limit(1);
+  const inboundByThread = new Map(
+    latestInbound.map((message) => [message.threadId, message])
+  );
+  const outboundByThread = new Map(
+    latestOutbound.map((message) => [message.threadId, message])
+  );
 
-  const inbound = latestInbound[0];
-  const outbound = latestOutbound[0];
+  function getLatestMessage(threadId: string) {
+    const inbound = inboundByThread.get(threadId);
+    const outbound = outboundByThread.get(threadId);
 
-  if (!inbound && !outbound) return null;
+    if (!inbound && !outbound) return null;
 
-  const inboundPosition = inbound?.threadPosition || 0;
-  const outboundPosition = outbound?.threadPosition || 0;
+    const inboundPosition = inbound?.threadPosition || 0;
+    const outboundPosition = outbound?.threadPosition || 0;
 
-  if (outboundPosition > inboundPosition && outbound) {
-    let attachments: any[] = [];
-    try {
-      attachments = outbound.attachments
-        ? JSON.parse(outbound.attachments)
-        : [];
-    } catch (e) {}
+    if (outboundPosition > inboundPosition && outbound) {
+      let attachments: unknown[] = [];
+      try {
+        attachments = outbound.attachments
+          ? JSON.parse(outbound.attachments)
+          : [];
+      } catch (e) {}
 
-    return {
-      id: outbound.id,
-      type: "outbound" as const,
-      subject: outbound.subject,
-      from_text: outbound.from,
-      text_preview: outbound.textBody
-        ? outbound.textBody.substring(0, 200)
-        : null,
-      is_read: true,
-      has_attachments: attachments.length > 0,
-      date: outbound.sentAt?.toISOString() || null,
-    };
-  } else if (inbound) {
-    let fromText = "Unknown Sender";
-    try {
-      if (inbound.fromData) {
-        const fromParsed = JSON.parse(inbound.fromData);
-        fromText =
-          fromParsed.text ||
-          fromParsed.addresses?.[0]?.address ||
-          "Unknown Sender";
-      }
-    } catch (e) {}
+      return {
+        id: outbound.id,
+        type: "outbound" as const,
+        subject: outbound.subject,
+        from_text: outbound.from,
+        text_preview: outbound.textBody
+          ? outbound.textBody.substring(0, 200)
+          : null,
+        is_read: true,
+        has_attachments: attachments.length > 0,
+        date: outbound.sentAt?.toISOString() || null,
+      };
+    } else if (inbound) {
+      let fromText = "Unknown Sender";
+      try {
+        if (inbound.fromData) {
+          const fromParsed = JSON.parse(inbound.fromData);
+          fromText =
+            fromParsed.text ||
+            fromParsed.addresses?.[0]?.address ||
+            "Unknown Sender";
+        }
+      } catch (e) {}
 
-    let attachments: any[] = [];
-    try {
-      attachments = inbound.attachments ? JSON.parse(inbound.attachments) : [];
-    } catch (e) {}
+      let attachments: unknown[] = [];
+      try {
+        attachments = inbound.attachments ? JSON.parse(inbound.attachments) : [];
+      } catch (e) {}
 
-    return {
-      id: inbound.id,
-      type: "inbound" as const,
-      subject: inbound.subject,
-      from_text: fromText,
-      text_preview: inbound.textBody
-        ? inbound.textBody.substring(0, 200)
-        : null,
-      is_read: inbound.isRead || false,
-      has_attachments: attachments.length > 0,
-      date: inbound.date?.toISOString() || null,
-    };
+      return {
+        id: inbound.id,
+        type: "inbound" as const,
+        subject: inbound.subject,
+        from_text: fromText,
+        text_preview: inbound.textBody
+          ? inbound.textBody.substring(0, 200)
+          : null,
+        is_read: inbound.isRead || false,
+        has_attachments: attachments.length > 0,
+        date: inbound.date?.toISOString() || null,
+      };
+    }
+
+    return null;
   }
 
-  return null;
+  return getLatestMessage;
 }
 
-// Get unread count for a thread
-async function getThreadUnreadCount(
-  threadId: string,
-  userId: string
-): Promise<number> {
+async function getThreadUnreadCounts(threadIds: string[], userId: string) {
   const result = await db
-    .select({ count: sql<number>`count(*)` })
+    .select({ threadId: structuredEmails.threadId, count: count() })
     .from(structuredEmails)
     .where(
       and(
-        eq(structuredEmails.threadId, threadId),
+        inArray(structuredEmails.threadId, threadIds),
         eq(structuredEmails.userId, userId),
         eq(structuredEmails.isRead, false)
       )
-    );
+    )
+    .groupBy(structuredEmails.threadId);
 
-  return Number(result[0]?.count || 0);
+  return new Map(result.map((row) => [row.threadId, Number(row.count || 0)]));
 }
 
 export const listThreads = new Elysia().get(
@@ -480,6 +489,12 @@ export const listThreads = new Elysia().get(
         break;
       }
 
+      const threadIds = threads.map((thread) => thread.id);
+      const [getLatestMessage, unreadCounts] = await Promise.all([
+        getLatestMessageResolver(threadIds, userId),
+        getThreadUnreadCounts(threadIds, userId),
+      ]);
+
       // Process threads
       for (const thread of threads) {
         if (threadItems.length >= limit) {
@@ -487,11 +502,8 @@ export const listThreads = new Elysia().get(
           break;
         }
 
-        const latestMessage = await getLatestMessageForThread(
-          thread.id,
-          userId
-        );
-        const unreadCount = await getThreadUnreadCount(thread.id, userId);
+        const latestMessage = getLatestMessage(thread.id);
+        const unreadCount = unreadCounts.get(thread.id) ?? 0;
         const hasUnread = unreadCount > 0;
 
         // Apply unread filter


### PR DESCRIPTION
## Summary
Reduce database work and function data transfer without changing public API responses or webhook contracts.

- Batch endpoint delivery aggregates and group members for the authenticated page, retaining null-first last-delivery behavior.
- Batch thread previews and unread counts; leave participant formatting and cursor/filter behavior intact.
- Move unified email-log filtering, counting, ordering, and pagination into PostgreSQL. Hydrate only the selected emails and their deliveries instead of the complete matching history.
- Combine four lifetime delivery-count queries into one aggregate while retaining overlapping success/failure/pending counts.

No migrations, indexes, dependencies, API/schema changes, or webhook changes. Based on current `main`; unrelated local working-tree changes are excluded.

## Local measurements
Compared baseline and changed code against the same disposable PostgreSQL 18 dataset, with authentication injected and no calls to production services. SQL counts exclude authentication.

| Scenario | Before | After |
| --- | ---: | ---: |
| Endpoint list, 50 endpoints | 119 queries | 4 queries |
| Thread list, 25 threads | 126 queries | 54 queries |
| Dashboard, 50 of 1,298 matching emails | 9 queries | 8 queries |
| Serialized database results for that dashboard request | 2,591,766 bytes | 72,487 bytes |

The byte measurement is serialized result data from synthetic fixtures, not measured production network billing or dollar savings. Exact totals and lifetime statistics still require aggregation; this eliminates unbounded application-side hydration, not all database scans.

## Verification
- Baseline/current response equivalence: 10 endpoint scenarios and 9 thread scenarios on PostgreSQL.
- Final dashboard response equivalence: 90 scenarios across two tenants and an empty account, including status/search/domain/guard filters, pagination edge cases, delivery details, lifetime statistics, and microsecond timestamp ties.
- Targeted in-memory TypeScript compiler checks: no diagnostics in the three changed files; no emitted files or incremental-state writes.
- `git diff --check` passed; independent compatibility review found no blockers.
- Targeted Biome lint remains blocked by 16 pre-existing explicit-`any` errors in untouched portions of `primary.ts` and `threads-list.ts`; endpoint-list lint passes.

No new test files were added. Checks ran inline against the actual query/formatting code; no deployed API tests, dev server, build, or production mutations were run.

## Compatibility notes
Preserves response fields/defaults, exact pagination totals, page-derived domain options, inbound-first cross-type timestamp ties, null delivery timestamps, and failed status meaning failed delivery OR parse failure. Same-type exact timestamp ties and unordered delivery arrays remain unspecified by SQL, as before.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large refactor of filtering, pagination, and aggregation SQL for the dashboard and API lists; behavior is intended to be equivalent but ordering/tie and delivery-stat edge cases are sensitive.
> 
> **Overview**
> This PR **reduces database round-trips and memory use** on list-style reads while keeping the same response shapes and filter semantics.
> 
> **Unified dashboard email logs** (`getUnifiedEmailLogs` in `primary.ts`) no longer load the full inbound/outbound match set into Node. Inbound delivery status filters move into SQL via `exists` / `notExists`; matching rows are counted and paginated with a `unionAll` subquery and millisecond ordering (inbound before outbound on ties). Only the current page is hydrated, with deliveries loaded for those inbound `emailId`s. Lifetime inbound delivery metrics collapse from four distinct-count queries into one grouped aggregate.
> 
> **E2 endpoint list** batches delivery stats and email-group members for all returned endpoints in two queries instead of per-endpoint queries, including the rule that **`lastDelivery` is null** when any delivery row lacks `lastAttemptAt`.
> 
> **E2 thread list** resolves latest message previews and unread counts per batch of thread IDs (e.g. `selectDistinctOn` + grouped counts) instead of two queries per thread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9a9fca805419e102495308becc028c9cff0ac84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->