### PR TITLE
Reduce database work without schema changes

### DIFF
--- a/app/api/e2/domains/list-query.test.ts
+++ b/app/api/e2/domains/list-query.test.ts
@@ -1,0 +1,672 @@
+import { Database, type SQLQueryBindings } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { Elysia, t } from "elysia";
+import * as orm from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pg-proxy";
+import type { PgTable } from "drizzle-orm/pg-core";
+import {
+	domainDnsRecords,
+	emailAddresses,
+	emailDomains,
+	endpoints,
+	webhooks,
+} from "@/lib/db/schema";
+
+const tables = {
+	domainDnsRecords,
+	emailAddresses,
+	emailDomains,
+	endpoints,
+	webhooks,
+};
+const timestamp = new Date("2026-01-01T00:00:00Z");
+const booleanNames = new Set(
+	Object.values(tables).flatMap((table) =>
+		Object.values(orm.getTableColumns(table))
+			.filter((column) => column.dataType === "boolean")
+			.map((column) => column.name),
+	),
+);
+const timestampNames = new Set(
+	Object.values(tables).flatMap((table) =>
+		Object.values(orm.getTableColumns(table))
+			.filter((column) => column.dataType === "date")
+			.map((column) => column.name),
+	),
+);
+const sources = await Promise.all(
+	["domains", "email-addresses"].map(async (directory) => {
+		const path = new URL(`../${directory}/list.ts`, import.meta.url);
+		const source = (await Bun.file(path).text())
+			.replace(/^import[\s\S]*?from ["'][^"']+["'];\n/gm, "")
+			.replace(/export const /g, "const ");
+		const exported =
+			directory === "domains" ? "listDomains" : "listEmailAddresses";
+		return new Bun.Transpiler({ loader: "ts" }).transformSync(
+			`${source}\nreturn ${exported};`,
+		);
+	}),
+);
+
+function binding(value: unknown): SQLQueryBindings {
+	if (typeof value === "boolean") return Number(value);
+	if (
+		value === null ||
+		typeof value === "string" ||
+		typeof value === "number"
+	) {
+		return value;
+	}
+	throw new Error("Unexpected test database binding");
+}
+
+function setup(
+	options: {
+		authorized?: boolean;
+		sesStatus?: string;
+		sesError?: boolean;
+		dnsError?: boolean;
+	} = {},
+) {
+	const sqlite = new Database(":memory:");
+	for (const table of Object.values(tables)) {
+		const columns = Object.values(orm.getTableColumns(table));
+		sqlite.exec(
+			`CREATE TABLE "${orm.getTableName(table)}" (${columns
+				.map((column) => `"${column.name}" ${column.getSQLType()}`)
+				.join(", ")})`,
+		);
+	}
+	const queries: { sql: string; params: unknown[] }[] = [];
+	const db = drizzle(async (sql, params) => {
+		queries.push({ sql, params });
+		const statement = sqlite.query(sql.replace(/\$\d+/g, "?"));
+		const names = statement.columnNames;
+		return {
+			rows: (statement.values(...params.map(binding)) ?? []).map((row) =>
+				row.map((value, index) => {
+					if (value !== null && booleanNames.has(names[index]))
+						return Boolean(value);
+					if (typeof value === "string" && timestampNames.has(names[index])) {
+						return value.replace(/Z$/, "");
+					}
+					return value;
+				}),
+			),
+		};
+	});
+	const insertNullableRows = <T extends PgTable>(
+		table: T,
+		values: T["$inferInsert"][],
+	) =>
+		db
+			.insert(table)
+			.values(
+				values.map(
+					(row) =>
+						Object.fromEntries(
+							Object.keys(orm.getTableColumns(table)).map((key) => [
+								key,
+								(row as Record<string, unknown>)[key] ?? null,
+							]),
+						) as T["$inferInsert"],
+				),
+			);
+	const dnsCalls: { type: string; name: string; value: string }[][] = [];
+	const sesCalls: unknown[] = [];
+	let authCalls = 0;
+	const dependencies = {
+		Elysia,
+		t,
+		db,
+		...orm,
+		...tables,
+		validateAndRateLimit: async () => {
+			authCalls++;
+			if (options.authorized === false) throw new Error("Unauthorized");
+			return "u";
+		},
+		verifyDnsRecords: async (
+			records: { type: string; name: string; value: string }[],
+		) => {
+			dnsCalls.push(records);
+			if (options.dnsError) throw new Error("DNS unavailable");
+			return records.map((record) => ({
+				...record,
+				expectedValue: record.value,
+				isVerified: true,
+			}));
+		},
+		SESClient: class {
+			async send(command: { input: { Identities: string[] } }) {
+				sesCalls.push(command.input);
+				if (options.sesError) throw new Error("SES unavailable");
+				return {
+					VerificationAttributes: Object.fromEntries(
+						command.input.Identities.map((domain) => [
+							domain,
+							{ VerificationStatus: options.sesStatus },
+						]),
+					),
+				};
+			}
+		},
+		GetIdentityVerificationAttributesCommand: class {
+			constructor(public input: { Identities: string[] }) {}
+		},
+		process: {
+			env:
+				options.sesStatus || options.sesError
+					? {
+							AWS_ACCESS_KEY_ID: "test-only",
+							AWS_SECRET_ACCESS_KEY: "test-only",
+						}
+					: {},
+		},
+		console: { log() {}, error() {} },
+	};
+	const apps = sources.map(
+		(source) =>
+			new Function(...Object.keys(dependencies), source)(
+				...Object.values(dependencies),
+			) as Elysia,
+	);
+	const request = async (path: string) => {
+		queries.length = 0;
+		return apps[path.startsWith("/domains") ? 0 : 1].handle(
+			new Request(`http://localhost${path}`),
+		);
+	};
+	return {
+		db,
+		insertNullableRows,
+		queries,
+		dnsCalls,
+		sesCalls,
+		request,
+		authCalls: () => authCalls,
+		[Symbol.dispose]: () => sqlite.close(),
+	};
+}
+
+type Context = ReturnType<typeof setup>;
+type ListBody = {
+	data: Record<string, unknown>[];
+	pagination: {
+		limit: number;
+		offset: number;
+		total: number;
+		hasMore: boolean;
+	};
+	capabilities?: { envelopeRecipients: boolean };
+};
+async function json(response: Response): Promise<ListBody> {
+	const text = await response.text();
+	expect(response.status, text).toBe(200);
+	return JSON.parse(text);
+}
+
+async function seed(context: Context) {
+	await context.insertNullableRows(emailDomains, [
+		{
+			id: "d1",
+			domain: "one.example",
+			userId: "u",
+			status: "pending",
+			catchAllEndpointId: "e1",
+			isCatchAllEnabled: false,
+			canReceiveEmails: true,
+			createdAt: timestamp,
+			updatedAt: timestamp,
+		},
+		{
+			id: "d2",
+			domain: "two.example",
+			userId: "u",
+			status: "verified",
+			catchAllEndpointId: "missing",
+			canReceiveEmails: false,
+			createdAt: new Date(timestamp.getTime() - 1000),
+			updatedAt: timestamp,
+		},
+		{
+			id: "d3",
+			domain: "three.example",
+			userId: "u",
+			status: "pending",
+			catchAllEndpointId: "foreign",
+			canReceiveEmails: null,
+			createdAt: new Date(timestamp.getTime() - 2000),
+			updatedAt: timestamp,
+		},
+		{
+			id: "d4",
+			domain: "four.example",
+			userId: "u",
+			status: "pending",
+			catchAllEndpointId: null,
+			createdAt: new Date(timestamp.getTime() - 3000),
+			updatedAt: timestamp,
+		},
+		{
+			id: "other",
+			domain: "other.example",
+			userId: "other",
+			status: "pending",
+			createdAt: timestamp,
+		},
+	]);
+	await context.insertNullableRows(endpoints, [
+		{
+			id: "e1",
+			name: "Local endpoint",
+			userId: "u",
+			type: "webhook",
+			config: '{"url":"https://example.invalid"}',
+			isActive: null,
+		},
+		{
+			id: "foreign",
+			name: "Foreign endpoint",
+			userId: "other",
+			type: "webhook",
+			config: "invalid",
+			isActive: true,
+		},
+	]);
+	await context.insertNullableRows(webhooks, [
+		{
+			id: "w1",
+			name: "Local webhook",
+			userId: "u",
+			url: "https://example.invalid",
+			isActive: null,
+		},
+		{
+			id: "foreign",
+			name: "Foreign webhook",
+			userId: "other",
+			url: "https://other.invalid",
+			isActive: true,
+		},
+	]);
+	await context.insertNullableRows(
+		emailAddresses,
+		[
+			{
+				id: "a1",
+				domainId: "d1",
+				endpointId: "e1",
+				webhookId: "w1",
+				isActive: true,
+				isReceiptRuleConfigured: true,
+			},
+			{
+				id: "a2",
+				domainId: "d1",
+				endpointId: "missing",
+				webhookId: "w1",
+				isActive: false,
+				isReceiptRuleConfigured: false,
+			},
+			{
+				id: "a3",
+				domainId: "d1",
+				webhookId: "w1",
+				isActive: null,
+				isReceiptRuleConfigured: null,
+			},
+			{
+				id: "a4",
+				domainId: "d2",
+				endpointId: "foreign",
+				webhookId: "w1",
+				isActive: true,
+			},
+			{ id: "a5", domainId: "d2", webhookId: "foreign", isActive: false },
+			{ id: "a6", domainId: "d2", webhookId: "missing", isActive: true },
+			{ id: "a7", domainId: "d2", isActive: false },
+			{ id: "orphan", domainId: "missing", isActive: true },
+		].map((row, index) => ({
+			...row,
+			address: `${row.id}@example.invalid`,
+			userId: "u",
+			createdAt: new Date(timestamp.getTime() - index * 1000),
+			updatedAt: timestamp,
+		})),
+	);
+	await context.insertNullableRows(emailAddresses, [
+		{
+			id: "foreign-address",
+			address: "foreign@other.invalid",
+			domainId: "other",
+			userId: "other",
+			isActive: true,
+		},
+	]);
+}
+
+describe("domain and address list query regressions", () => {
+	test("domains retain stats, nullable defaults, catch-all IDs and tenant isolation in four reads", async () => {
+		using context = setup();
+		await seed(context);
+		const body = await json(await context.request("/domains"));
+		expect(context.queries).toHaveLength(4);
+		expect(body.capabilities).toEqual({ envelopeRecipients: true });
+		expect(body.pagination).toEqual({
+			limit: 50,
+			offset: 0,
+			total: 4,
+			hasMore: false,
+		});
+		expect(body.data.map((row) => row.id)).toEqual(["d1", "d2", "d3", "d4"]);
+		expect(body.data[0]).toMatchObject({
+			stats: {
+				totalEmailAddresses: 3,
+				activeEmailAddresses: 1,
+				hasCatchAll: true,
+			},
+			isCatchAllEnabled: false,
+			hasMxRecords: false,
+			receiveDmarcEmails: false,
+			lastDnsCheck: null,
+			lastSesCheck: null,
+			domainProvider: null,
+			catchAllEndpoint: {
+				id: "e1",
+				name: "Local endpoint",
+				type: "webhook",
+				isActive: false,
+			},
+			createdAt: timestamp.toISOString(),
+			updatedAt: timestamp.toISOString(),
+		});
+		for (const row of body.data.slice(1, 3)) {
+			expect(row).toMatchObject({
+				catchAllEndpoint: null,
+				stats: { hasCatchAll: true },
+			});
+		}
+		expect(body.data[3]).toMatchObject({
+			catchAllEndpoint: null,
+			stats: {
+				totalEmailAddresses: 0,
+				activeEmailAddresses: 0,
+				hasCatchAll: false,
+			},
+		});
+		expect(body.data[0]).not.toHaveProperty("verificationCheck");
+		expect(context.dnsCalls).toHaveLength(0);
+		expect(context.sesCalls).toHaveLength(0);
+	});
+
+	test("domain counts retain domain ownership semantics for mismatched address owners", async () => {
+		using context = setup();
+		await seed(context);
+		await context.insertNullableRows(emailAddresses, [
+			{
+				id: "mismatch",
+				address: "mismatch@example.invalid",
+				domainId: "d1",
+				userId: "other",
+				isActive: null,
+			},
+		]);
+		const body = await json(await context.request("/domains?limit=1"));
+		expect(body.data[0]).toMatchObject({
+			stats: { totalEmailAddresses: 4, activeEmailAddresses: 1 },
+		});
+	});
+
+	test("domain filtering, pagination and empty pages retain counts and ordering", async () => {
+		using context = setup();
+		await seed(context);
+		const page = await json(
+			await context.request("/domains?status=pending&limit=1&offset=1"),
+		);
+		expect(page.data.map((row) => row.id)).toEqual(["d3"]);
+		expect(page.pagination).toEqual({
+			limit: 1,
+			offset: 1,
+			total: 3,
+			hasMore: true,
+		});
+		for (const [value, id] of [
+			["true", "d1"],
+			["false", "d2"],
+		]) {
+			const filtered = await json(
+				await context.request(`/domains?canReceive=${value}`),
+			);
+			expect(filtered.data.map((row) => row.id)).toEqual([id]);
+		}
+		const empty = await json(await context.request("/domains?offset=100"));
+		expect(empty.data).toEqual([]);
+		expect(empty.pagination).toEqual({
+			limit: 50,
+			offset: 100,
+			total: 4,
+			hasMore: false,
+		});
+		expect(context.queries).toHaveLength(2);
+	});
+
+	test("addresses preserve routing precedence, missing/foreign associations and nullable defaults", async () => {
+		using context = setup();
+		await seed(context);
+		const body = await json(await context.request("/email-addresses"));
+		expect(context.queries).toHaveLength(4);
+		expect(body.pagination).toEqual({
+			limit: 50,
+			offset: 0,
+			total: 8,
+			hasMore: true,
+		});
+		expect(body.data.map((row) => row.id)).toEqual([
+			"a1",
+			"a2",
+			"a3",
+			"a4",
+			"a5",
+			"a6",
+			"a7",
+		]);
+		expect(body.data[0]).toMatchObject({
+			domain: { id: "d1", name: "one.example", status: "pending" },
+			routing: {
+				type: "endpoint",
+				id: "e1",
+				name: "Local endpoint",
+				config: { url: "https://example.invalid" },
+				isActive: false,
+			},
+		});
+		expect(body.data[2]).toMatchObject({
+			isActive: false,
+			isReceiptRuleConfigured: false,
+			receiptRuleName: null,
+			routing: {
+				type: "webhook",
+				id: "w1",
+				config: { url: "https://example.invalid" },
+				isActive: false,
+			},
+		});
+		for (const index of [1, 3, 4, 5, 6]) {
+			expect(body.data[index].routing).toEqual({
+				type: "none",
+				id: null,
+				name: null,
+				isActive: false,
+			});
+		}
+	});
+
+	test("address filters, page boundaries and tenant scoping are unchanged", async () => {
+		using context = setup();
+		await seed(context);
+		for (const [query, ids] of [
+			["domainId=d1&isActive=true", ["a1"]],
+			["domainId=d1&isActive=false", ["a2"]],
+			["isReceiptRuleConfigured=true", ["a1"]],
+			["isReceiptRuleConfigured=false", ["a2"]],
+			["domainId=other", []],
+			["limit=2&offset=2", ["a3", "a4"]],
+		] as const) {
+			const body = await json(
+				await context.request(`/email-addresses?${query}`),
+			);
+			expect(body.data.map((row) => row.id)).toEqual([...ids]);
+			expect(context.queries.length).toBeLessThanOrEqual(4);
+		}
+		const empty = await json(
+			await context.request("/email-addresses?offset=100"),
+		);
+		expect(empty.data).toEqual([]);
+		expect(empty.pagination.total).toBe(8);
+		expect(context.queries).toHaveLength(2);
+	});
+
+	test("query counts stay bounded at full page size", async () => {
+		using context = setup();
+		await seed(context);
+		await context.insertNullableRows(
+			emailDomains,
+			Array.from({ length: 60 }, (_, index) => ({
+				id: `extra-${index}`,
+				domain: `extra-${index}.example`,
+				userId: "u",
+				status: "pending",
+				catchAllEndpointId: "e1",
+				createdAt: timestamp,
+			})),
+		);
+		await context.insertNullableRows(
+			emailAddresses,
+			Array.from({ length: 60 }, (_, index) => ({
+				id: `extra-${index}`,
+				address: `extra-${index}@example.invalid`,
+				domainId: "d1",
+				userId: "u",
+				endpointId: index % 2 ? "e1" : null,
+				webhookId: "w1",
+				createdAt: timestamp,
+			})),
+		);
+		for (const path of ["/domains", "/email-addresses"]) {
+			const body = await json(await context.request(`${path}?limit=50`));
+			expect(body.data).toHaveLength(50);
+			expect(body.pagination.hasMore).toBe(true);
+			expect(context.queries).toHaveLength(4);
+		}
+	});
+
+	test("malformed selected endpoint config retains the handler error response", async () => {
+		using context = setup();
+		await seed(context);
+		await context.db
+			.update(endpoints)
+			.set({ config: "invalid" })
+			.where(orm.eq(endpoints.id, "e1"));
+		expect((await context.request("/email-addresses")).status).toBe(500);
+		expect(context.queries).toHaveLength(4);
+	});
+
+	test("authentication failure prevents all list reads", async () => {
+		using context = setup({ authorized: false });
+		for (const path of ["/domains", "/email-addresses"]) {
+			expect((await context.request(path)).status).not.toBe(200);
+			expect(context.queries).toHaveLength(0);
+		}
+		expect(context.authCalls()).toBe(2);
+	});
+
+	for (const sesStatus of ["Success", "Failed"]) {
+		test(`check=true preserves DNS/SES verification and ${sesStatus} status updates`, async () => {
+			using context = setup({ sesStatus });
+			await seed(context);
+			await context.insertNullableRows(domainDnsRecords, [
+				{
+					id: "dns1",
+					domainId: "d1",
+					recordType: "TXT",
+					name: "one.example",
+					value: "synthetic-token",
+				},
+			]);
+			const body = await json(
+				await context.request("/domains?limit=1&check=true"),
+			);
+			expect(body.data[0]).toMatchObject({
+				status: sesStatus === "Success" ? "verified" : "failed",
+				verificationCheck: {
+					dnsRecords: [
+						{
+							type: "TXT",
+							name: "one.example",
+							value: "synthetic-token",
+							isVerified: true,
+						},
+					],
+					sesStatus,
+					isFullyVerified: sesStatus === "Success",
+				},
+			});
+			expect(context.dnsCalls).toEqual([
+				[{ type: "TXT", name: "one.example", value: "synthetic-token" }],
+			]);
+			expect(context.sesCalls).toEqual([{ Identities: ["one.example"] }]);
+			const [record] = await context.db.select().from(domainDnsRecords);
+			expect(record.isVerified).toBe(true);
+			expect(record.lastChecked).toBeInstanceOf(Date);
+			const [domain] = await context.db
+				.select()
+				.from(emailDomains)
+				.where(orm.eq(emailDomains.id, "d1"));
+			expect(domain.status).toBe(
+				sesStatus === "Success" ? "verified" : "failed",
+			);
+			expect(domain.lastSesCheck).toBeInstanceOf(Date);
+		});
+	}
+
+	test("verification without credentials or records remains Unknown and unverified", async () => {
+		using context = setup();
+		await seed(context);
+		const body = await json(
+			await context.request("/domains?limit=1&check=true"),
+		);
+		expect(body.data[0]).toMatchObject({
+			verificationCheck: {
+				dnsRecords: [],
+				sesStatus: "Unknown",
+				isFullyVerified: false,
+			},
+		});
+		expect(context.dnsCalls).toHaveLength(0);
+		expect(context.sesCalls).toHaveLength(0);
+	});
+
+	for (const failure of ["dnsError", "sesError"] as const) {
+		test(`verification ${failure} remains isolated to verificationCheck`, async () => {
+			using context = setup({ [failure]: true });
+			await seed(context);
+			await context.insertNullableRows(domainDnsRecords, [
+				{
+					id: "dns1",
+					domainId: "d1",
+					recordType: "TXT",
+					name: "one.example",
+					value: "synthetic-token",
+				},
+			]);
+			const body = await json(
+				await context.request("/domains?limit=1&check=true"),
+			);
+			expect(body.data[0]).toMatchObject({
+				status: "pending",
+				verificationCheck: { sesStatus: "Error", isFullyVerified: false },
+			});
+		});
+	}
+});

--- a/app/api/e2/domains/list.ts
+++ b/app/api/e2/domains/list.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from "elysia";
-import { validateAndRateLimit } from "../lib/auth";
+import { validateAndRateLimit } from "@/app/api/e2/lib/auth";
 import { db } from "@/lib/db";
 import {
   emailDomains,
@@ -7,7 +7,7 @@ import {
   endpoints,
   domainDnsRecords,
 } from "@/lib/db/schema";
-import { eq, and, desc, count } from "drizzle-orm";
+import { eq, and, desc, count, inArray } from "drizzle-orm";
 import { verifyDnsRecords } from "@/lib/domains-and-dns/dns";
 import {
   SESClient,
@@ -197,39 +197,34 @@ export const listDomains = new Elysia().get(
       "total"
     );
 
-    // Enhance domains with stats, catch-all endpoint info, and verification check
-    const enhancedDomains = await Promise.all(
-      domains.map(async (domain) => {
-        // Get email address count
-        const emailCountResult = await db
-          .select({ count: count() })
-          .from(emailAddresses)
-          .where(eq(emailAddresses.domainId, domain.id));
-
-        const emailCount = emailCountResult[0]?.count || 0;
-
-        // Get active email address count
-        const activeEmailCountResult = await db
-          .select({ count: count() })
-          .from(emailAddresses)
-          .where(
-            and(
-              eq(emailAddresses.domainId, domain.id),
-              eq(emailAddresses.isActive, true)
+    const domainIds = domains.map((domain) => domain.id);
+    const catchAllEndpointIds = [
+      ...new Set(
+        domains.flatMap((domain) =>
+          domain.catchAllEndpointId ? [domain.catchAllEndpointId] : []
+        )
+      ),
+    ];
+    const [emailCounts, catchAllEndpoints] = await Promise.all([
+      domainIds.length > 0
+        ? db
+            .select({
+              domainId: emailAddresses.domainId,
+              isActive: emailAddresses.isActive,
+              count: count(),
+            })
+            .from(emailAddresses)
+            .innerJoin(emailDomains, eq(emailAddresses.domainId, emailDomains.id))
+            .where(
+              and(
+                inArray(emailAddresses.domainId, domainIds),
+                eq(emailDomains.userId, userId)
+              )
             )
-          );
-
-        const activeEmailCount = activeEmailCountResult[0]?.count || 0;
-
-        // Get catch-all endpoint info if configured
-        let catchAllEndpoint: {
-          id: string;
-          name: string;
-          type: string;
-          isActive: boolean;
-        } | null = null;
-        if (domain.catchAllEndpointId) {
-          const endpointResult = await db
+            .groupBy(emailAddresses.domainId, emailAddresses.isActive)
+        : [],
+      catchAllEndpointIds.length > 0
+        ? db
             .select({
               id: endpoints.id,
               name: endpoints.name,
@@ -237,20 +232,42 @@ export const listDomains = new Elysia().get(
               isActive: endpoints.isActive,
             })
             .from(endpoints)
-            .where(eq(endpoints.id, domain.catchAllEndpointId))
-            .limit(1);
+            .where(
+              and(
+                inArray(endpoints.id, catchAllEndpointIds),
+                eq(endpoints.userId, userId)
+              )
+            )
+        : [],
+    ]);
+    const countsByDomainId = new Map<string, { total: number; active: number }>();
+    for (const emailCount of emailCounts) {
+      const stats = countsByDomainId.get(emailCount.domainId) || {
+        total: 0,
+        active: 0,
+      };
+      stats.total += emailCount.count;
+      if (emailCount.isActive === true) {
+        stats.active += emailCount.count;
+      }
+      countsByDomainId.set(emailCount.domainId, stats);
+    }
+    const endpointsById = new Map(
+      catchAllEndpoints.map((endpoint) => [endpoint.id, endpoint])
+    );
 
-          catchAllEndpoint = endpointResult[0]
-            ? {
-                id: endpointResult[0].id,
-                name: endpointResult[0].name,
-                type: endpointResult[0].type,
-                isActive: endpointResult[0].isActive || false,
-              }
-            : null;
-        }
+    // Enhance domains with stats, catch-all endpoint info, and verification check
+    const enhancedDomains = await Promise.all(
+      domains.map(async (domain) => {
+        const stats = countsByDomainId.get(domain.id);
+        const endpoint = domain.catchAllEndpointId
+          ? endpointsById.get(domain.catchAllEndpointId)
+          : undefined;
+        const catchAllEndpoint = endpoint
+          ? { ...endpoint, isActive: endpoint.isActive || false }
+          : null;
 
-        const enhancedDomain: any = {
+        const enhancedDomain: typeof DomainSchema.static = {
           ...domain,
           canReceiveEmails: domain.canReceiveEmails || false,
           hasMxRecords: domain.hasMxRecords || false,
@@ -263,8 +280,8 @@ export const listDomains = new Elysia().get(
           createdAt: (domain.createdAt || new Date()).toISOString(),
           updatedAt: (domain.updatedAt || new Date()).toISOString(),
           stats: {
-            totalEmailAddresses: emailCount,
-            activeEmailAddresses: activeEmailCount,
+            totalEmailAddresses: stats?.total || 0,
+            activeEmailAddresses: stats?.active || 0,
             hasCatchAll: !!domain.catchAllEndpointId,
           },
           catchAllEndpoint,

--- a/app/api/e2/email-addresses/list.ts
+++ b/app/api/e2/email-addresses/list.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from "elysia";
-import { validateAndRateLimit } from "../lib/auth";
+import { validateAndRateLimit } from "@/app/api/e2/lib/auth";
 import { db } from "@/lib/db";
 import {
   emailAddresses,
@@ -7,7 +7,7 @@ import {
   endpoints,
   webhooks,
 } from "@/lib/db/schema";
-import { eq, and, desc, count } from "drizzle-orm";
+import { eq, and, desc, count, inArray } from "drizzle-orm";
 
 // Request/Response Types (OpenAPI-compatible)
 const ListEmailAddressesQuery = t.Object({
@@ -157,6 +157,58 @@ export const listEmailAddresses = new Elysia().get(
     const totalCount = totalCountResult[0]?.count || 0;
     console.log("📊 Total email addresses count:", totalCount);
 
+    const endpointIds = [
+      ...new Set(
+        userEmailAddresses.flatMap((emailAddress) =>
+          emailAddress.endpointId ? [emailAddress.endpointId] : []
+        )
+      ),
+    ];
+    const webhookIds = [
+      ...new Set(
+        userEmailAddresses.flatMap((emailAddress) =>
+          !emailAddress.endpointId && emailAddress.webhookId
+            ? [emailAddress.webhookId]
+            : []
+        )
+      ),
+    ];
+    const [addressEndpoints, addressWebhooks] = await Promise.all([
+      endpointIds.length > 0
+        ? db
+            .select({
+              id: endpoints.id,
+              name: endpoints.name,
+              type: endpoints.type,
+              config: endpoints.config,
+              isActive: endpoints.isActive,
+            })
+            .from(endpoints)
+            .where(
+              and(inArray(endpoints.id, endpointIds), eq(endpoints.userId, userId))
+            )
+        : [],
+      webhookIds.length > 0
+        ? db
+            .select({
+              id: webhooks.id,
+              name: webhooks.name,
+              url: webhooks.url,
+              isActive: webhooks.isActive,
+            })
+            .from(webhooks)
+            .where(
+              and(inArray(webhooks.id, webhookIds), eq(webhooks.userId, userId))
+            )
+        : [],
+    ]);
+    const endpointsById = new Map(
+      addressEndpoints.map((endpoint) => [endpoint.id, endpoint])
+    );
+    const webhooksById = new Map(
+      addressWebhooks.map((webhook) => [webhook.id, webhook])
+    );
+
     // Enhance email addresses with routing information
     console.log("🔧 Enhancing email addresses with routing information");
     const enhancedEmailAddresses = await Promise.all(
@@ -165,7 +217,7 @@ export const listEmailAddresses = new Elysia().get(
           type: "webhook" | "endpoint" | "none";
           id: string | null;
           name: string | null;
-          config?: any;
+          config?: unknown;
           isActive: boolean;
         } = {
           type: "none",
@@ -176,46 +228,27 @@ export const listEmailAddresses = new Elysia().get(
 
         // Get endpoint or webhook routing info
         if (emailAddress.endpointId) {
-          const endpoint = await db
-            .select({
-              id: endpoints.id,
-              name: endpoints.name,
-              type: endpoints.type,
-              config: endpoints.config,
-              isActive: endpoints.isActive,
-            })
-            .from(endpoints)
-            .where(eq(endpoints.id, emailAddress.endpointId))
-            .limit(1);
+          const endpoint = endpointsById.get(emailAddress.endpointId);
 
-          if (endpoint[0]) {
+          if (endpoint) {
             routing = {
               type: "endpoint",
-              id: endpoint[0].id,
-              name: endpoint[0].name,
-              config: JSON.parse(endpoint[0].config),
-              isActive: endpoint[0].isActive || false,
+              id: endpoint.id,
+              name: endpoint.name,
+              config: JSON.parse(endpoint.config),
+              isActive: endpoint.isActive || false,
             };
           }
         } else if (emailAddress.webhookId) {
-          const webhook = await db
-            .select({
-              id: webhooks.id,
-              name: webhooks.name,
-              url: webhooks.url,
-              isActive: webhooks.isActive,
-            })
-            .from(webhooks)
-            .where(eq(webhooks.id, emailAddress.webhookId))
-            .limit(1);
+          const webhook = webhooksById.get(emailAddress.webhookId);
 
-          if (webhook[0]) {
+          if (webhook) {
             routing = {
               type: "webhook",
-              id: webhook[0].id,
-              name: webhook[0].name,
-              config: { url: webhook[0].url },
-              isActive: webhook[0].isActive || false,
+              id: webhook.id,
+              name: webhook.name,
+              config: { url: webhook.url },
+              isActive: webhook.isActive || false,
             };
           }
         }

--- a/app/api/e2/emails/list.test.ts
+++ b/app/api/e2/emails/list.test.ts
@@ -1,0 +1,285 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import * as orm from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pg-proxy";
+import { Elysia, t } from "elysia";
+import * as schema from "@/lib/db/schema";
+
+if (process.env.EMAIL_LIST_TEST_WORKER !== "1") {
+  test("public email list regressions in an isolated runtime", async () => {
+    const child = Bun.spawn([process.execPath, "--no-env-file", "test", import.meta.path], {
+      env: { ...process.env, EMAIL_LIST_TEST_WORKER: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+    expect(exitCode, `${stdout}\n${stderr}`).toBe(0);
+  }, 30_000);
+} else {
+  type Value = string | number | boolean | null;
+  type Email = {
+    id: string;
+    type: string;
+    created_at: string;
+    status: string;
+    preview: string | null;
+    subject: string;
+    from: string;
+    from_name?: string | null;
+    to: string[];
+    cc: string[];
+    has_attachments: boolean;
+    attachment_count: number;
+  };
+  type Result = {
+    data: Email[];
+    pagination: { limit: number; offset: number; total: number; has_more: boolean };
+    filters: Record<string, string | undefined>;
+    error?: string;
+  };
+  type Handler = (context: {
+    request: Request;
+    query: Record<string, string>;
+    set: { status?: number };
+  }) => Promise<Result>;
+  const now = "2026-09-05T12:00:00.000Z";
+  const timestamp = "2026-09-04 12:00:00.123456";
+  class FixedDate extends Date {
+    constructor(value?: string | number) {
+      super(value ?? now);
+    }
+  }
+  const source = await Bun.file(new URL("./list.ts", import.meta.url)).text();
+  const code = new Bun.Transpiler({ loader: "ts" }).transformSync(
+    source.replace(/^import[\s\S]*?;\n/gm, "").replace("export const listEmails", "const listEmails"),
+  );
+  const createHandler = new Function(
+    "Elysia", "t", "db", "schema", "orm", "validateAndRateLimit", "Date", "console",
+    `const {sentEmails, structuredEmails, scheduledEmails, emailDomains, emailAddresses} = schema;
+     const {eq, and, desc, sql, or, like, gte, inArray} = orm;
+     ${code}
+     return listEmails.routes[0].handler;`,
+  ) as (...dependencies: unknown[]) => Handler;
+  let handler: Handler;
+  let authFailure: Error | undefined;
+  let databaseFailure: Error | undefined;
+  let authCalls: number;
+  let results: Value[][][];
+  let queries: { params: unknown[]; rows: number }[];
+
+  function received(id: string, createdAt: string | null = timestamp): Value[] {
+    return [id, "in@example.com", "message", '{"addresses":[{"address":"from@example.com","name":"Sender"}]}', '{"addresses":[{"address":"in@example.com"}]}', "broken", "", `${"x".repeat(199)}\ny`, "broken", true, createdAt, null, null, null, "thread"];
+  }
+
+  function sent(id: string, createdAt: string | null = timestamp): Value[] {
+    return [id, "message", "Sender <from@example.com>", '["in@example.com"]', '["cc@example.com"]', "Sent", " hi\nthere ", '[{"filename":"file"}]', "sent", createdAt, null, "sent-thread"];
+  }
+
+  function scheduled(id: string, createdAt: string | null = timestamp): Value[] {
+    return [id, "from@example.com", '["in@example.com"]', "Scheduled", "scheduled", createdAt, null, "2026-09-06 12:00:00.000000", "broken"];
+  }
+
+  function domainRow(id: string, domain: string): Value[] {
+    return Object.keys(orm.getTableColumns(schema.emailDomains)).map((key) =>
+      ({ id, domain, userId: "tenant" })[key as "id" | "domain" | "userId"] ?? null,
+    );
+  }
+
+  function addressRow(id: string, address: string): Value[] {
+    return Object.keys(orm.getTableColumns(schema.emailAddresses)).map((key) =>
+      ({ id, address, userId: "tenant" })[key as "id" | "address" | "userId"] ?? null,
+    );
+  }
+
+  async function invoke(query: Record<string, string> = {}, set: { status?: number } = {}) {
+    return handler({ request: new Request("http://localhost/emails"), query: { time_range: "all", ...query }, set });
+  }
+
+  beforeEach(() => {
+    authFailure = undefined;
+    databaseFailure = undefined;
+    authCalls = 0;
+    results = [];
+    queries = [];
+    const db = drizzle(async (_sql, params) => {
+      if (databaseFailure) throw databaseFailure;
+      const rows = results.shift();
+      if (!rows) throw new Error("Unexpected database read");
+      queries.push({ params, rows: rows.length });
+      return { rows };
+    });
+    handler = createHandler(Elysia, t, db, schema, orm, async () => {
+      authCalls++;
+      if (authFailure) throw authFailure;
+      return "tenant";
+    }, FixedDate, { log: () => {} });
+  });
+
+  describe("public email list handler contract with stubbed database results", () => {
+    test("passes deep offsets to the database and hydrates only returned page IDs", async () => {
+      results = [[[20003]], [["second", 0, timestamp], ["first", 0, timestamp]], [received("first"), received("second")]];
+      const result = await invoke({ offset: "10001", limit: "2" });
+      expect(result.data.map((email) => email.id)).toEqual(["second", "first"]);
+      expect(result.pagination).toEqual({ limit: 2, offset: 10001, total: 20003, has_more: true });
+      expect(queries).toHaveLength(3);
+      expect(queries[1].params.slice(-2)).toEqual([2, 10001]);
+      expect(queries[2].params).toEqual(["tenant", "second", "first", 2]);
+      expect(queries[2].rows).toBe(2);
+      expect(results).toEqual([]);
+    });
+
+    test("retains exact counts and has_more for last and beyond-total pages", async () => {
+      results = [[[20003]], [["last", 2, timestamp]], [scheduled("last")]];
+      const last = await invoke({ offset: "20002", limit: "50" });
+      expect(last.data.map((email) => email.id)).toEqual(["last"]);
+      expect(last.pagination).toEqual({ limit: 50, offset: 20002, total: 20003, has_more: false });
+      queries = [];
+      results = [[[20003]]];
+      const empty = await invoke({ offset: "30000" });
+      expect(empty.data).toEqual([]);
+      expect(empty.pagination.total).toBe(20003);
+      expect(empty.pagination.has_more).toBe(false);
+      expect(queries).toHaveLength(1);
+    });
+
+    test("preserves database page order with source-colliding IDs and millisecond output", async () => {
+      results = [[[4]], [["later", 0, "2026-09-04 12:00:00.123002"], ["shared", 0, "2026-09-04 12:00:00.123001"], ["shared", 1, "2026-09-04 12:00:00.123999"], ["shared", 2, "2026-09-04 12:00:00.123999"]], [received("shared"), received("later")], [sent("shared")], [scheduled("shared")]];
+      const result = await invoke();
+      expect(result.data.map((email) => `${email.type}:${email.id}`)).toEqual([
+        "received:later", "received:shared", "sent:shared", "scheduled:shared",
+      ]);
+      expect(new Set(result.data.map((email) => email.created_at))).toEqual(new Set(["2026-09-04T12:00:00.123Z"]));
+      expect(queries).toHaveLength(5);
+      for (const query of queries.slice(2)) expect(query.params[0]).toBe("tenant");
+    });
+
+    test("forwards one request timestamp and normalizes null output", async () => {
+      results = [[[3]], [["null", 0, null], ["null", 1, null], ["null", 2, null]], [received("null", null)], [sent("null", null)], [scheduled("null", null)]];
+      const result = await invoke();
+      expect(result.data.map((email) => [email.type, email.created_at])).toEqual([
+        ["received", now], ["sent", now], ["scheduled", now],
+      ]);
+      expect(queries[1].params).toContain(now);
+    });
+
+    test("passes status parameters and skips database reads for unsupported single-source statuses", async () => {
+      const cases = [
+        { status: "unread", values: [false, false] },
+        { status: "read", values: [true] },
+        { status: "archived", values: [true] },
+        { status: "delivered", values: [true, "sent"] },
+        { status: "pending", values: ["pending", "processing"] },
+        { status: "failed", values: [false, "failed", "failed"] },
+        { status: "bounced", values: ["bounced"] },
+        { status: "scheduled", values: ["scheduled"] },
+        { status: "cancelled", values: ["cancelled"] },
+        { status: "paused", values: ["paused"] },
+      ];
+      for (const { status, values } of cases) {
+        queries = [];
+        results = [[[0]]];
+        const result = await invoke({ status });
+        expect(result.data, status).toEqual([]);
+        expect(result.pagination.total, status).toBe(0);
+        expect(result.pagination.has_more, status).toBe(false);
+        expect(queries, status).toHaveLength(1);
+        expect(queries[0].params.filter((value) => value !== "tenant"), status).toEqual(values);
+      }
+      queries = [];
+      for (const [type, statuses] of [
+        ["sent", ["unread", "read", "archived", "scheduled", "cancelled", "paused"]],
+        ["scheduled", ["unread", "read", "archived", "delivered", "bounced"]],
+      ] as const) {
+        for (const status of statuses) {
+          const result = await invoke({ type, status });
+          expect(result.data).toEqual([]);
+          expect(result.pagination.total).toBe(0);
+          expect(result.pagination.has_more).toBe(false);
+        }
+      }
+      expect(queries).toEqual([]);
+    });
+
+    test("shares resolved domain, address, time and search parameters across count and page", async () => {
+      results = [[domainRow("domain", "example.com")], [addressRow("address", "in@example.com")], [[1]], [["match", 0, timestamp]], [received("match")]];
+      const result = await invoke({ domain: "domain", address: "address", time_range: "7d", search: " nEeDlE " });
+      expect(result.filters).toMatchObject({ domain: "example.com", address: "in@example.com", search: "nEeDlE", time_range: "7d" });
+      expect(result.pagination.total).toBe(1);
+      expect(queries[0].params).toEqual(["tenant", "domain", "domain", 1]);
+      expect(queries[1].params).toEqual(["tenant", "address", "address", 1]);
+      const filters = queries[2].params;
+      expect(queries[3].params.slice(0, filters.length)).toEqual(filters);
+      expect(filters.filter((value) => value === "tenant")).toHaveLength(3);
+      expect(filters.filter((value) => value === "%nEeDlE%")).toHaveLength(9);
+      expect(filters).toContain("%@example.com");
+      expect(filters).toContain("%in@example.com%");
+      expect(filters.filter((value) => value === "2026-08-29T12:00:00.000Z")).toHaveLength(3);
+    });
+
+    test("falls back to raw filters when tenant-parameterized lookups return no records", async () => {
+      results = [[], [], [[0]]];
+      const result = await invoke({ domain: "foreign-domain", address: "foreign-address" });
+      expect(result.data).toEqual([]);
+      expect(result.filters).toMatchObject({ domain: "foreign-domain", address: "foreign-address" });
+      expect(queries[0].params[0]).toBe("tenant");
+      expect(queries[1].params[0]).toBe("tenant");
+      expect(queries[2].params).toContain("%@foreign-domain");
+      expect(queries[2].params).toContain("%foreign-address%");
+    });
+
+    test("formats all three sources and hydrates only the supplied page", async () => {
+      results = [[[3]], [["r", 0, timestamp], ["s", 1, timestamp], ["q", 2, timestamp]], [received("r")], [sent("s")], [scheduled("q")]];
+      const result = await invoke();
+      expect(result.data[0]).toMatchObject({ subject: "No Subject", preview: `${"x".repeat(199)}...`, from: "from@example.com", from_name: "Sender", to: ["in@example.com"], cc: [], has_attachments: false, attachment_count: 0, envelope_recipient: "in@example.com", is_read: false, is_archived: false, thread_id: "thread", status: "delivered" });
+      expect(result.data[1]).toMatchObject({ preview: "hi there", cc: ["cc@example.com"], has_attachments: true, attachment_count: 1, status: "delivered", thread_id: "sent-thread" });
+      expect(result.data[2]).toMatchObject({ preview: null, cc: [], has_attachments: false, status: "scheduled" });
+      expect(result.data).toHaveLength(3);
+      expect(result.pagination.total).toBe(3);
+      expect(queries).toHaveLength(5);
+      expect(queries.slice(2).reduce((total, query) => total + query.rows, 0)).toBe(3);
+      expect(results).toEqual([]);
+    });
+
+    test("retains single-source pagination and passes tenant parameters to data and count reads", async () => {
+      for (const [type, row] of [["received", received("r")], ["sent", sent("s")], ["scheduled", scheduled("q")]] as const) {
+        queries = [];
+        results = [[row], [[3]]];
+        const result = await invoke({ type, limit: "1", offset: "1" });
+        expect(result.data[0].type).toBe(type);
+        expect(result.pagination).toEqual({ limit: 1, offset: 1, total: 3, has_more: true });
+        expect(queries).toHaveLength(2);
+        expect(queries[0].params).toEqual(["tenant", 1, 1]);
+        expect(queries[1].params).toEqual(["tenant"]);
+      }
+    });
+
+    test("caps limits and preserves empty/invalid pagination behavior", async () => {
+      results = [[[0]]];
+      expect((await invoke({ limit: "999" })).pagination.limit).toBe(100);
+      results = [[[3]]];
+      const invalid = await invoke({ limit: "invalid", offset: "NaN" });
+      expect(invalid.data).toEqual([]);
+      expect(invalid.pagination.has_more).toBe(false);
+      const invalidQueries: Record<string, string>[] = [{ limit: "0" }, { offset: "-1" }];
+      for (const query of invalidQueries) {
+        const set: { status?: number } = {};
+        expect((await invoke(query, set)).error).toBeString();
+        expect(set.status).toBe(400);
+      }
+    });
+
+    test("propagates auth/database errors without returning partial success", async () => {
+      authFailure = new Error("unauthorized");
+      await expect(invoke()).rejects.toThrow("unauthorized");
+      expect(authCalls).toBe(1);
+      expect(queries).toEqual([]);
+      authFailure = undefined;
+      databaseFailure = new Error("database unavailable");
+      await expect(invoke()).rejects.toThrow("database unavailable");
+      expect(authCalls).toBe(2);
+    });
+  });
+}

--- a/app/api/e2/emails/list.ts
+++ b/app/api/e2/emails/list.ts
@@ -1,5 +1,6 @@
 import { Elysia, t } from "elysia";
-import { validateAndRateLimit } from "../lib/auth";
+import { eq, and, desc, sql, or, like, gte, inArray, type SQL } from "drizzle-orm";
+import { validateAndRateLimit } from "@/app/api/e2/lib/auth";
 import { db } from "@/lib/db";
 import {
   sentEmails,
@@ -8,7 +9,6 @@ import {
   emailDomains,
   emailAddresses,
 } from "@/lib/db/schema";
-import { eq, and, desc, sql, or, like, gte } from "drizzle-orm";
 
 // Query parameters schema with full OpenAPI descriptions
 const ListEmailsQuerySchema = t.Object({
@@ -249,7 +249,7 @@ function parseAddressesFromData(field: string | null): string[] {
   if (!field) return [];
   try {
     const parsed = JSON.parse(field);
-    return parsed?.addresses?.map((a: any) => a.address).filter(Boolean) || [];
+    return parsed?.addresses?.map((a: { address?: string }) => a.address).filter(Boolean) || [];
   } catch {
     return [];
   }
@@ -317,16 +317,10 @@ export const listEmails = new Elysia().get(
       return { error: "Offset must be non-negative" };
     }
 
-    const emails: any[] = [];
+    let emails: (typeof EmailItemSchema.static)[] = [];
     let total = 0;
-    let receivedTotal = 0;
-    let sentTotal = 0;
-    let scheduledTotal = 0;
     const timeThreshold = getTimeThreshold(timeRange);
-
-    // For "all" type queries, we need to fetch enough records from each table
-    // to properly paginate after combining and sorting. Cap at 10000 to prevent memory issues.
-    const allTypeFetchLimit = Math.min(offset + limit, 10000);
+    const fallbackCreatedAt = new Date().toISOString();
 
     // Resolve domain filter - supports ID, registered domain, or raw domain name
     let resolvedDomain: string | null = null;
@@ -370,12 +364,16 @@ export const listEmails = new Elysia().get(
       resolvedAddress = address.length > 0 ? address[0].address : addressFilter;
     }
 
-    // Fetch received emails (if type is 'all' or 'received')
-    if (type === "all" || type === "received") {
-      console.log("🔍 Fetching received emails...");
+    const receivedConditions: (SQL | undefined)[] = [eq(structuredEmails.userId, userId)];
+    const sentConditions: (SQL | undefined)[] = [eq(sentEmails.userId, userId)];
+    const scheduledConditions: (SQL | undefined)[] = [eq(scheduledEmails.userId, userId)];
+    const includeReceived = type === "all" || type === "received";
+    const includeSent = (type === "all" || type === "sent") &&
+      !["unread", "read", "archived", "scheduled", "cancelled", "paused"].includes(status);
+    const includeScheduled = (type === "all" || type === "scheduled") &&
+      !["unread", "read", "archived", "delivered", "bounced"].includes(status);
 
-      const receivedConditions: any[] = [eq(structuredEmails.userId, userId)];
-
+    if (includeReceived) {
       // Time range filter
       if (timeThreshold) {
         receivedConditions.push(gte(structuredEmails.createdAt, timeThreshold));
@@ -419,7 +417,144 @@ export const listEmails = new Elysia().get(
           sql`(${structuredEmails.subject} ILIKE ${searchPattern} OR ${structuredEmails.fromData}::text ILIKE ${searchPattern} OR ${structuredEmails.toData}::text ILIKE ${searchPattern})`
         );
       }
+    }
 
+    if (includeSent) {
+      // Time range filter
+      if (timeThreshold) {
+        sentConditions.push(gte(sentEmails.createdAt, timeThreshold));
+      }
+
+      // Status filters for sent emails
+      if (status === "delivered") {
+        sentConditions.push(eq(sentEmails.status, "sent"));
+      } else if (status === "pending") {
+        sentConditions.push(eq(sentEmails.status, "pending"));
+      } else if (status === "failed") {
+        sentConditions.push(eq(sentEmails.status, "failed"));
+      } else if (status === "bounced") {
+        sentConditions.push(eq(sentEmails.status, "bounced"));
+      }
+
+      // Domain filter
+      if (resolvedDomain) {
+        sentConditions.push(eq(sentEmails.fromDomain, resolvedDomain));
+      }
+
+      // Address filter - match from address or in to addresses
+      if (resolvedAddress) {
+        sentConditions.push(
+          or(
+            eq(sentEmails.fromAddress, resolvedAddress),
+            like(sentEmails.to, `%${resolvedAddress}%`)
+          )
+        );
+      }
+
+      // Search filter
+      if (searchQuery) {
+        const searchPattern = `%${searchQuery}%`;
+        sentConditions.push(
+          sql`(${sentEmails.subject} ILIKE ${searchPattern} OR ${sentEmails.from} ILIKE ${searchPattern} OR ${sentEmails.to}::text ILIKE ${searchPattern})`
+        );
+      }
+    }
+
+    if (includeScheduled) {
+      if (timeThreshold) {
+        scheduledConditions.push(gte(scheduledEmails.createdAt, timeThreshold));
+      }
+
+      // Status filters for scheduled emails
+      if (status === "scheduled") {
+        scheduledConditions.push(eq(scheduledEmails.status, "scheduled"));
+      } else if (status === "cancelled") {
+        scheduledConditions.push(eq(scheduledEmails.status, "cancelled"));
+      } else if (status === "paused") {
+        scheduledConditions.push(eq(scheduledEmails.status, "paused"));
+      } else if (status === "pending") {
+        scheduledConditions.push(eq(scheduledEmails.status, "processing"));
+      } else if (status === "failed") {
+        scheduledConditions.push(eq(scheduledEmails.status, "failed"));
+      }
+
+      // Domain filter
+      if (resolvedDomain) {
+        scheduledConditions.push(eq(scheduledEmails.fromDomain, resolvedDomain));
+      }
+
+      // Address filter
+      if (resolvedAddress) {
+        scheduledConditions.push(
+          or(
+            eq(scheduledEmails.fromAddress, resolvedAddress),
+            like(scheduledEmails.toAddresses, `%${resolvedAddress}%`)
+          )
+        );
+      }
+
+      // Search filter
+      if (searchQuery) {
+        const searchPattern = `%${searchQuery}%`;
+        scheduledConditions.push(
+          sql`(${scheduledEmails.subject} ILIKE ${searchPattern} OR ${scheduledEmails.fromAddress} ILIKE ${searchPattern} OR ${scheduledEmails.toAddresses}::text ILIKE ${searchPattern})`
+        );
+      }
+    }
+
+    let page: { id: string; typeOrder: number }[] = [];
+    if (type === "all") {
+      const matchingEmails = db
+        .select({
+          id: structuredEmails.id,
+          typeOrder: sql<number>`0`.as("type_order"),
+          createdAt: structuredEmails.createdAt,
+        })
+        .from(structuredEmails)
+        .where(and(...receivedConditions))
+        .unionAll(
+          db.select({
+            id: sentEmails.id,
+            typeOrder: sql<number>`1`.as("type_order"),
+            createdAt: sentEmails.createdAt,
+          })
+            .from(sentEmails)
+            .where(and(...sentConditions, includeSent ? undefined : sql`false`))
+        )
+        .unionAll(
+          db.select({
+            id: scheduledEmails.id,
+            typeOrder: sql<number>`2`.as("type_order"),
+            createdAt: scheduledEmails.createdAt,
+          })
+            .from(scheduledEmails)
+            .where(and(...scheduledConditions, includeScheduled ? undefined : sql`false`))
+        )
+        .as("matching_emails");
+
+      const [{ count }] = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(matchingEmails);
+      total = Number(count);
+      if (Number.isFinite(limit) && Number.isFinite(offset) && offset < total) {
+        page = await db
+          .select()
+          .from(matchingEmails)
+          .orderBy(
+            desc(sql`date_trunc('milliseconds', coalesce(${matchingEmails.createdAt}, ${fallbackCreatedAt}::timestamp))`),
+            matchingEmails.typeOrder,
+            desc(matchingEmails.createdAt)
+          )
+          .limit(limit)
+          .offset(offset);
+      }
+    }
+
+    const receivedIds = page.filter((email) => email.typeOrder === 0).map((email) => email.id);
+    const sentIds = page.filter((email) => email.typeOrder === 1).map((email) => email.id);
+    const scheduledIds = page.filter((email) => email.typeOrder === 2).map((email) => email.id);
+
+    if (includeReceived && (type !== "all" || receivedIds.length > 0)) {
       const receivedEmails = await db
         .select({
           id: structuredEmails.id,
@@ -439,16 +574,17 @@ export const listEmails = new Elysia().get(
           threadId: structuredEmails.threadId,
         })
         .from(structuredEmails)
-        .where(and(...receivedConditions))
+        .where(type === "all"
+          ? and(eq(structuredEmails.userId, userId), inArray(structuredEmails.id, receivedIds))
+          : and(...receivedConditions))
         .orderBy(desc(structuredEmails.createdAt))
-        .limit(type === "received" ? limit : allTypeFetchLimit)
-        .offset(type === "received" ? offset : 0);
+        .limit(limit)
+        .offset(type === "all" ? 0 : offset);
 
       for (const email of receivedEmails) {
         const attachments = parseJsonField(email.attachments, []);
         const fromParsed = parseFromData(email.fromData);
 
-        // Create preview from text body
         let preview: string | null = null;
         if (email.textBody) {
           preview = email.textBody.substring(0, 200).replace(/\n/g, " ").trim();
@@ -459,7 +595,7 @@ export const listEmails = new Elysia().get(
 
         emails.push({
           id: email.id,
-          type: "received" as const,
+          type: "received",
           envelope_recipient: email.recipient,
           message_id: email.messageId,
           from: fromParsed.address,
@@ -469,8 +605,7 @@ export const listEmails = new Elysia().get(
           subject: email.subject || "No Subject",
           preview,
           status: email.parseSuccess ? "delivered" : "failed",
-          created_at:
-            email.createdAt?.toISOString() || new Date().toISOString(),
+          created_at: email.createdAt?.toISOString() || (type === "all" ? fallbackCreatedAt : new Date().toISOString()),
           sent_at: null,
           scheduled_at: null,
           has_attachments: attachments.length > 0,
@@ -482,259 +617,143 @@ export const listEmails = new Elysia().get(
         });
       }
 
-      // Get count for pagination
-      const [{ count }] = await db
-        .select({ count: sql<number>`count(*)` })
-        .from(structuredEmails)
-        .where(and(...receivedConditions));
-
-      receivedTotal = Number(count);
       if (type === "received") {
-        total = receivedTotal;
+        const [{ count }] = await db
+          .select({ count: sql<number>`count(*)` })
+          .from(structuredEmails)
+          .where(and(...receivedConditions));
+        total = Number(count);
       }
     }
 
-    // Fetch sent emails (if type is 'all' or 'sent')
-    if (type === "all" || type === "sent") {
-      // Skip if status filter only applies to received or scheduled emails
-      if (
-        !["unread", "read", "archived", "scheduled", "cancelled", "paused"].includes(
-          status
-        )
-      ) {
-        console.log("🔍 Fetching sent emails...");
+    if (includeSent && (type !== "all" || sentIds.length > 0)) {
+      const sentEmailsList = await db
+        .select({
+          id: sentEmails.id,
+          messageId: sentEmails.messageId,
+          from: sentEmails.from,
+          to: sentEmails.to,
+          cc: sentEmails.cc,
+          subject: sentEmails.subject,
+          textBody: sentEmails.textBody,
+          attachments: sentEmails.attachments,
+          status: sentEmails.status,
+          createdAt: sentEmails.createdAt,
+          sentAt: sentEmails.sentAt,
+          threadId: sentEmails.threadId,
+        })
+        .from(sentEmails)
+        .where(type === "all"
+          ? and(eq(sentEmails.userId, userId), inArray(sentEmails.id, sentIds))
+          : and(...sentConditions))
+        .orderBy(desc(sentEmails.createdAt))
+        .limit(limit)
+        .offset(type === "all" ? 0 : offset);
 
-        const sentConditions: any[] = [eq(sentEmails.userId, userId)];
+      for (const email of sentEmailsList) {
+        const attachments = parseJsonField(email.attachments, []);
+        const toAddresses = parseJsonField(email.to, []);
+        const ccAddresses = parseJsonField(email.cc, []);
 
-        // Time range filter
-        if (timeThreshold) {
-          sentConditions.push(gte(sentEmails.createdAt, timeThreshold));
-        }
-
-        // Status filters for sent emails
-        if (status === "delivered") {
-          sentConditions.push(eq(sentEmails.status, "sent"));
-        } else if (status === "pending") {
-          sentConditions.push(eq(sentEmails.status, "pending"));
-        } else if (status === "failed") {
-          sentConditions.push(eq(sentEmails.status, "failed"));
-        } else if (status === "bounced") {
-          sentConditions.push(eq(sentEmails.status, "bounced"));
-        }
-
-        // Domain filter
-        if (resolvedDomain) {
-          sentConditions.push(eq(sentEmails.fromDomain, resolvedDomain));
-        }
-
-        // Address filter - match from address or in to addresses
-        if (resolvedAddress) {
-          sentConditions.push(
-            or(
-              eq(sentEmails.fromAddress, resolvedAddress),
-              like(sentEmails.to, `%${resolvedAddress}%`)
-            )
-          );
-        }
-
-        // Search filter
-        if (searchQuery) {
-          const searchPattern = `%${searchQuery}%`;
-          sentConditions.push(
-            sql`(${sentEmails.subject} ILIKE ${searchPattern} OR ${sentEmails.from} ILIKE ${searchPattern} OR ${sentEmails.to}::text ILIKE ${searchPattern})`
-          );
-        }
-
-        const sentEmailsList = await db
-          .select()
-          .from(sentEmails)
-          .where(and(...sentConditions))
-          .orderBy(desc(sentEmails.createdAt))
-          .limit(type === "sent" ? limit : allTypeFetchLimit)
-          .offset(type === "sent" ? offset : 0);
-
-        for (const email of sentEmailsList) {
-          const attachments = parseJsonField(email.attachments, []);
-          const toAddresses = parseJsonField(email.to, []);
-          const ccAddresses = parseJsonField(email.cc, []);
-
-          // Create preview from text body
-          let preview: string | null = null;
-          if (email.textBody) {
-            preview = email.textBody
-              .substring(0, 200)
-              .replace(/\n/g, " ")
-              .trim();
-            if (email.textBody.length > 200) {
-              preview += "...";
-            }
+        let preview: string | null = null;
+        if (email.textBody) {
+          preview = email.textBody.substring(0, 200).replace(/\n/g, " ").trim();
+          if (email.textBody.length > 200) {
+            preview += "...";
           }
-
-          emails.push({
-            id: email.id,
-            type: "sent" as const,
-            message_id: email.messageId,
-            from: email.from,
-            from_name: null,
-            to: toAddresses,
-            cc: ccAddresses,
-            subject: email.subject || "No Subject",
-            preview,
-            status: email.status === "sent" ? "delivered" : email.status,
-            created_at:
-              email.createdAt?.toISOString() || new Date().toISOString(),
-            sent_at: email.sentAt?.toISOString() || null,
-            scheduled_at: null,
-            has_attachments: attachments.length > 0,
-            attachment_count: attachments.length,
-            thread_id: email.threadId,
-          });
         }
 
-        // Get count for pagination
+        emails.push({
+          id: email.id,
+          type: "sent",
+          message_id: email.messageId,
+          from: email.from,
+          from_name: null,
+          to: toAddresses,
+          cc: ccAddresses,
+          subject: email.subject || "No Subject",
+          preview,
+          status: email.status === "sent" ? "delivered" : email.status,
+          created_at: email.createdAt?.toISOString() || (type === "all" ? fallbackCreatedAt : new Date().toISOString()),
+          sent_at: email.sentAt?.toISOString() || null,
+          scheduled_at: null,
+          has_attachments: attachments.length > 0,
+          attachment_count: attachments.length,
+          thread_id: email.threadId,
+        });
+      }
+
+      if (type === "sent") {
         const [{ count }] = await db
           .select({ count: sql<number>`count(*)` })
           .from(sentEmails)
           .where(and(...sentConditions));
-
-        sentTotal = Number(count);
-        if (type === "sent") {
-          total = sentTotal;
-        }
+        total = Number(count);
       }
     }
 
-    // Fetch scheduled emails (if type is 'all' or 'scheduled')
-    if (type === "all" || type === "scheduled") {
-      // Skip if status filter only applies to received emails
-      if (
-        !["unread", "read", "archived", "delivered", "bounced"].includes(status)
-      ) {
-        console.log("🔍 Fetching scheduled emails...");
+    if (includeScheduled && (type !== "all" || scheduledIds.length > 0)) {
+      const scheduledEmailsList = await db
+        .select({
+          id: scheduledEmails.id,
+          fromAddress: scheduledEmails.fromAddress,
+          toAddresses: scheduledEmails.toAddresses,
+          subject: scheduledEmails.subject,
+          status: scheduledEmails.status,
+          createdAt: scheduledEmails.createdAt,
+          sentAt: scheduledEmails.sentAt,
+          scheduledAt: scheduledEmails.scheduledAt,
+          attachments: scheduledEmails.attachments,
+        })
+        .from(scheduledEmails)
+        .where(type === "all"
+          ? and(eq(scheduledEmails.userId, userId), inArray(scheduledEmails.id, scheduledIds))
+          : and(...scheduledConditions))
+        .orderBy(desc(scheduledEmails.createdAt))
+        .limit(limit)
+        .offset(type === "all" ? 0 : offset);
 
-        const scheduledConditions: any[] = [eq(scheduledEmails.userId, userId)];
+      for (const email of scheduledEmailsList) {
+        const attachments = parseJsonField(email.attachments, []);
+        const toAddresses = parseJsonField(email.toAddresses, []);
 
-        // Time range filter (for scheduled, check scheduledAt)
-        if (timeThreshold) {
-          scheduledConditions.push(
-            gte(scheduledEmails.createdAt, timeThreshold)
-          );
-        }
+        emails.push({
+          id: email.id,
+          type: "scheduled",
+          message_id: null,
+          from: email.fromAddress,
+          from_name: null,
+          to: toAddresses,
+          cc: [],
+          subject: email.subject || "No Subject",
+          preview: null,
+          status: email.status,
+          created_at: email.createdAt?.toISOString() || (type === "all" ? fallbackCreatedAt : new Date().toISOString()),
+          sent_at: email.sentAt?.toISOString() || null,
+          scheduled_at: email.scheduledAt?.toISOString() || null,
+          has_attachments: attachments.length > 0,
+          attachment_count: attachments.length,
+        });
+      }
 
-        // Status filters for scheduled emails
-        if (status === "scheduled") {
-          scheduledConditions.push(eq(scheduledEmails.status, "scheduled"));
-        } else if (status === "cancelled") {
-          scheduledConditions.push(eq(scheduledEmails.status, "cancelled"));
-        } else if (status === "paused") {
-          scheduledConditions.push(eq(scheduledEmails.status, "paused"));
-        } else if (status === "pending") {
-          scheduledConditions.push(eq(scheduledEmails.status, "processing"));
-        } else if (status === "failed") {
-          scheduledConditions.push(eq(scheduledEmails.status, "failed"));
-        }
-
-        // Domain filter
-        if (resolvedDomain) {
-          scheduledConditions.push(
-            eq(scheduledEmails.fromDomain, resolvedDomain)
-          );
-        }
-
-        // Address filter
-        if (resolvedAddress) {
-          scheduledConditions.push(
-            or(
-              eq(scheduledEmails.fromAddress, resolvedAddress),
-              like(scheduledEmails.toAddresses, `%${resolvedAddress}%`)
-            )
-          );
-        }
-
-        // Search filter
-        if (searchQuery) {
-          const searchPattern = `%${searchQuery}%`;
-          scheduledConditions.push(
-            sql`(${scheduledEmails.subject} ILIKE ${searchPattern} OR ${scheduledEmails.fromAddress} ILIKE ${searchPattern} OR ${scheduledEmails.toAddresses}::text ILIKE ${searchPattern})`
-          );
-        }
-
-        const scheduledEmailsList = await db
-          .select()
-          .from(scheduledEmails)
-          .where(and(...scheduledConditions))
-          .orderBy(desc(scheduledEmails.createdAt))
-          .limit(type === "scheduled" ? limit : allTypeFetchLimit)
-          .offset(type === "scheduled" ? offset : 0);
-
-        for (const email of scheduledEmailsList) {
-          const attachments = parseJsonField(email.attachments, []);
-          const toAddresses = parseJsonField(email.toAddresses, []);
-
-          emails.push({
-            id: email.id,
-            type: "scheduled" as const,
-            message_id: null,
-            from: email.fromAddress,
-            from_name: null,
-            to: toAddresses,
-            cc: [],
-            subject: email.subject || "No Subject",
-            preview: null,
-            status: email.status,
-            created_at:
-              email.createdAt?.toISOString() || new Date().toISOString(),
-            sent_at: email.sentAt?.toISOString() || null,
-            scheduled_at: email.scheduledAt?.toISOString() || null,
-            has_attachments: attachments.length > 0,
-            attachment_count: attachments.length,
-          });
-        }
-
-        // Get count for pagination
+      if (type === "scheduled") {
         const [{ count }] = await db
           .select({ count: sql<number>`count(*)` })
           .from(scheduledEmails)
           .where(and(...scheduledConditions));
-
-        scheduledTotal = Number(count);
-        if (type === "scheduled") {
-          total = scheduledTotal;
-        }
+        total = Number(count);
       }
     }
 
-    // If type is 'all', sort combined results and apply pagination
     if (type === "all") {
-      emails.sort(
-        (a, b) =>
-          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-      );
-      // Calculate true total from individual counts
-      total = receivedTotal + sentTotal + scheduledTotal;
-      const paginatedEmails = emails.slice(offset, offset + limit);
-
-      console.log(
-        `✅ Successfully retrieved ${paginatedEmails.length} emails (total: ${total})`
-      );
-
-      return {
-        data: paginatedEmails,
-        pagination: {
-          limit,
-          offset,
-          total,
-          has_more: offset + paginatedEmails.length < total,
-        },
-        filters: {
-          type,
-          status: status !== "all" ? status : undefined,
-          time_range: timeRange,
-          search: searchQuery || undefined,
-          domain: resolvedDomain || undefined,
-          address: resolvedAddress || undefined,
-        },
-      };
+      const typeNames = ["received", "sent", "scheduled"];
+      const emailsById = new Map(emails.map((email) => [
+        `${email.type}:${email.id}`, email,
+      ]));
+      emails = page.flatMap(({ id, typeOrder }) => {
+        const email = emailsById.get(`${typeNames[typeOrder]}:${id}`);
+        return email ? [email] : [];
+      });
     }
 
     console.log(

--- a/app/api/e2/lib/participants.test.ts
+++ b/app/api/e2/lib/participants.test.ts
@@ -1,0 +1,571 @@
+import { describe, expect, test } from "bun:test";
+
+type Row = Record<string, unknown>;
+type Table = Record<string, string>;
+type Predicate = (row: Row) => boolean;
+type Fields = Record<string, string | symbol>;
+type Ordering = string | { column: string; descending: true };
+type ParticipantModule = typeof import("@/app/api/e2/lib/participants");
+type ThreadResponse = {
+	threads: { id: string; participant_names: string[]; has_unread: boolean }[];
+	pagination: { limit: number; has_more: boolean; next_cursor: string | null };
+};
+type Handler = (context: {
+	request: Request;
+	query: Record<string, string>;
+	set: { status?: number };
+}) => Promise<ThreadResponse>;
+
+const transpiler = new Bun.Transpiler({ loader: "ts" });
+const compile = async (url: URL) =>
+	transpiler.transformSync(
+		(await Bun.file(url).text())
+			.replace(/^import[\s\S]*?from "[^"]+";?\r?\n/gm, "")
+			.replace(/export /g, ""),
+	);
+const participantSource = await compile(
+	new URL("participants.ts", import.meta.url),
+);
+const threadSource = await compile(
+	new URL("../mail/threads-list.ts", import.meta.url),
+);
+const addresses = (...values: unknown[]) =>
+	JSON.stringify({ addresses: values });
+const address = (email: string, name: string | null = null) => ({
+	address: email,
+	name,
+});
+
+function createHarness() {
+	const makeTable = (): Table =>
+		new Proxy({}, { get: (_target, key) => String(key) });
+	const structuredEmails = makeTable();
+	const sentEmails = makeTable();
+	const emailThreads = makeTable();
+	const rows = new Map<Table, Row[]>();
+	const calls: { table: Table; fields: Fields; rows: Row[] }[] = [];
+	const aggregate = Symbol("count");
+	const select = (fields: Fields, distinct: string[] = []) => {
+		let table: Table;
+		let predicate: Predicate = () => true;
+		let ordering: Ordering[] = [];
+		let grouping: string | undefined;
+		let limit = Number.POSITIVE_INFINITY;
+		const run = () => {
+			let result = (rows.get(table) ?? []).filter(predicate);
+			result.sort((left, right) => {
+				for (const order of ordering) {
+					const column = typeof order === "string" ? order : order.column;
+					const a = left[column];
+					const b = right[column];
+					const comparison =
+						typeof a === "string" && typeof b === "string"
+							? a.localeCompare(b)
+							: Number(a) - Number(b);
+					if (comparison)
+						return typeof order === "string" ? comparison : -comparison;
+				}
+				return 0;
+			});
+			if (distinct.length) {
+				const seen = new Set<string>();
+				result = result.filter((row) => {
+					const key = JSON.stringify(distinct.map((column) => row[column]));
+					if (seen.has(key)) return false;
+					seen.add(key);
+					return true;
+				});
+			}
+			calls.push({ table, fields, rows: result });
+			if (grouping) {
+				const counts = new Map<unknown, number>();
+				for (const row of result)
+					counts.set(row[grouping], (counts.get(row[grouping]) ?? 0) + 1);
+				return Array.from(counts, ([threadId, count]) => ({ threadId, count }));
+			}
+			return result
+				.slice(0, limit)
+				.map((row) =>
+					Object.fromEntries(
+						Object.entries(fields).map(([alias, column]) => [
+							alias,
+							typeof column === "string" ? row[column] : 0,
+						]),
+					),
+				);
+		};
+		const query = {
+			from(value: Table) {
+				table = value;
+				return query;
+			},
+			where(value: Predicate) {
+				predicate = value;
+				return query;
+			},
+			orderBy(...value: Ordering[]) {
+				ordering = value;
+				return query;
+			},
+			groupBy(value: string) {
+				grouping = value;
+				return query;
+			},
+			limit(value: number) {
+				limit = value;
+				return query;
+			},
+			then(
+				resolve: (value: Row[]) => unknown,
+				reject: (error: unknown) => unknown,
+			) {
+				return Promise.resolve().then(run).then(resolve, reject);
+			},
+		};
+		return query;
+	};
+	const bindings = {
+		db: {
+			select,
+			selectDistinctOn: (distinct: string[], fields: Fields) =>
+				select(fields, distinct),
+		},
+		structuredEmails,
+		sentEmails,
+		emailThreads,
+		emailDomains: makeTable(),
+		emailAddresses: makeTable(),
+		eq:
+			(column: string, value: unknown): Predicate =>
+			(row) =>
+				row[column] === value,
+		inArray:
+			(column: string, values: unknown[]): Predicate =>
+			(row) =>
+				values.includes(row[column]),
+		and:
+			(...predicates: Predicate[]): Predicate =>
+			(row) =>
+				predicates.every((predicate) => predicate(row)),
+		or:
+			(...predicates: Predicate[]): Predicate =>
+			(row) =>
+				predicates.some((predicate) => predicate(row)),
+		like:
+			(column: string, value: string): Predicate =>
+			(row) =>
+				String(row[column]).includes(value.replaceAll("%", "")),
+		desc: (column: string): Ordering => ({ column, descending: true }),
+		count: () => aggregate,
+		sql:
+			(_parts: TemplateStringsArray, column: string, value: Date): Predicate =>
+			(row) =>
+				Number(row[column]) < value.getTime(),
+	};
+	const participants = Function(
+		...Object.keys(bindings),
+		`${participantSource}; return { getThreadParticipantNames, getThreadParticipantNamesBatch };`,
+	)(...Object.values(bindings)) as Pick<
+		ParticipantModule,
+		"getThreadParticipantNames" | "getThreadParticipantNamesBatch"
+	>;
+	const routeBindings = {
+		...bindings,
+		...participants,
+		Elysia: class {
+			get(_path: string, handler: Handler) {
+				return handler;
+			}
+		},
+		t: new Proxy({}, { get: () => () => ({}) }),
+		validateAndRateLimit: async () => "user",
+		console: { log() {}, error() {} },
+	};
+	const handler = Function(
+		...Object.keys(routeBindings),
+		`${threadSource}; return listThreads;`,
+	)(...Object.values(routeBindings)) as Handler;
+	return {
+		...participants,
+		rows,
+		calls,
+		structuredEmails,
+		sentEmails,
+		emailThreads,
+		request: (query: Record<string, string> = {}) =>
+			handler({
+				request: new Request("http://localhost/mail/threads"),
+				query,
+				set: {},
+			}),
+		participantCalls: () =>
+			calls.filter(
+				(call) =>
+					"ccData" in call.fields ||
+					("from" in call.fields && "to" in call.fields),
+			),
+	};
+}
+
+function inbound(threadId: string, fields: Row = {}): Row {
+	return {
+		id: `in-${threadId}`,
+		threadId,
+		userId: "user",
+		fromData: null,
+		toData: null,
+		ccData: null,
+		isRead: false,
+		threadPosition: 1,
+		date: new Date(1700000000000),
+		...fields,
+	};
+}
+
+function outbound(threadId: string, fields: Row = {}): Row {
+	return { threadId, userId: "user", from: "", to: null, ...fields };
+}
+
+function thread(index: number, fields: Row = {}): Row {
+	return {
+		id: `thread-${index}`,
+		userId: "user",
+		rootMessageId: `root-${index}`,
+		normalizedSubject: "Subject",
+		participantEmails: "[]",
+		messageCount: 1,
+		lastMessageAt: new Date(1700000000000 - index * 1000),
+		createdAt: new Date(1600000000000),
+		...fields,
+	};
+}
+
+describe("batched thread participants", () => {
+	test("preserves inbound precedence, case deduplication, CC, and insertion order", async () => {
+		const h = createHarness();
+		h.rows.set(h.structuredEmails, [
+			inbound("one", {
+				fromData: addresses(address("A@EXAMPLE.COM")),
+				toData: addresses(address("b@example.com", "Bee")),
+				ccData: addresses(
+					address("a@example.com", "First"),
+					address("cc@example.com", "CC"),
+				),
+			}),
+			inbound("two", {
+				fromData: addresses(address("other@example.com", "Other")),
+			}),
+			inbound("one", {
+				fromData: addresses(address("a@example.com", "Second")),
+				toData: addresses(address("b@example.com", "Later Bee")),
+			}),
+		]);
+		h.rows.set(h.sentEmails, [
+			outbound("one", {
+				from: "A@example.com",
+				to: JSON.stringify([
+					"b@example.com",
+					"ONLYSENT@example.com",
+					{ address: "onlysent@example.com" },
+				]),
+			}),
+		]);
+		const result = await h.getThreadParticipantNamesBatch(
+			["one", "two"],
+			"user",
+		);
+		expect(result.get("one")).toEqual([
+			"First <a@example.com>",
+			"Bee <b@example.com>",
+			"CC <cc@example.com>",
+			"ONLYSENT@example.com",
+		]);
+		expect(result.get("two")).toEqual(["Other <other@example.com>"]);
+		expect(h.calls).toHaveLength(2);
+		expect(await h.getThreadParticipantNames("one", "user")).toEqual(
+			result.get("one") ?? [],
+		);
+		expect(h.calls).toHaveLength(4);
+	});
+
+	test("keeps first-name winners dependent on supplied row order, not an invented SQL order", async () => {
+		const h = createHarness();
+		const first = inbound("one", {
+			fromData: addresses(address("a@example.com", "First")),
+		});
+		const second = inbound("one", {
+			fromData: addresses(address("A@example.com", "Second")),
+		});
+		h.rows.set(h.structuredEmails, [first, second]);
+		expect(
+			(await h.getThreadParticipantNamesBatch(["one"], "user")).get("one"),
+		).toEqual(["First <a@example.com>"]);
+		h.rows.set(h.structuredEmails, [second, first]);
+		expect(
+			(await h.getThreadParticipantNamesBatch(["one"], "user")).get("one"),
+		).toEqual(["Second <A@example.com>"]);
+	});
+
+	test("retains partial progress and field-local aborts for malformed JSON and address values", async () => {
+		const h = createHarness();
+		h.rows.set(h.structuredEmails, [
+			inbound("one", {
+				fromData: "{",
+				toData: "null",
+				ccData: addresses(address("cc@example.com", "CC")),
+			}),
+			inbound("one", {
+				fromData: addresses(
+					address("before@example.com"),
+					null,
+					address("ignored@example.com"),
+				),
+				toData: addresses(address("to@example.com", "To")),
+				ccData: addresses(
+					{ address: "bad@example.com", name: 7 },
+					address("also-ignored@example.com"),
+				),
+			}),
+			inbound("one", {
+				fromData: addresses(address("BEFORE@example.com", " ")),
+				toData: addresses(address("before@example.com", "Named")),
+				ccData: "[]",
+			}),
+		]);
+		h.rows.set(h.sentEmails, [
+			outbound("one", { from: "FROM@example.com", to: "{" }),
+			outbound("one", {
+				to: JSON.stringify([
+					"prefix@example.com",
+					null,
+					"ignored-outbound@example.com",
+				]),
+			}),
+			outbound("one", {
+				to: JSON.stringify([
+					{ address: "object@example.com", name: "Ignored Name" },
+					{},
+					"ignored-object@example.com",
+				]),
+			}),
+			outbound("one", { to: "null" }),
+		]);
+		expect(
+			(await h.getThreadParticipantNamesBatch(["one"], "user")).get("one"),
+		).toEqual([
+			"CC <cc@example.com>",
+			"Named <before@example.com>",
+			"To <to@example.com>",
+			"FROM@example.com",
+			"prefix@example.com",
+			"object@example.com",
+		]);
+	});
+
+	test("scopes both queries to requested IDs and tenant", async () => {
+		const h = createHarness();
+		h.rows.set(h.structuredEmails, [
+			inbound("one", { fromData: addresses(address("own@example.com")) }),
+			inbound("one", {
+				userId: "other",
+				fromData: addresses(address("foreign@example.com")),
+			}),
+			inbound("excluded", {
+				fromData: addresses(address("excluded@example.com")),
+			}),
+		]);
+		h.rows.set(h.sentEmails, [
+			outbound("one", { from: "sent@example.com" }),
+			outbound("one", { userId: "other", from: "foreign-sent@example.com" }),
+			outbound("excluded", { from: "excluded-sent@example.com" }),
+		]);
+		expect(
+			(await h.getThreadParticipantNamesBatch(["one"], "user")).get("one"),
+		).toEqual(["own@example.com", "sent@example.com"]);
+		expect(h.calls).toHaveLength(2);
+		for (const call of h.calls)
+			expect(call.rows.map((row) => [row.threadId, row.userId])).toEqual([
+				["one", "user"],
+			]);
+	});
+
+	test("issues no queries for empty IDs and two queries for requested threads without messages", async () => {
+		const h = createHarness();
+		expect(await h.getThreadParticipantNamesBatch([], "user")).toEqual(
+			new Map(),
+		);
+		expect(h.calls).toHaveLength(0);
+		expect(
+			await h.getThreadParticipantNamesBatch(["empty", "also-empty"], "user"),
+		).toEqual(
+			new Map([
+				["empty", []],
+				["also-empty", []],
+			]),
+		);
+		expect(h.calls).toHaveLength(2);
+	});
+});
+
+describe("thread-list participant batching", () => {
+	test("loads names for returned page IDs only, excluding sentinel and other tenants", async () => {
+		const h = createHarness();
+		h.rows.set(h.emailThreads, [
+			thread(-1, { userId: "other" }),
+			thread(0),
+			thread(1),
+			thread(2),
+		]);
+		h.rows.set(h.structuredEmails, [
+			inbound("thread-0", {
+				fromData: addresses(address("zero@example.com", "Zero")),
+			}),
+			inbound("thread-1", {
+				fromData: addresses(address("one@example.com", "One")),
+			}),
+			Object.defineProperty(
+				inbound("thread-2", {
+					fromData: addresses(address("sentinel@example.com")),
+				}),
+				"ccData",
+				{
+					get() {
+						throw new Error("Nonreturned participant data must not be loaded");
+					},
+				},
+			),
+			inbound("thread-0", {
+				userId: "other",
+				fromData: addresses(address("foreign@example.com")),
+			}),
+		]);
+		const result = await h.request({ limit: "2" });
+		expect(
+			result.threads.map((item) => [item.id, item.participant_names]),
+		).toEqual([
+			["thread-0", ["Zero <zero@example.com>"]],
+			["thread-1", ["One <one@example.com>"]],
+		]);
+		expect(result.pagination).toEqual({
+			limit: 2,
+			has_more: true,
+			next_cursor: "thread-1",
+		});
+		expect(h.calls).toHaveLength(6);
+		expect(h.participantCalls()).toHaveLength(2);
+		expect(h.participantCalls()[0].rows.map((row) => row.threadId)).toEqual([
+			"thread-0",
+			"thread-1",
+		]);
+	});
+
+	test("applies unread filtering before participant reads without changing existing partial-batch pagination", async () => {
+		const h = createHarness();
+		h.rows.set(h.emailThreads, [thread(0), thread(1), thread(2), thread(3)]);
+		h.rows.set(h.structuredEmails, [
+			inbound("thread-0", { isRead: true }),
+			inbound("thread-1", {
+				ccData: addresses(address("cc@example.com", "CC")),
+			}),
+			inbound("thread-2"),
+			inbound("thread-3"),
+		]);
+		const result = await h.request({ limit: "2", unread: "true" });
+		expect(
+			result.threads.map((item) => [
+				item.id,
+				item.has_unread,
+				item.participant_names,
+			]),
+		).toEqual([
+			["thread-1", true, ["CC <cc@example.com>"]],
+			["thread-2", true, []],
+		]);
+		expect(result.pagination).toEqual({
+			limit: 2,
+			has_more: false,
+			next_cursor: null,
+		});
+		expect(h.participantCalls()).toHaveLength(2);
+		expect(h.participantCalls()[0].rows.map((row) => row.threadId)).toEqual([
+			"thread-1",
+			"thread-2",
+		]);
+	});
+
+	test("skips participant queries for noncontributing unread batches and continues with the existing cursor", async () => {
+		const h = createHarness();
+		h.rows.set(
+			h.emailThreads,
+			Array.from({ length: 52 }, (_, index) => thread(index)),
+		);
+		h.rows.set(
+			h.structuredEmails,
+			Array.from({ length: 52 }, (_, index) =>
+				inbound(`thread-${index}`, { isRead: index < 50 }),
+			),
+		);
+		const result = await h.request({ limit: "2", unread: "true" });
+		expect(result.threads.map((item) => item.id)).toEqual([
+			"thread-50",
+			"thread-51",
+		]);
+		expect(result.pagination).toEqual({
+			limit: 2,
+			has_more: false,
+			next_cursor: null,
+		});
+		expect(h.calls).toHaveLength(11);
+		expect(h.participantCalls()).toHaveLength(2);
+		expect(h.participantCalls()[0].rows.map((row) => row.threadId)).toEqual([
+			"thread-50",
+			"thread-51",
+		]);
+	});
+
+	test("uses two participant queries per contributing batch, not per returned thread", async () => {
+		const h = createHarness();
+		h.rows.set(
+			h.emailThreads,
+			Array.from({ length: 53 }, (_, index) => thread(index)),
+		);
+		h.rows.set(
+			h.structuredEmails,
+			Array.from({ length: 53 }, (_, index) =>
+				inbound(`thread-${index}`, { isRead: index > 0 && index < 50 }),
+			),
+		);
+		const result = await h.request({ limit: "3", unread: "true" });
+		expect(result.threads.map((item) => item.id)).toEqual([
+			"thread-0",
+			"thread-50",
+			"thread-51",
+		]);
+		expect(h.calls).toHaveLength(13);
+		expect(h.participantCalls()).toHaveLength(4);
+		expect(
+			h
+				.participantCalls()
+				.flatMap((call) => call.rows.map((row) => row.threadId)),
+		).toEqual(["thread-0", "thread-50", "thread-51"]);
+	});
+
+	test("returns an empty page without participant queries when no threads or no unread threads exist", async () => {
+		for (const populated of [false, true]) {
+			const h = createHarness();
+			if (populated) {
+				h.rows.set(h.emailThreads, [thread(0)]);
+				h.rows.set(h.structuredEmails, [inbound("thread-0", { isRead: true })]);
+			}
+			const result = await h.request({ unread: "true" });
+			expect(result.threads).toEqual([]);
+			expect(result.pagination).toEqual({
+				limit: 25,
+				has_more: false,
+				next_cursor: null,
+			});
+			expect(h.participantCalls()).toHaveLength(0);
+			expect(h.calls).toHaveLength(populated ? 4 : 1);
+		}
+	});
+});

--- a/app/api/e2/lib/participants.ts
+++ b/app/api/e2/lib/participants.ts
@@ -1,6 +1,6 @@
 import { db } from "@/lib/db"
 import { structuredEmails, sentEmails } from "@/lib/db/schema"
-import { eq, and } from "drizzle-orm"
+import { eq, and, inArray } from "drizzle-orm"
 
 /**
  * Format a participant as "Name <email>" or just "email" if no name is available
@@ -46,6 +46,76 @@ export async function getThreadParticipantNames(
       and(eq(sentEmails.threadId, threadId), eq(sentEmails.userId, userId))
     )
 
+  return getParticipantNames(emails, sentEmailsList)
+}
+
+export async function getThreadParticipantNamesBatch(
+  threadIds: string[],
+  userId: string
+): Promise<Map<string, string[]>> {
+  if (threadIds.length === 0) return new Map()
+
+  const [emails, sentEmailsList] = await Promise.all([
+    db
+      .select({
+        threadId: structuredEmails.threadId,
+        fromData: structuredEmails.fromData,
+        toData: structuredEmails.toData,
+        ccData: structuredEmails.ccData,
+      })
+      .from(structuredEmails)
+      .where(
+        and(
+          inArray(structuredEmails.threadId, threadIds),
+          eq(structuredEmails.userId, userId)
+        )
+      ),
+    db
+      .select({
+        threadId: sentEmails.threadId,
+        from: sentEmails.from,
+        to: sentEmails.to,
+      })
+      .from(sentEmails)
+      .where(
+        and(inArray(sentEmails.threadId, threadIds), eq(sentEmails.userId, userId))
+      ),
+  ])
+
+  const inboundByThread = new Map<string, typeof emails>()
+  for (const email of emails) {
+    if (email.threadId === null) continue
+    const threadEmails = inboundByThread.get(email.threadId) ?? []
+    threadEmails.push(email)
+    inboundByThread.set(email.threadId, threadEmails)
+  }
+
+  const outboundByThread = new Map<string, typeof sentEmailsList>()
+  for (const email of sentEmailsList) {
+    if (email.threadId === null) continue
+    const threadEmails = outboundByThread.get(email.threadId) ?? []
+    threadEmails.push(email)
+    outboundByThread.set(email.threadId, threadEmails)
+  }
+
+  return new Map(
+    threadIds.map((threadId) => [
+      threadId,
+      getParticipantNames(
+        inboundByThread.get(threadId) ?? [],
+        outboundByThread.get(threadId) ?? []
+      ),
+    ])
+  )
+}
+
+function getParticipantNames(
+  emails: Pick<
+    typeof structuredEmails.$inferSelect,
+    "fromData" | "toData" | "ccData"
+  >[],
+  sentEmailsList: Pick<typeof sentEmails.$inferSelect, "from" | "to">[]
+): string[] {
   // Map of email -> formatted name (to deduplicate and keep best name)
   const participantMap = new Map<string, string>()
 

--- a/app/api/e2/mail/threads-list.ts
+++ b/app/api/e2/mail/threads-list.ts
@@ -1,6 +1,6 @@
 import { Elysia, t } from "elysia";
 import { validateAndRateLimit } from "@/app/api/e2/lib/auth";
-import { getThreadParticipantNames } from "@/app/api/e2/lib/participants";
+import { getThreadParticipantNamesBatch } from "@/app/api/e2/lib/participants";
 import { db } from "@/lib/db";
 import {
   emailThreads,
@@ -495,6 +495,15 @@ export const listThreads = new Elysia().get(
         getThreadUnreadCounts(threadIds, userId),
       ]);
 
+      const participantThreadIds = threads
+        .filter((thread) => !unreadOnly || (unreadCounts.get(thread.id) ?? 0) > 0)
+        .slice(0, limit - threadItems.length)
+        .map((thread) => thread.id);
+      const participantNamesByThread = await getThreadParticipantNamesBatch(
+        participantThreadIds,
+        userId
+      );
+
       // Process threads
       for (const thread of threads) {
         if (threadItems.length >= limit) {
@@ -522,10 +531,7 @@ export const listThreads = new Elysia().get(
         }
 
         // Get formatted participant names (e.g., "First Last <email@domain.com>")
-        const participantNames = await getThreadParticipantNames(
-          thread.id,
-          userId
-        );
+        const participantNames = participantNamesByThread.get(thread.id) ?? [];
 
         threadItems.push({
           id: thread.id,

--- a/lib/email-management/email-blocking.ts
+++ b/lib/email-management/email-blocking.ts
@@ -1,6 +1,6 @@
 import { db } from '@/lib/db'
 import { blockedEmails, emailDomains, emailAddresses } from '@/lib/db/schema'
-import { eq, and } from 'drizzle-orm'
+import { eq, and, inArray, sql } from 'drizzle-orm'
 import { nanoid } from 'nanoid'
 
 /**
@@ -50,10 +50,10 @@ export async function checkRecipientsAgainstBlocklist(
       return extracted.toLowerCase().trim()
     })
 
-    // Query all blocked addresses at once
     const blockedResults = await db
       .select({ emailAddress: blockedEmails.emailAddress })
       .from(blockedEmails)
+      .where(inArray(sql`lower(${blockedEmails.emailAddress})`, normalizedRecipients))
 
     // Create a set of blocked addresses for efficient lookup
     const blockedSet = new Set(blockedResults.map(r => r.emailAddress.toLowerCase()))

--- a/lib/email-management/sending-spike-detector.test.ts
+++ b/lib/email-management/sending-spike-detector.test.ts
@@ -1,0 +1,295 @@
+import { Database, type SQLQueryBindings } from "bun:sqlite";
+import { afterEach, describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import * as orm from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pg-proxy";
+import { ModuleKind, transpileModule } from "typescript";
+import * as authSchema from "@/lib/db/auth-schema";
+import * as schema from "@/lib/db/schema";
+
+const NOW = Date.parse("2026-09-05T12:00:00.000Z");
+const MINUTE = 60 * 1000;
+const DAY = 24 * 60 * MINUTE;
+const databases: Database[] = [];
+const sources = Object.fromEntries(
+	["email-blocking", "sending-spike-detector"].map((name) => [
+		name,
+		transpileModule(
+			readFileSync(
+				Bun.resolveSync(`@/lib/email-management/${name}.ts`, import.meta.dir),
+				"utf8",
+			),
+			{ compilerOptions: { module: ModuleKind.CommonJS } },
+		).outputText,
+	]),
+);
+
+class FixedDate extends Date {
+	constructor(value: string | number | Date = NOW) {
+		super(value);
+	}
+
+	static now() {
+		return NOW;
+	}
+}
+
+function setup() {
+	const sqlite = new Database(":memory:");
+	databases.push(sqlite);
+	sqlite.exec(`
+		CREATE TABLE blocked_emails (email_address TEXT, domain_id TEXT);
+		CREATE TABLE sent_emails (user_id TEXT, status TEXT, sent_at TEXT, created_at TEXT);
+		CREATE TABLE user (id TEXT, email TEXT, name TEXT, created_at TEXT);
+	`);
+	const state = {
+		queries: 0,
+		returnedRows: 0,
+		failDatabase: false,
+		cooldown: false,
+		failRedis: false,
+		externalCalls: 0,
+	};
+	const db = drizzle(async (query, params: SQLQueryBindings[]) => {
+		state.queries++;
+		if (state.failDatabase) throw new Error("database unavailable");
+		const rows = sqlite.query(query).values(...params);
+		state.returnedRows += rows.length;
+		return { rows };
+	});
+	const unexpectedCall = () => {
+		state.externalCalls++;
+		throw new Error("external calls forbidden");
+	};
+	const dependencies: Record<string, unknown> = {
+		"drizzle-orm": orm,
+		"@/lib/db": { db },
+		"@/lib/db/schema": schema,
+		"@/lib/db/auth-schema": authSchema,
+		nanoid: { nanoid: unexpectedCall },
+		"@/lib/aws-ses/aws-stats-core": { getAwsSesStats: unexpectedCall },
+		"@/lib/notifications/hark": {
+			quarterHourBucket: unexpectedCall,
+			sendHarkNotification: unexpectedCall,
+		},
+		"@/lib/redis": {
+			redis: {
+				get: async () => {
+					if (state.failRedis) throw new Error("redis unavailable");
+					return state.cooldown ? NOW : null;
+				},
+				set: unexpectedCall,
+			},
+		},
+	};
+	function load<T>(name: string): T {
+		const module = { exports: {} };
+		new Function(
+			"require",
+			"module",
+			"exports",
+			"Date",
+			"console",
+			"process",
+			"fetch",
+			sources[name],
+		)(
+			(path: string) => {
+				if (!(path in dependencies)) throw new Error(`Unexpected import: ${path}`);
+				return dependencies[path];
+			},
+			module,
+			module.exports,
+			FixedDate,
+			{ log() {}, warn() {}, error() {} },
+			{ env: {} },
+			unexpectedCall,
+		);
+		return module.exports as T;
+	}
+	const blocking = load<typeof import("@/lib/email-management/email-blocking")>(
+		"email-blocking",
+	);
+	const spike = load<typeof import("@/lib/email-management/sending-spike-detector")>(
+		"sending-spike-detector",
+	);
+	function addSent(
+		sentAt: number | null,
+		createdAt: number | null = NOW,
+		status = "sent",
+		userId = "target-user",
+	) {
+		sqlite
+			.query("INSERT INTO sent_emails VALUES (?, ?, ?, ?)")
+			.run(
+				userId,
+				status,
+				sentAt === null ? null : new Date(sentAt).toISOString(),
+				createdAt === null ? null : new Date(createdAt).toISOString(),
+			);
+	}
+	return { sqlite, state, addSent, ...blocking, ...spike };
+}
+
+afterEach(() => {
+	for (const database of databases.splice(0)) database.close();
+});
+
+describe("recipient blocklist query", () => {
+	it("matches global mixed-case rows while preserving normalized duplicates and order", async () => {
+		const test = setup();
+		const insert = test.sqlite.query("INSERT INTO blocked_emails VALUES (?, ?)");
+		insert.run("BLOCKED@Example.com", "another-users-domain");
+		insert.run("Second@Example.com", "different-domain");
+		insert.run("irrelevant@example.com", "another-users-domain");
+		insert.run(" padded@example.com ", "different-domain");
+
+		expect(
+			await test.checkRecipientsAgainstBlocklist([
+				"Display Name <Second@Example.com>",
+				" BLOCKED@example.com ",
+				"not-blocked@example.com",
+				"Another Name <blocked@EXAMPLE.com>",
+				"padded@example.com",
+			]),
+		).toEqual({
+			hasBlockedRecipients: true,
+			blockedAddresses: [
+				"second@example.com",
+				"blocked@example.com",
+				"blocked@example.com",
+			],
+		});
+		expect(test.state.queries).toBe(1);
+		expect(test.state.returnedRows).toBe(2);
+	});
+
+	it("skips the database for empty recipients", async () => {
+		const test = setup();
+		expect(await test.checkRecipientsAgainstBlocklist([])).toEqual({
+			hasBlockedRecipients: false,
+			blockedAddresses: [],
+		});
+		expect(test.state.queries).toBe(0);
+	});
+
+	it("returns no blocked recipients for nonmatches and database errors", async () => {
+		const test = setup();
+		const expected = { hasBlockedRecipients: false, blockedAddresses: [] };
+		expect(await test.checkRecipientsAgainstBlocklist(["none@example.com"])).toEqual(expected);
+		test.state.failDatabase = true;
+		expect(await test.checkRecipientsAgainstBlocklist(["none@example.com"])).toEqual(expected);
+	});
+});
+
+describe("sending spike aggregate query", () => {
+	const boundaries = [
+		{ age: -MINUTE, current15m: 1, current1h: 1, currentCount: 1, historicalAverage: 0 },
+		{ age: 15 * MINUTE - 1, current15m: 1, current1h: 1, currentCount: 1, historicalAverage: 0 },
+		{ age: 15 * MINUTE, current15m: 1, current1h: 1, currentCount: 1, historicalAverage: 0 },
+		{ age: 15 * MINUTE + 1, current15m: 0, current1h: 1, currentCount: 1, historicalAverage: 0 },
+		{ age: 60 * MINUTE, current15m: 0, current1h: 1, currentCount: 1, historicalAverage: 0 },
+		{ age: 60 * MINUTE + 1, current15m: 0, current1h: 0, currentCount: 1, historicalAverage: 0 },
+		{ age: DAY, current15m: 0, current1h: 0, currentCount: 1, historicalAverage: 0 },
+		{ age: DAY + 1, current15m: 0, current1h: 0, currentCount: 0, historicalAverage: 1 / 14 },
+		{ age: 15 * DAY, current15m: 0, current1h: 0, currentCount: 0, historicalAverage: 1 / 14 },
+		{ age: 15 * DAY + 1, current15m: 0, current1h: 0, currentCount: 0, historicalAverage: 0 },
+	];
+
+	for (const useFallback of [false, true]) {
+		it.each(boundaries)(
+			`uses ${useFallback ? "createdAt fallback" : "sentAt"} at age $age`,
+			async ({ age, ...expected }) => {
+				const test = setup();
+				test.addSent(useFallback ? null : NOW - age, useFallback ? NOW - age : NOW);
+				expect(await test.checkSendingSpike("target-user")).toMatchObject({
+					...expected,
+					isSpike: false,
+					spikeMultiplier: null,
+					alertSent: false,
+				});
+				expect(test.state.queries).toBe(2);
+				expect(test.state.externalCalls).toBe(0);
+			},
+		);
+	}
+
+	it("counts only sent emails for this user and prioritizes non-null sentAt", async () => {
+		const test = setup();
+		test.addSent(NOW - 2 * DAY, NOW);
+		test.addSent(NOW - 16 * DAY, NOW);
+		test.addSent(NOW, NOW, "failed");
+		test.addSent(null, NOW, "pending");
+		test.addSent(NOW, NOW, "sent", "other-user");
+		test.addSent(null, NOW, "sent", "other-user");
+		test.addSent(null, null);
+		expect(await test.checkSendingSpike("target-user")).toMatchObject({
+			current15m: 0,
+			current1h: 0,
+			currentCount: 0,
+			historicalAverage: 1 / 14,
+		});
+	});
+
+	it("uses the entire fourteen-day denominator rather than active days", async () => {
+		const test = setup();
+		for (let index = 0; index < 700; index++) test.addSent(NOW - 2 * DAY);
+		test.addSent(NOW);
+		expect(await test.checkSendingSpike("target-user")).toMatchObject({
+			current15m: 1,
+			current1h: 1,
+			currentCount: 1,
+			historicalAverage: 50,
+			spikeMultiplier: 0.02,
+			isSpike: false,
+		});
+		expect(test.state.queries).toBe(2);
+	});
+
+	it("returns zero counts for an empty history", async () => {
+		const test = setup();
+		expect(await test.checkSendingSpike("target-user")).toEqual({
+			isSpike: false,
+			currentCount: 0,
+			current1h: 0,
+			current15m: 0,
+			historicalAverage: 0,
+			spikeMultiplier: null,
+			alertSent: false,
+			reason: "No spam-oriented spike thresholds exceeded",
+		});
+	});
+
+	it("skips all database queries during cooldown", async () => {
+		const test = setup();
+		test.state.cooldown = true;
+		expect(await test.checkSendingSpike("target-user")).toMatchObject({
+			isSpike: false,
+			currentCount: 0,
+			alertSent: false,
+			reason: "User in cooldown period",
+		});
+		expect(test.state.queries).toBe(0);
+		expect(test.state.externalCalls).toBe(0);
+	});
+
+	it("continues checking when Redis fails and retains the database-error result", async () => {
+		const test = setup();
+		test.state.failRedis = true;
+		test.addSent(NOW);
+		expect(await test.checkSendingSpike("target-user")).toMatchObject({ currentCount: 1 });
+		expect(test.state.queries).toBe(2);
+		test.state.failDatabase = true;
+		expect(await test.checkSendingSpike("target-user")).toEqual({
+			isSpike: false,
+			currentCount: 0,
+			current1h: 0,
+			current15m: 0,
+			historicalAverage: 0,
+			spikeMultiplier: null,
+			alertSent: false,
+			reason: "Error: database unavailable",
+		});
+		expect(test.state.externalCalls).toBe(0);
+	});
+});

--- a/lib/email-management/sending-spike-detector.ts
+++ b/lib/email-management/sending-spike-detector.ts
@@ -1,4 +1,4 @@
-import { and, count, eq, gte, isNull, lt, or } from "drizzle-orm"
+import { and, eq, gte, isNull, lt, or, sql } from "drizzle-orm"
 import { getAwsSesStats } from "@/lib/aws-ses/aws-stats-core"
 import { user } from "@/lib/db/auth-schema"
 import { db } from "@/lib/db"
@@ -44,51 +44,6 @@ type AwsReputationSnapshot = {
 	isWarning: boolean
 	isAtRisk: boolean
 	checkedAt: string
-}
-
-async function getEmailsSentSince(userId: string, cutoffTime: Date): Promise<number> {
-	const result = await db
-		.select({ total: count() })
-		.from(sentEmails)
-		.where(
-			and(
-				eq(sentEmails.userId, userId),
-				eq(sentEmails.status, "sent"),
-				or(
-					gte(sentEmails.sentAt, cutoffTime),
-					and(isNull(sentEmails.sentAt), gte(sentEmails.createdAt, cutoffTime)),
-				),
-			),
-		)
-
-	return Number(result[0]?.total || 0)
-}
-
-async function getHistoricalDailyAverage(userId: string, days: number): Promise<number> {
-	const now = new Date()
-	const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000)
-	const historicalStart = new Date(now.getTime() - (days + 1) * 24 * 60 * 60 * 1000)
-
-	const result = await db
-		.select({ total: count() })
-		.from(sentEmails)
-		.where(
-			and(
-				eq(sentEmails.userId, userId),
-				eq(sentEmails.status, "sent"),
-				or(
-					and(gte(sentEmails.sentAt, historicalStart), lt(sentEmails.sentAt, oneDayAgo)),
-					and(
-						isNull(sentEmails.sentAt),
-						gte(sentEmails.createdAt, historicalStart),
-						lt(sentEmails.createdAt, oneDayAgo),
-					),
-				),
-			),
-		)
-
-	const totalEmails = Number(result[0]?.total || 0)
-	return days > 0 ? totalEmails / days : 0
 }
 
 async function getUserInfo(
@@ -431,14 +386,46 @@ export async function checkSendingSpike(userId: string): Promise<SpikeDetectionR
 		const oneHourAgo = new Date(now - 60 * 60 * 1000)
 		const oneDayAgo = new Date(now - 24 * 60 * 60 * 1000)
 
-		const [current15m, current1h, current24h, historicalAverage, userInfo] =
-			await Promise.all([
-				getEmailsSentSince(userId, fifteenMinutesAgo),
-				getEmailsSentSince(userId, oneHourAgo),
-				getEmailsSentSince(userId, oneDayAgo),
-				getHistoricalDailyAverage(userId, SPIKE_DETECTION_CONFIG.HISTORICAL_DAYS),
-				getUserInfo(userId),
-			])
+		const historicalDays = SPIKE_DETECTION_CONFIG.HISTORICAL_DAYS
+		const historicalStart = new Date(now - (historicalDays + 1) * 24 * 60 * 60 * 1000)
+
+		const [[counts], userInfo] = await Promise.all([
+			db
+				.select({
+					current15m: sql<number>`count(*) filter (where ${or(
+						gte(sentEmails.sentAt, fifteenMinutesAgo),
+						and(isNull(sentEmails.sentAt), gte(sentEmails.createdAt, fifteenMinutesAgo)),
+					)})`.mapWith(Number),
+					current1h: sql<number>`count(*) filter (where ${or(
+						gte(sentEmails.sentAt, oneHourAgo),
+						and(isNull(sentEmails.sentAt), gte(sentEmails.createdAt, oneHourAgo)),
+					)})`.mapWith(Number),
+					current24h: sql<number>`count(*) filter (where ${or(
+						gte(sentEmails.sentAt, oneDayAgo),
+						and(isNull(sentEmails.sentAt), gte(sentEmails.createdAt, oneDayAgo)),
+					)})`.mapWith(Number),
+					historicalTotal: sql<number>`count(*) filter (where ${or(
+						lt(sentEmails.sentAt, oneDayAgo),
+						and(isNull(sentEmails.sentAt), lt(sentEmails.createdAt, oneDayAgo)),
+					)})`.mapWith(Number),
+				})
+				.from(sentEmails)
+				.where(
+					and(
+						eq(sentEmails.userId, userId),
+						eq(sentEmails.status, "sent"),
+						or(
+							gte(sentEmails.sentAt, historicalStart),
+							and(isNull(sentEmails.sentAt), gte(sentEmails.createdAt, historicalStart)),
+						),
+					),
+				),
+			getUserInfo(userId),
+		])
+		const current15m = counts?.current15m || 0
+		const current1h = counts?.current1h || 0
+		const current24h = counts?.current24h || 0
+		const historicalAverage = historicalDays > 0 ? (counts?.historicalTotal || 0) / historicalDays : 0
 
 		const baselineReady =
 			historicalAverage >= SPIKE_DETECTION_CONFIG.MIN_HISTORICAL_DAILY_AVERAGE


### PR DESCRIPTION
## Summary
Schema-free optimizations from the repository SQL audit. This reduces repeated reads, large result transfers, and aggregation work without changing public response schemas or adding caches, dependencies, migrations, indexes, or database-provider changes.

| Path | Before | After |
| --- | --- | --- |
| Domain list | Per-domain address counts and catch-all endpoint lookups | Grouped page-domain counts and batched owned endpoints |
| Email-address list | One association read per address | Batch distinct owned endpoint/webhook associations |
| Thread list | Two participant reads per returned thread | Two participant reads per contributing batch, only for returned threads |
| Public `type=all` email list | Fetch earlier pages from three tables, hydrate/sort/slice in memory, cap each source at 10,000 | Narrow filtered UNION, exact SQL count/pagination, and page-only hydration |
| Recipient blocklist | Transfer every blocked address | Return only requested normalized matches, retaining global suppression |
| Send-spike detection | Four overlapping history-count queries plus user lookup | One conditional aggregate plus user lookup |

Single-source email lists also project only response dependencies instead of full sent/scheduled rows. Attachment JSON remains JavaScript-parsed to preserve malformed-history tolerance; this is not the separate attachment-metadata/schema optimization.

## Measured with synthetic PostgreSQL data
Actual extracted handlers and Drizzle queries, mocked auth/external services, PostgreSQL 18, two tenants plus an empty account. Counts exclude authentication and optional verification lookups.

| Scenario | Before | After |
| --- | ---: | ---: |
| 100 domains | 302 queries | 4 queries |
| 100 addresses | 102 queries | 4 queries |
| 25 threads | 54 queries | 6 queries |
| Send-spike check | 5 queries | 2 queries |
| 50 mixed-list emails at offset 5,000 | 6 queries / 6,458,723 serialized result bytes | 3 queries / 57,011 serialized result bytes |
| Mixed-list offset 11,000 with matching records | 0 returned due to source cap | Correct 50-row page |

These are workload/query-count and serialized-result measurements, **not production latency or billing guarantees**. Mixed-list query count varies with sources represented in a page (up to five). Participant batching primarily reduces round trips, not data volume.

## Compatibility and intentional edge behavior
- Preserve response fields, filters, exact totals, routing precedence, nullable defaults, recipient normalization/order/duplicates, and the participant-name reducer.
- Retain authentication, tenant scoping, optional `check=true` DNS/SES verification, security checks, Redis cooldown/alerts, and delivery fencing.
- Related endpoint/webhook batch reads explicitly require ownership; malformed foreign associations cannot reveal another tenant's configuration.
- Mixed-list sorting preserves JavaScript millisecond comparison and received-before-sent-before-scheduled ties, with within-source raw timestamp ordering. Source-qualified IDs prevent cross-table collisions.
- Remove the old 10,000-per-source pagination cap. For mixed-list rows with null creation time, use one request timestamp instead of latency-dependent per-row `now` values.
- Spike windows use one timestamp and preserve sent-status/user conditions, null `sentAt` fallback, and the full 14-day historical denominator.
- Participant SQL row order remains unspecified as before; conflicting-name winners still depend on row order. No new ordering policy, unread-pagination change, or cursor change is introduced.

## Verification
- **88 disposable PostgreSQL checks**: before/after response equivalence plus intended deep-page correction; all status/source combinations, domain/address/search/time filters, pagination edges, tenant isolation, empty data, malformed JSON, microsecond ties, null timestamps, cross-source ID collisions, mixed-case blocking, and count-window boundaries.
- `bun test app/api/e2/domains/list-query.test.ts app/api/e2/emails/list.test.ts app/api/e2/lib/participants.test.ts lib/email-management/sending-spike-detector.test.ts app/api/e2/emails/retry.test.ts lib/email-management/delivery-diagnostics.test.ts`: **111 pass, 0 fail, 403 assertions** reported by the parent runner; email-list wrapper also runs 11 isolated child cases.
- New persistent tests use actual handlers/query construction with isolated in-memory database or injected boundaries. Stubbed email-list tests are labeled handler-contract/parameter-forwarding checks; real PostgreSQL checks establish SQL semantics.
- In-memory TypeScript compiler checks with no emit/incremental writes: zero diagnostics in all 11 changed files.
- Targeted lint: only existing thread-list explicit-any errors (2) and existing warnings. `git diff --check` clean.
- Independent source compatibility/security review: no introduced blockers.
- No customer data, real DNS/SES calls, or external email sends; no UI changes or browser audit required. Disposable verification harness is outside the repository.

## Deliberately excluded
Indexes/migrations, provider migration, stale display/security caches, payload-retention changes, IMAP synchronization/state changes, scheduling/idempotency fixes, and skipping the unlimited-account guard count (would alter current fail-closed error behavior). Those require separate contracts/validation; existing idempotency PRs remain separate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mixed-email pagination and sorting moved into SQL (behavior heavily tested but touches core listing APIs); batched association reads change which foreign rows are visible when IDs cross tenants.
> 
> **Overview**
> This PR cuts database round trips and data transfer across several hot list paths **without schema or response-shape changes**, backed by large regression suites.
> 
> **Domain and email-address lists** replace per-row lookups with batched reads: grouped address counts (with domain-owner join), owned catch-all endpoints, and page-scoped endpoint/webhook routing maps.
> 
> **Public `type=all` email list** stops fetching up to 10k rows per source, sorting in memory, and slicing. It now uses a filtered **UNION** for exact count and SQL `LIMIT`/`OFFSET`, then hydrates only IDs on the current page. Deep offsets are fixed where the old per-source cap could return empty pages.
> 
> **Thread list** loads participant display names via **`getThreadParticipantNamesBatch`** (two queries per batch) for threads actually returned, including unread-filtered pages.
> 
> **Email management** narrows recipient blocklist checks to requested normalized addresses (case-insensitive) instead of loading the full blocklist, and collapses send-spike window counts into **one conditional aggregate** query.
> 
> Auth import paths move to `@/app/api/e2/lib/auth`; tenant checks on batched endpoint/webhook reads are explicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fcbd7b71082a19f7ae155201c6c207f2f8346d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->